### PR TITLE
Converting Class.forName() calls to the form taking the Thread ContextClassloader

### DIFF
--- a/src/main/mondrian/olap/Util.java
+++ b/src/main/mondrian/olap/Util.java
@@ -162,7 +162,10 @@ public class Util extends XOMUtil {
         }
         try {
             Class<UtilCompatible> clazz =
-                (Class<UtilCompatible>) Class.forName(className);
+                (Class<UtilCompatible>) Class.forName(
+                    className,
+                    true,
+                    Thread.currentThread().getContextClassLoader());
             compatible = clazz.newInstance();
         } catch (ClassNotFoundException e) {
             throw Util.newInternal(e, "Could not load '" + className + "'");

--- a/src/main/mondrian/olap4j/MondrianOlap4jDriver.java
+++ b/src/main/mondrian/olap4j/MondrianOlap4jDriver.java
@@ -86,7 +86,10 @@ public class MondrianOlap4jDriver implements Driver {
     private static Factory createFactory() {
         final String factoryClassName = getFactoryClassName();
         try {
-            final Class<?> clazz = Class.forName(factoryClassName);
+            final Class<?> clazz = Class.forName(
+                factoryClassName,
+                true,
+                Thread.currentThread().getContextClassLoader());
             return (Factory) clazz.newInstance();
         } catch (ClassNotFoundException e) {
             throw new RuntimeException(e);

--- a/src/main/mondrian/rolap/RolapConnection.java
+++ b/src/main/mondrian/rolap/RolapConnection.java
@@ -468,7 +468,10 @@ public class RolapConnection extends ConnectionBase {
                     JndiDataSourceResolver.class.getName());
             try {
                 final Class<?> clazz;
-                clazz = Class.forName(className);
+                clazz = Class.forName(
+                    className,
+                    true,
+                    Thread.currentThread().getContextClassLoader());
                 if (!DataSourceResolver.class.isAssignableFrom(clazz)) {
                     throw Util.newInternal(
                         "Plugin class specified by property "

--- a/src/main/mondrian/rolap/RolapSchema.java
+++ b/src/main/mondrian/rolap/RolapSchema.java
@@ -486,7 +486,10 @@ public class RolapSchema extends OlapElementBase implements Schema {
             final Class<UserDefinedFunction> klass;
             try {
                 //noinspection unchecked
-                klass = (Class<UserDefinedFunction>) Class.forName(className);
+                klass = (Class<UserDefinedFunction>) Class.forName(
+                    className,
+                    true,
+                    Thread.currentThread().getContextClassLoader());
             } catch (ClassNotFoundException e) {
                 throw MondrianResource.instance().UdfClassNotFound.ex(
                     name,
@@ -597,7 +600,10 @@ public class RolapSchema extends OlapElementBase implements Schema {
             Exception e2;
             try {
                 Properties properties = null;
-                Class<?> clazz = Class.forName(memberReaderClass);
+                Class<?> clazz = Class.forName(
+                    memberReaderClass,
+                    true,
+                    Thread.currentThread().getContextClassLoader());
                 Constructor<?> constructor = clazz.getConstructor(
                     RolapHierarchy.class,
                     Properties.class);
@@ -667,7 +673,10 @@ public class RolapSchema extends OlapElementBase implements Schema {
 
         if (!Util.isEmpty(dataSourceChangeListenerStr)) {
             try {
-                Class<?> clazz = Class.forName(dataSourceChangeListenerStr);
+                Class<?> clazz = Class.forName(
+                    dataSourceChangeListenerStr,
+                    true,
+                    Thread.currentThread().getContextClassLoader());
                 Constructor<?> constructor = clazz.getConstructor();
                 changeListener =
                     (DataSourceChangeListener) constructor.newInstance();

--- a/src/main/mondrian/rolap/RolapSchemaPool.java
+++ b/src/main/mondrian/rolap/RolapSchemaPool.java
@@ -302,7 +302,10 @@ class RolapSchemaPool {
             @SuppressWarnings("unchecked")
             final Class<DynamicSchemaProcessor> clazz =
                 (Class<DynamicSchemaProcessor>)
-                    Class.forName(dynProcName);
+                    Class.forName(
+                        dynProcName,
+                        true,
+                        Thread.currentThread().getContextClassLoader());
             final Constructor<DynamicSchemaProcessor> ctor =
                 clazz.getConstructor();
             final DynamicSchemaProcessor dynProc = ctor.newInstance();

--- a/src/main/mondrian/rolap/RolapUtil.java
+++ b/src/main/mondrian/rolap/RolapUtil.java
@@ -392,7 +392,10 @@ public class RolapUtil {
             String jdbcDriver = tok.nextToken();
             if (loadedDrivers.add(jdbcDriver)) {
                 try {
-                    Class.forName(jdbcDriver);
+                    Class.forName(
+                        jdbcDriver,
+                        true,
+                        Thread.currentThread().getContextClassLoader());
                     LOGGER.info(
                         "Mondrian: JDBC driver "
                         + jdbcDriver + " loaded successfully");

--- a/src/main/mondrian/rolap/agg/SegmentCacheWorker.java
+++ b/src/main/mondrian/rolap/agg/SegmentCacheWorker.java
@@ -95,7 +95,10 @@ public final class SegmentCacheWorker {
         try {
             LOGGER.debug("Starting cache instance: " + cacheName);
             Class<?> clazz =
-                Class.forName(cacheName);
+                Class.forName(
+                    cacheName,
+                    true,
+                    Thread.currentThread().getContextClassLoader());
             Object scObject = clazz.newInstance();
             if (!(scObject instanceof SegmentCache)) {
                 throw MondrianResource.instance()

--- a/src/main/mondrian/rolap/aggmatcher/JdbcSchema.java
+++ b/src/main/mondrian/rolap/aggmatcher/JdbcSchema.java
@@ -91,7 +91,10 @@ public class JdbcSchema {
                 factory = new StdFactory();
             } else {
                 try {
-                    Class<?> clz = Class.forName(classname);
+                    Class<?> clz = Class.forName(
+                        classname,
+                        true,
+                        Thread.currentThread().getContextClassLoader());
                     factory = (Factory) clz.newInstance();
                 } catch (ClassNotFoundException ex) {
                     throw mres.BadJdbcFactoryClassName.ex(classname);

--- a/src/main/mondrian/spi/impl/JdbcDialectImpl.java
+++ b/src/main/mondrian/spi/impl/JdbcDialectImpl.java
@@ -886,7 +886,10 @@ public class JdbcDialectImpl implements Dialect {
             new ArrayList<StatisticsProvider>();
         for (String name : names) {
             try {
-                final Class<?> clazz = Class.forName(name);
+                final Class<?> clazz = Class.forName(
+                    name,
+                    true,
+                    Thread.currentThread().getContextClassLoader());
                 StatisticsProvider provider =
                     (StatisticsProvider) clazz.newInstance();
                 providerList.add(provider);

--- a/src/main/mondrian/util/UtilCompatibleJdk15.java
+++ b/src/main/mondrian/util/UtilCompatibleJdk15.java
@@ -64,7 +64,10 @@ public class UtilCompatibleJdk15 implements UtilCompatible {
         try {
             Class<? extends Annotation> annotationClass =
                 (Class<? extends Annotation>)
-                    Class.forName(annotationClassName);
+                    Class.forName(
+                        annotationClassName,
+                        true,
+                        Thread.currentThread().getContextClassLoader());
             if (method.isAnnotationPresent(annotationClass)) {
                 final Annotation annotation =
                     method.getAnnotation(annotationClass);


### PR DESCRIPTION
This is done to enable loading of classes from outside of the scope from the classloader in which Mondrian is in, child plugin classloaders for instance. There is no impact on simple monolithic classloader setups such that Mondrian was written for.
