### PR TITLE
Converting Class.forName() calls to the form taking the Thread ContextClassloader

### DIFF
--- a/src/main/mondrian/olap/Util.java
+++ b/src/main/mondrian/olap/Util.java
@@ -151,17 +151,7 @@ public class Util extends XOMUtil {
         } else {
             className = "mondrian.util.UtilCompatibleJdk16";
         }
-        try {
-            Class<UtilCompatible> clazz =
-                (Class<UtilCompatible>) Class.forName(className);
-            compatible = clazz.newInstance();
-        } catch (ClassNotFoundException e) {
-            throw Util.newInternal(e, "Could not load '" + className + "'");
-        } catch (InstantiationException e) {
-            throw Util.newInternal(e, "Could not load '" + className + "'");
-        } catch (IllegalAccessException e) {
-            throw Util.newInternal(e, "Could not load '" + className + "'");
-        }
+        compatible = ClassResolver.INSTANCE.instantiateSafe(className);
     }
 
     public static boolean isNull(Object o) {

--- a/src/main/mondrian/olap4j/MondrianOlap4jDriver.java
+++ b/src/main/mondrian/olap4j/MondrianOlap4jDriver.java
@@ -81,6 +81,9 @@ public class MondrianOlap4jDriver implements Driver {
     private static Factory createFactory() {
         final String factoryClassName = getFactoryClassName();
         try {
+
+            // Cannot use ClassResolver here, because factory's constructor has
+            // package access.
             final Class<?> clazz = Class.forName(factoryClassName);
             return (Factory) clazz.newInstance();
         } catch (ClassNotFoundException e) {

--- a/src/main/mondrian/rolap/RolapConnection.java
+++ b/src/main/mondrian/rolap/RolapConnection.java
@@ -460,34 +460,25 @@ public class RolapConnection extends ConnectionBase {
      * @return data source resolver
      */
     private static synchronized DataSourceResolver getDataSourceResolver() {
-        if (dataSourceResolver == null) {
-            final StringProperty property =
-                MondrianProperties.instance().DataSourceResolverClass;
-            final String className =
-                property.get(
-                    JndiDataSourceResolver.class.getName());
-            try {
-                final Class<?> clazz;
-                clazz = Class.forName(className);
-                if (!DataSourceResolver.class.isAssignableFrom(clazz)) {
-                    throw Util.newInternal(
-                        "Plugin class specified by property "
-                        + property.getPath() + " must implement "
-                        + DataSourceResolver.class.getName());
-                }
-                dataSourceResolver = (DataSourceResolver) clazz.newInstance();
-            } catch (ClassNotFoundException e) {
-                throw Util.newInternal(
-                    e, "Error while loading plugin class '" + className + "'");
-            } catch (IllegalAccessException e) {
-                throw Util.newInternal(
-                    e, "Error while loading plugin class '" + className + "'");
-            } catch (InstantiationException e) {
-                throw Util.newInternal(
-                    e, "Error while loading plugin class '" + className + "'");
-            }
+      if (dataSourceResolver == null) {
+        final StringProperty property =
+            MondrianProperties.instance().DataSourceResolverClass;
+        final String className =
+            property.get(
+                JndiDataSourceResolver.class.getName());
+        try {
+          dataSourceResolver =
+              ClassResolver.INSTANCE.instantiateSafe(className);
+        } catch (ClassCastException e) {
+          throw Util.newInternal(
+              e,
+              "Plugin class specified by property "
+                  + property.getPath()
+                  + " must implement "
+                  + DataSourceResolver.class.getName());
         }
-        return dataSourceResolver;
+      }
+      return dataSourceResolver;
     }
 
     /**

--- a/src/main/mondrian/rolap/RolapSchemaPool.java
+++ b/src/main/mondrian/rolap/RolapSchemaPool.java
@@ -304,13 +304,8 @@ class RolapSchemaPool {
                 + "\" using dynamic processor");
         }
         try {
-            @SuppressWarnings("unchecked")
-            final Class<DynamicSchemaProcessor> clazz =
-                (Class<DynamicSchemaProcessor>)
-                    Class.forName(dynProcName);
-            final Constructor<DynamicSchemaProcessor> ctor =
-                clazz.getConstructor();
-            final DynamicSchemaProcessor dynProc = ctor.newInstance();
+            final DynamicSchemaProcessor dynProc =
+                ClassResolver.INSTANCE.instantiateSafe(dynProcName);
             return dynProc.processSchema(catalogUrl, connectInfo);
         } catch (Exception e) {
             throw Util.newError(

--- a/src/main/mondrian/rolap/RolapUtil.java
+++ b/src/main/mondrian/rolap/RolapUtil.java
@@ -19,6 +19,7 @@ import mondrian.olap.fun.FunUtil;
 import mondrian.resource.MondrianResource;
 import mondrian.server.*;
 import mondrian.spi.Dialect;
+import mondrian.util.ClassResolver;
 
 import org.apache.log4j.Logger;
 
@@ -385,7 +386,7 @@ public class RolapUtil {
             String jdbcDriver = tok.nextToken();
             if (loadedDrivers.add(jdbcDriver)) {
                 try {
-                    Class.forName(jdbcDriver);
+                    ClassResolver.INSTANCE.forName(jdbcDriver, true);
                     LOGGER.info(
                         "Mondrian: JDBC driver "
                         + jdbcDriver + " loaded successfully");

--- a/src/main/mondrian/rolap/agg/SegmentCacheWorker.java
+++ b/src/main/mondrian/rolap/agg/SegmentCacheWorker.java
@@ -13,6 +13,7 @@ import mondrian.olap.MondrianProperties;
 import mondrian.resource.MondrianResource;
 import mondrian.spi.*;
 import mondrian.util.ServiceDiscovery;
+import mondrian.util.ClassResolver;
 
 import org.apache.log4j.Logger;
 
@@ -101,14 +102,10 @@ public final class SegmentCacheWorker {
     private static SegmentCache instantiateCache(String cacheName) {
         try {
             LOGGER.debug("Starting cache instance: " + cacheName);
-            Class<?> clazz =
-                Class.forName(cacheName);
-            Object scObject = clazz.newInstance();
-            if (!(scObject instanceof SegmentCache)) {
-                throw MondrianResource.instance()
-                    .SegmentCacheIsNotImplementingInterface.ex();
-            }
-            return (SegmentCache) scObject;
+            return ClassResolver.INSTANCE.instantiateSafe(cacheName);
+        } catch (ClassCastException e) {
+            throw MondrianResource.instance()
+                .SegmentCacheIsNotImplementingInterface.ex();
         } catch (Exception e) {
             LOGGER.error(
                 MondrianResource.instance()

--- a/src/main/mondrian/server/FileRepository.java
+++ b/src/main/mondrian/server/FileRepository.java
@@ -157,7 +157,8 @@ public class FileRepository implements Repository {
         // Make sure we load the Mondrian driver into
         // the ClassLoader.
         try {
-            Class.forName(MondrianOlap4jDriver.class.getName());
+          ClassResolver.INSTANCE.forName(
+              MondrianOlap4jDriver.class.getName(), true);
         } catch (ClassNotFoundException e) {
             throw new OlapException("Cannot find mondrian olap4j driver.");
         }

--- a/src/main/mondrian/spi/impl/JdbcDialectImpl.java
+++ b/src/main/mondrian/spi/impl/JdbcDialectImpl.java
@@ -13,6 +13,7 @@ import mondrian.olap.MondrianProperties;
 import mondrian.olap.Util;
 import mondrian.spi.Dialect;
 import mondrian.spi.StatisticsProvider;
+import mondrian.util.ClassResolver;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -899,30 +900,14 @@ public class JdbcDialectImpl implements Dialect {
             new ArrayList<StatisticsProvider>();
         for (String name : names) {
             try {
-                final Class<?> clazz = Class.forName(name);
                 StatisticsProvider provider =
-                    (StatisticsProvider) clazz.newInstance();
+                    ClassResolver.INSTANCE.instantiateSafe(name);
                 providerList.add(provider);
-            } catch (ClassNotFoundException e) {
+            } catch (Exception e) {
                 LOGGER.info(
                     "Error instantiating statistics provider (class=" + name
-                    + ")",
+                        + ")",
                     e);
-            } catch (InstantiationException e) {
-                LOGGER.info(
-                    "Error instantiating statistics provider (class=" + name
-                    + ")",
-                    e);
-            } catch (IllegalAccessException e) {
-                LOGGER.info(
-                    "Error instantiating statistics provider (class="
-                    + name
-                    + ")", e);
-            } catch (ClassCastException e) {
-                LOGGER.info(
-                    "Error instantiating statistics provider (class="
-                    + name
-                    + ")", e);
             }
         }
         return providerList;

--- a/src/main/mondrian/util/ClassResolver.java
+++ b/src/main/mondrian/util/ClassResolver.java
@@ -1,0 +1,120 @@
+/*
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (C) 2005-2005 Julian Hyde
+// Copyright (C) 2005-2012 Pentaho
+// All Rights Reserved.
+*/
+package mondrian.util;
+
+import org.apache.commons.collections.iterators.EnumerationIterator;
+
+import java.io.IOException;
+import java.lang.reflect.*;
+import java.net.URL;
+import java.util.*;
+
+/**
+ * Instantiates a class.
+ *
+ * <p>Has same effect as calling {@link Class#forName(String)},  but uses the
+ * appropriate {@link ClassLoader}.</p>
+ */
+public interface ClassResolver {
+
+    /** Equivalent of {@link Class#forName(String, boolean, ClassLoader)}. */
+    <T> Class<T> forName(String className, boolean initialize)
+        throws ClassNotFoundException;
+
+    /**
+     * Instantiates a class and constructs an instance using the given
+     * arguments.
+     *
+     * @param className Class name
+     * @param args Arguments
+     * @param <T> Desired type
+     * @throws ClassCastException if resulting object is not an instance of T
+     */
+    <T> T instantiateSafe(String className, Object... args);
+
+    /** Equivalent of {@link ClassLoader#getResources(String)}. */
+    Iterable<URL> getResources(String lookupName) throws IOException;
+
+    /** Default resolver. */
+    ClassResolver INSTANCE = new ThreadContextClassResolver();
+
+    /** Implementation of {@link ClassResolver} that calls
+     * {@link Thread#getContextClassLoader()} on the current thread. */
+    class ThreadContextClassResolver extends AbstractClassResolver {
+        protected ClassLoader getClassLoader() {
+            return Thread.currentThread().getContextClassLoader();
+        }
+    }
+
+    /** Partial implementation of {@link ClassResolver}. Derived class just
+     * needs to implement {@link #getClassLoader()}. */
+    abstract class AbstractClassResolver implements ClassResolver {
+        public <T> T instantiateSafe(String className, Object... args) {
+            try {
+                final Class<T> clazz = forName(className, true);
+                if (args.length == 0) {
+                    return clazz.newInstance();
+                } else {
+                    Class[] types = new Class[args.length];
+                    for (int i = 0; i < args.length; i++) {
+                        types[i] = args[i].getClass();
+                    }
+                    final Constructor<T> constructor =
+                        clazz.getConstructor(types);
+                    return constructor.newInstance(args);
+                }
+            } catch (InstantiationException e) {
+                throw new RuntimeException(e);
+            } catch (IllegalAccessException e) {
+                throw new RuntimeException(e);
+            } catch (NoSuchMethodException e) {
+                throw new RuntimeException(e);
+            } catch (InvocationTargetException e) {
+                throw new RuntimeException(e);
+            } catch (ClassNotFoundException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        public <T> Class<T> forName(String className, boolean initialize)
+            throws ClassNotFoundException
+        {
+            //noinspection unchecked
+            return (Class<T>) Class.forName(
+                className,
+                initialize,
+                getClassLoader());
+        }
+
+        /** Returns the class loader to use for the current operation. May be
+         * null. */
+        protected abstract ClassLoader getClassLoader();
+
+        /** Returns the class loader to use for the current operation, never
+         * null. */
+        protected ClassLoader getClassLoaderNotNull() {
+            final ClassLoader classLoader = getClassLoader();
+            return classLoader != null
+                ? classLoader
+                : getClass().getClassLoader();
+        }
+
+        public Iterable<URL> getResources(String name) throws IOException {
+            final Enumeration<URL> resources =
+                getClassLoaderNotNull().getResources(name);
+            //noinspection unchecked
+            return new IteratorIterable<URL>(
+                new EnumerationIterator(resources));
+        }
+    }
+}
+
+// End ClassResolver.java

--- a/src/main/mondrian/util/IteratorIterable.java
+++ b/src/main/mondrian/util/IteratorIterable.java
@@ -1,0 +1,74 @@
+/*
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (C) 2005-2005 Julian Hyde
+// Copyright (C) 2005-2012 Pentaho
+// All Rights Reserved.
+*/
+package mondrian.util;
+
+import java.util.*;
+
+/**
+ * Iterable over an iterator.
+ *
+ * <p>It can be restarted. As you iterate, it stores elements in a backing
+ * array. If you call {@link #iterator()} again, it will first replay elements
+ * from that array.</p>
+ */
+public class IteratorIterable<E> implements Iterable<E> {
+    private final List<E> list = new ArrayList<E>();
+    private final Iterator<E> recordingIterator;
+
+    /** Creates an IteratorIterable. */
+    public IteratorIterable(final Iterator<E> iterator) {
+        this.recordingIterator =
+            new Iterator<E>() {
+                public boolean hasNext() {
+                    return iterator.hasNext();
+                }
+
+                public E next() {
+                    final E e = iterator.next();
+                    list.add(e);
+                    return e;
+                }
+
+                public void remove() {
+                    throw new UnsupportedOperationException();
+                }
+            };
+    }
+
+    public Iterator<E> iterator() {
+        // Return an iterator over the union of (1) the list, (2) the rest
+        // of the iterator. The second part writes elements to the list as
+        // it returns them.
+        //noinspection unchecked
+        return Composite.of(
+            // Can't use ArrayList.iterator(). It throws
+            // ConcurrentModificationException, because the list is growing
+            // under its feet.
+            new Iterator<E>() {
+                int i = 0;
+
+                public boolean hasNext() {
+                    return i < list.size();
+                }
+
+                public E next() {
+                    return list.get(i++);
+                }
+
+                public void remove() {
+                    throw new UnsupportedOperationException();
+                }
+            },
+            recordingIterator);
+    }
+}
+
+// End IteratorIterable.java

--- a/src/main/mondrian/util/ObjectFactory.java
+++ b/src/main/mondrian/util/ObjectFactory.java
@@ -4,7 +4,7 @@
 // http://www.eclipse.org/legal/epl-v10.html.
 // You must accept the terms of that agreement to use this software.
 //
-// Copyright (C) 2007-2011 Pentaho and others
+// Copyright (C) 2007-2012 Pentaho and others
 // All Rights Reserved.
 */
 package mondrian.util;
@@ -25,25 +25,28 @@ import java.util.Properties;
  * methods for producing implementation instances - the same method is
  * used both for test and non-test modes. There are two ways of
  * modifying the implementation returned to the application code.
- * The first is for the application to use Properties.
+ *
+ * <p>The first is for the application to use Properties.
  * The <code>ObjectFactory</code> implementation looks for a given
  * property (by default the name of the property is the class name
  * of the interfaceClass object) and if found uses it as the classname
- * to create.
- * A second approach is to use a ThreadLocal; if the ThreadLocal
- * is non-empty then use it as the classname.
- * <p>
- * When to use a Factory?
- * <p>
- * Everyone has an opinion. For me, there are two criteria: enabling
+ * to create.</p>
+ *
+ * <p>A second approach is to use a ThreadLocal; if the ThreadLocal
+ * is non-empty then use it as the class name.</p>
+ *
+ * <p>When to use a Factory?
+ *
+ * <p>Everyone has an opinion. For me, there are two criteria: enabling
  * unit testing and providing end-user/developer-customizer overriding.
- * <p>
- * If a method has side-effects, either its result depends upon
+ *
+ * <p>If a method has side-effects, either its result depends upon
  * a side-effect or calling it causes a side-effect, then the Object
  * hosting the method is a candidate for having a factory. Why?
  * Well, consider the case where a method returns the value of
  * a System property and the System property is determined only once
  * and set to a static final variable:
+ *
  * <pre>
  *      class OneValue {
  *          private static final boolean propValue;
@@ -56,73 +59,75 @@ import java.util.Properties;
  *          }
  *      }
  * </pre>
- * <p>
- * In this case, only one value is ever returned. If you have a
+ *
+ * <p>In this case, only one value is ever returned. If you have a
  * module, a client of the above code, that uses the value returned
  * by a call to the
  * <code>hasInfo()</code> method, how do you write a unit test of
  * your module that tests both possible return values?
  * You can not, its value is based upon a side-effect, an external
- * value that can not be controled by the unit test.
- * If the <code>OneValue</code> class was an interface and there was a factory,
- * then the unit test could arrange that its own version of the
+ * value that can not be controlled by the unit test.</p>
+ *
+ * <p>If the <code>OneValue</code> class was an interface and there was a
+ * factory, then the unit test could arrange that its own version of the
  * <code>OneValue</code>
  * interface was returned and in one test arrange that <code>true</code>
  * was returned and in a second test, arrange that <code>false</code>
- * was returned.
- * <p>
- * The above is a trivial example of code that disallows clients of the
- * code from being properly tested.
- * <p>
- * Another example might be a module that directly initializes a JMS
+ * was returned.</p>
+ *
+ * <p>The above is a trivial example of code that disallows clients of the
+ * code from being properly tested.</p>
+ *
+ * <p>Another example might be a module that directly initializes a JMS
  * queue and receives JMS message
  * from the JMS queue. This code can not be tested without having a live
  * JMS queue. On the other hand, if one defines an interface allowing
  * one to wrap access to the JMS queue and accesses the implementation
  * via a factory, then unit tests can be create that use a mock
- * JMS queue.
- * <p>
- * With regards to providing end-user/developer-customizer overriding,
+ * JMS queue.</p>
+ *
+ * <p>With regards to providing end-user/developer-customizer overriding,
  * its generally good to have a flexible application framework.
  * Experimental or just different implementations can be developed and
- * tested without having to touch a lot of the application code itself.
- * <p>
- * There is, of course, a trade-off between the use of a factory
- * and the size or simplicity of the object being created.
- * <p>
- * What are the requirements for a template ObjectFactory?
- * <p>
- * First, every implementation must support the writing of unit tests.
+ * tested without having to touch a lot of the application code itself.</p>
+ *
+ * <p>There is, of course, a trade-off between the use of a factory
+ * and the size or simplicity of the object being created.</p>
+ *
+ * <p>What are the requirements for a template ObjectFactory?</p>
+ *
+ * <p>First, every implementation must support the writing of unit tests.
  * What this means it that test cases can override what the factory
  * produces. The test cases can all use the same produced Object or
  * each can request an Object targeted to its particular test. All this
- * without changing the <code>default</code> behavior of the factory.
- * <p>
- * Next, it should be possible to create a factory from the template that
+ * without changing the <code>default</code> behavior of the factory.</p>
+ *
+ * <p>Next, it should be possible to create a factory from the template that
  * is intended to deliver the same Object each time it is called, a
  * different, new Object each time it is called, or, based on the
  * calling environment (parameters, properties, <code>ThreadLocal</code>,
  * etc.) one of a set of Objects. These are possible <code>default</code>
- * behaviors, but, again, they can be overridden for test purposes.
- * <p>
- * While a factory has a <code>default</code> behavior in an
+ * behaviors, but, again, they can be overridden for test purposes.</p>
+ *
+ * <p>While a factory has a <code>default</code> behavior in an
  * application, it must be possible for every factory's behavior
  * in that application to be globally overridden. What that means is
  * if the application designer has dictated a <code>default</code>, the
  * application user should be able to change the default. An example of
  * this is overriding what Object is returned based upon a
- * <code>System</code> property value.
- * <p>
- * Lastly, every factory is a singleton - if an interface with
+ * <code>System</code> property value.</p>
+ *
+ * <p>Lastly, every factory is a singleton - if an interface with
  * an implementation whose creation is mediated by a factory, then
  * there is a single factory that does that creating.
  * This does not mean that such a factory always return the same value,
- * rather that there is only one instance of the factory itself.
- * <p>
- * The following is an example class that generates a factory
+ * rather that there is only one instance of the factory itself.</p>
+ *
+ * <p>The following is an example class that generates a factory
  * singleton. In this case, the factory extends the
  * <code>ObjectFactory</code>
- * rather than the <code>ObjectFactory.Singleton</code>:
+ * rather than the <code>ObjectFactory.Singleton</code>:</p>
+ *
  * <pre>
  *
  *      public final class FooFactory extends ObjectFactory<Foo> {
@@ -142,9 +147,9 @@ import java.util.Properties;
  *      }
  *
  * </pre>
- * <p>
- * There are multiple ways of creating derived classes that have support
- * for unit testing. A very simple way is to use <code>ThreadLocal</code>s.
+ *
+ * <p>There are multiple ways of creating derived classes that have support
+ * for unit testing. A very simple way is to use <code>ThreadLocal</code>s.</p>
  *
  * <pre>
  *
@@ -164,17 +169,17 @@ import java.util.Properties;
  *          }
  *
  * </pre>
- * <p>
- * Here, the unit test will call the <code>setThreadLocalClassName</code>
- * method setting it with the class name of a specialized implemetation of
+ *
+ * <p>Here, the unit test will call the <code>setThreadLocalClassName</code>
+ * method setting it with the class name of a specialized implementation of
  * the template interface. In the <code>finally</code> clause of the
  * unit test, it is very important that there be a call to the
  * <code>clearThreadLocalClassName</code> method so that other
  * tests, etc. do not get an instance of the test-specific specialized
- * implementation.
- * <p>
- * The following is an example unit test that uses the factory's
- * <code>ThreadLocal</code> to override the implementation that is returned.
+ * implementation.</p>
+ *
+ * <p>The following is an example unit test that uses the factory's
+ * <code>ThreadLocal</code> to override the implementation that is returned.</p>
  *
  * <pre>
  *      interface Boo {
@@ -266,12 +271,12 @@ import java.util.Properties;
  *      }
  *
  * </pre>
- * <p>
- * While this is a very simple example, it shows how using such factories
+ *
+ * <p>While this is a very simple example, it shows how using such factories
  * can aid in creating testable code. The MyCode method is a client of
  * the Boo implementation. How to test the two different code branches the
  * method can take? Because the Boo object is generated by a factory,
- * one can override what object the factory returns.
+ * one can override what object the factory returns.</p>
  *
  * @author Richard M. Emberson
  * @since Feb 01 2007
@@ -379,9 +384,9 @@ public abstract class ObjectFactory<V> {
 
         final String propClassName = getClassName(props);
         return (propClassName != null)
-                // User overriding application default
+            // User overriding application default
             ? getObject(propClassName, parameterTypes, parameterValues)
-                // Get application default
+            // Get application default
             : getDefault(parameterTypes, parameterValues);
     }
 
@@ -413,10 +418,8 @@ public abstract class ObjectFactory<V> {
         try {
             // As a place to begin google:
             //   org.apache.cxf.BusFactoryHelper.java
-            final ClassLoader loader =
-                Thread.currentThread().getContextClassLoader();
             final Class<?> genericClass =
-                Class.forName(className, true, loader);
+                ClassResolver.INSTANCE.forName(className, true);
 
             // Are we creating a Proxy or an instance?
             if (InvocationHandler.class.isAssignableFrom(genericClass)) {
@@ -424,13 +427,14 @@ public abstract class ObjectFactory<V> {
                     genericClass.getConstructor(parameterTypes);
                 InvocationHandler handler = (InvocationHandler)
                     constructor.newInstance(parameterValues);
+                //noinspection unchecked
                 return (V) Proxy.newProxyInstance(
-                    loader,
+                    genericClass.getClassLoader(),
                     new Class[] { this.interfaceClass },
                     handler);
             } else {
                 final Class<? extends V> specificClass =
-                    asSubclass(this.interfaceClass, genericClass);
+                    genericClass.asSubclass(interfaceClass);
                 final Constructor<? extends V> constructor =
                     specificClass.getConstructor(parameterTypes);
 
@@ -439,30 +443,8 @@ public abstract class ObjectFactory<V> {
         } catch (Exception exc) {
             throw new CreationException(
                 "Error creating object of type \""
-                + this.interfaceClass.getName() + "\"",
+                    + this.interfaceClass.getName() + "\"",
                 exc);
-        }
-    }
-
-    /**
-     * This is a back port of a 1.5 version Class method.
-     *
-     * @param clazz the base class which the genericClass will be case
-     * @param genericClass the class to be cast to the base clazz
-     * @return this <tt>Class</tt> object, cast to represent a subclass of
-     * the specified class object.
-     * @throws ClassCastException if this <tt>Class</tt> object does
-     * not represent a subclass of the specified class (here "subclass"
-     * includes the class itself).
-     */
-    private static <V> Class<? extends V> asSubclass(
-        final Class<V> clazz,
-        final Class<?> genericClass)
-    {
-        if (clazz.isAssignableFrom(genericClass)) {
-            return (Class<? extends V>) genericClass;
-        } else {
-            throw new ClassCastException(genericClass.toString());
         }
     }
 
@@ -496,9 +478,9 @@ public abstract class ObjectFactory<V> {
         final StringProperty stringProp = getStringProperty();
         final String className = stringProp.get();
         return (className != null)
-                ? className
-                : (props == null)
-                    ? null : props.getProperty(stringProp.getPath());
+            ? className
+            : (props == null)
+            ? null : props.getProperty(stringProp.getPath());
     }
 
     /**
@@ -522,29 +504,13 @@ public abstract class ObjectFactory<V> {
     protected abstract V getDefault(
         Class[] parameterTypes,
         Object[] parameterValues)
-    throws CreationException;
+        throws CreationException;
 
     /**
-     * Factory method which creates an exception to be thrown
-     * if an object can not be created.
+     * Gets the current override values in the opaque context object and
+     * clears those values within the Factory.
      *
-     * @return an exception to be thrown if an object can not be created
-     */
-    // REVIEW: jhyde, 2007/2/4: CreationException is superfluous, since it's
-    // unlikely that anyone will want to handle it. This code should wrap the
-    // error using Util.newError, just like elsewhere in mondrian.
-    protected CreationException defaultCreationException() {
-        return new CreationException(
-            "Error creating object of type \""
-            + this.interfaceClass.getName()
-            + "\"");
-    }
-
-    /**
-     * Get the current override values in the opaque context object and
-     * clear those values within the Factory.
-     * <p>
-     * This is used in testing.
+     * <p>This is used in testing.
      *
      * @return the test <code>Context</code> object.
      */
@@ -553,9 +519,9 @@ public abstract class ObjectFactory<V> {
     }
 
     /**
-     * Restore the context object resetting override values.
-     * <p>
-     * This is used in testing.
+     * Restores the context object resetting override values.
+     *
+     * <p>This is used in testing.
      *
      * @param context the context object to be restored.
      */
@@ -644,9 +610,9 @@ public abstract class ObjectFactory<V> {
                 final String propClassName = getClassName(props);
 
                 this.singleInstance = (propClassName != null)
-                        // The user overriding application default
+                    // The user overriding application default
                     ? getObject(propClassName, parameterTypes, parameterValues)
-                        // Get application default
+                    // Get application default
                     : getDefault(parameterTypes, parameterValues);
             }
             return this.singleInstance;


### PR DESCRIPTION
This is done to enable loading of classes from outside of the scope from the classloader in which Mondrian is in, child plugin classloaders for instance. There is no impact on simple monolithic classloader setups such that Mondrian was written for.
