### PR TITLE
Size hyperlinks the same as surrounding text

### DIFF
--- a/doc/stylesheet.css
+++ b/doc/stylesheet.css
@@ -85,19 +85,19 @@ a[name], a[name]:hover, a[name]:active, a[name]:link {
 }
 /* end ff fix/nn */
 a {
-	font: normal .80em Tahoma, Helvetica, sans-serif;
+	font: normal Tahoma, Helvetica, sans-serif;
 	color: #949e3e;
 	text-decoration: none;
 }
 
 a:link, a:visited {
-	font: normal .80em Tahoma, Helvetica, sans-serif;
+	font: normal Tahoma, Helvetica, sans-serif;
 	color: #949e3e;
 	text-decoration: none;
 }
 
 a:hover, a:active {
-	font: normal .80em Tahoma, Helvetica, sans-serif;
+	font: normal Tahoma, Helvetica, sans-serif;
 	color: #ef8033;
 	text-decoration: none;
 }


### PR DESCRIPTION
Since the manual is littered with hyperlinked XML element names, make them fit
with the surrounding text by having the same size.
