### PR TITLE
Improve thread names in Mondrian's worker queues

### DIFF
--- a/src/main/mondrian/olap/Util.java
+++ b/src/main/mondrian/olap/Util.java
@@ -42,6 +42,7 @@ import java.sql.*;
 import java.sql.Connection;
 import java.util.*;
 import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -239,11 +240,12 @@ public class Util extends XOMUtil {
         // have the right name and are marked as daemon threads.
         final ThreadFactory factory =
             new ThreadFactory() {
+                private final AtomicInteger counter = new AtomicInteger(0);
                 public Thread newThread(Runnable r) {
                     final Thread t =
                         Executors.defaultThreadFactory().newThread(r);
                     t.setDaemon(true);
-                    t.setName(name);
+                    t.setName(name + '_' + counter.incrementAndGet());
                     return t;
                 }
             };
@@ -293,11 +295,12 @@ public class Util extends XOMUtil {
         return Executors.newScheduledThreadPool(
             maxNbThreads,
             new ThreadFactory() {
+                final AtomicInteger counter = new AtomicInteger(0);
                 public Thread newThread(Runnable r) {
                     final Thread thread =
                         Executors.defaultThreadFactory().newThread(r);
                     thread.setDaemon(true);
-                    thread.setName(name);
+                    thread.setName(name + '_' + counter.incrementAndGet());
                     return thread;
                 }
             }


### PR DESCRIPTION
Right now, all of the threads in each pool have the same name, which makes it difficult to trace a single action through the logs. A simple counter is enough to differentiate the threads and also provides a quick way to see how many threads Mondrian has spawned in each pool.
