### PR TITLE
Convert Mondrian to use SLF4J.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -156,7 +156,7 @@ mondrian/rolap/RolapCubeUsages.java"/>
     <pathelement location="${lib.dir}/eigenbase-properties.jar"/>
     <pathelement location="${lib.dir}/eigenbase-resgen.jar"/>
     <pathelement location="${lib.dir}/eigenbase-xom.jar"/>
-    <pathelement location="${lib.dir}/log4j.jar"/>
+    <pathelement location="${lib.dir}/slf4j-api.jar"/>
     <pathelement location="${lib.dir}/olap4j.jar"/>
     <pathelement location="${lib.dir}/olap4j-xmlaserver.jar"/>
     <pathelement location="${lib.dir}/xalan.jar"/>
@@ -181,6 +181,8 @@ mondrian/rolap/RolapCubeUsages.java"/>
       <include name="olap4j-xmla.jar"/>
       <include name="xmlunit.jar"/>
       <include name="junit.jar"/>
+      <include name="logback-core.jar"/>
+      <include name="logback-classic.jar"/>
     </fileset>
     <!-- this picks up the default log4j.properties -->
     <pathelement path="${basedir}"/>

--- a/ivy.xml
+++ b/ivy.xml
@@ -59,7 +59,9 @@
         <dependency org="net.java.openjdk" name="ctsym-java6" rev="1.6.0_24" conf="codegen->default" />
         <dependency org="javax.servlet" name="jsp-api" rev="2.0"/>
         <dependency org="javax.servlet" name="servlet-api" rev="2.4"/>
-        <dependency org="log4j" name="log4j" rev="1.2.14"/>
+        <dependency org="org.slf4j" name="slf4j-api" rev="1.7.3"/>
+        <dependency org="ch.qos.logback" name="logback-core" rev="1.0.6"/>
+        <dependency org="ch.qos.logback" name="logback-classic" rev="1.0.6"/>
         <dependency org="org.olap4j" name="olap4j" rev="${dependency.olap4j-core.revision}">
             <artifact name="olap4j"/>
         </dependency>

--- a/src/main/mondrian/i18n/LocalizingDynamicSchemaProcessor.java
+++ b/src/main/mondrian/i18n/LocalizingDynamicSchemaProcessor.java
@@ -14,7 +14,8 @@ import mondrian.olap.Util;
 import mondrian.spi.DynamicSchemaProcessor;
 import mondrian.spi.impl.FilterDynamicSchemaProcessor;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.InputStream;
 import java.util.MissingResourceException;
@@ -33,7 +34,7 @@ public class LocalizingDynamicSchemaProcessor
     implements DynamicSchemaProcessor
 {
     private static final Logger LOGGER =
-        Logger.getLogger(LocalizingDynamicSchemaProcessor.class);
+        LoggerFactory.getLogger(LocalizingDynamicSchemaProcessor.class);
 
     /** Creates a new instance of LocalizingDynamicSchemaProcessor */
     public LocalizingDynamicSchemaProcessor() {

--- a/src/main/mondrian/olap/ConnectionBase.java
+++ b/src/main/mondrian/olap/ConnectionBase.java
@@ -14,7 +14,7 @@ import mondrian.parser.*;
 import mondrian.resource.MondrianResource;
 import mondrian.server.Statement;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
 
 /**
  * <code>ConnectionBase</code> implements some of the methods in

--- a/src/main/mondrian/olap/MondrianPropertiesBase.java
+++ b/src/main/mondrian/olap/MondrianPropertiesBase.java
@@ -10,7 +10,8 @@
 */
 package mondrian.olap;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.eigenbase.util.property.TriggerableProperties;
 
@@ -55,7 +56,7 @@ public abstract class MondrianPropertiesBase extends TriggerableProperties {
     private int populateCount;
 
     private static final Logger LOGGER =
-        Logger.getLogger(MondrianProperties.class);
+        LoggerFactory.getLogger(MondrianProperties.class);
 
     protected static final String mondrianDotProperties = "mondrian.properties";
 

--- a/src/main/mondrian/olap/OlapElementBase.java
+++ b/src/main/mondrian/olap/OlapElementBase.java
@@ -10,7 +10,8 @@
 */
 package mondrian.olap;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.*;
 

--- a/src/main/mondrian/olap/ResultBase.java
+++ b/src/main/mondrian/olap/ResultBase.java
@@ -13,7 +13,8 @@ package mondrian.olap;
 import mondrian.server.Execution;
 import mondrian.server.Statement;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.PrintWriter;
 import java.util.List;

--- a/src/main/mondrian/olap/SetBase.java
+++ b/src/main/mondrian/olap/SetBase.java
@@ -12,7 +12,8 @@ package mondrian.olap;
 
 import mondrian.olap.type.*;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -23,7 +24,7 @@ import org.apache.log4j.Logger;
  */
 public class SetBase extends OlapElementBase implements NamedSet {
 
-    private static final Logger LOGGER = Logger.getLogger(SetBase.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(SetBase.class);
 
     private String name;
     private Larder larder;

--- a/src/main/mondrian/olap/UnionRoleImpl.java
+++ b/src/main/mondrian/olap/UnionRoleImpl.java
@@ -9,7 +9,8 @@
 */
 package mondrian.olap;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -25,7 +26,7 @@ import java.util.List;
  */
 class UnionRoleImpl implements Role {
     private static final Logger LOGGER =
-        Logger.getLogger(UnionRoleImpl.class);
+        LoggerFactory.getLogger(UnionRoleImpl.class);
     private final List<Role> roleList;
 
     /**

--- a/src/main/mondrian/olap/Util.java
+++ b/src/main/mondrian/olap/Util.java
@@ -20,7 +20,8 @@ import mondrian.spi.*;
 import mondrian.util.*;
 
 import org.apache.commons.collections.Predicate;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.eigenbase.xom.XOMUtil;
 
@@ -55,7 +56,7 @@ public class Util extends XOMUtil {
 
     public static final String nl = System.getProperty("line.separator");
 
-    private static final Logger LOGGER = Logger.getLogger(Util.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(Util.class);
 
     /**
      * Placeholder which indicates a value NULL.

--- a/src/main/mondrian/olap/fun/FunUtil.java
+++ b/src/main/mondrian/olap/fun/FunUtil.java
@@ -22,7 +22,8 @@ import mondrian.util.*;
 
 import org.apache.commons.collections.ComparatorUtils;
 import org.apache.commons.collections.comparators.ComparatorChain;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.*;
 
@@ -2645,7 +2646,7 @@ public class FunUtil extends Util {
         public final int TOO_SMALL = 8;
 
         private static final Logger LOGGER =
-            Logger.getLogger(Quicksorter.class);
+            LoggerFactory.getLogger(Quicksorter.class);
         private final T[] vec;
         private final Comparator<T> comp;
         private final boolean traced;
@@ -2868,7 +2869,7 @@ public class FunUtil extends Util {
     private static abstract class MemberComparator implements Comparator<Member>
     {
         private static final Logger LOGGER =
-            Logger.getLogger(MemberComparator.class);
+            LoggerFactory.getLogger(MemberComparator.class);
         final Evaluator evaluator;
         final Calc exp;
 
@@ -3017,7 +3018,7 @@ public class FunUtil extends Util {
         implements Comparator<List<Member>>
     {
         private static final Logger LOGGER =
-            Logger.getLogger(TupleComparator.class);
+            LoggerFactory.getLogger(TupleComparator.class);
         final int arity;
 
         TupleComparator(int arity) {

--- a/src/main/mondrian/olap/fun/NativizeSetFunDef.java
+++ b/src/main/mondrian/olap/fun/NativizeSetFunDef.java
@@ -17,7 +17,8 @@ import mondrian.olap.*;
 import mondrian.olap.type.Type;
 import mondrian.resource.MondrianResource;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.olap4j.impl.Olap4jUtil;
 
@@ -35,7 +36,7 @@ public class NativizeSetFunDef extends FunDefBase {
 
     // Static final fields.
     protected static final Logger LOGGER =
-        Logger.getLogger(NativizeSetFunDef.class);
+        LoggerFactory.getLogger(NativizeSetFunDef.class);
 
     private static final String SENTINEL_PREFIX = "_Nativized_Sentinel_";
     private static final String MEMBER_NAME_PREFIX = "_Nativized_Member_";

--- a/src/main/mondrian/olap4j/MondrianOlap4jCell.java
+++ b/src/main/mondrian/olap4j/MondrianOlap4jCell.java
@@ -14,7 +14,8 @@ import mondrian.olap.Util;
 import mondrian.rolap.RolapCell;
 import mondrian.rolap.SqlStatement;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.olap4j.*;
 import org.olap4j.metadata.Property;

--- a/src/main/mondrian/olap4j/MondrianOlap4jDriver.java
+++ b/src/main/mondrian/olap4j/MondrianOlap4jDriver.java
@@ -11,6 +11,7 @@ package mondrian.olap4j;
 
 import mondrian.rolap.RolapConnectionProperties;
 import mondrian.xmla.XmlaHandler;
+import org.slf4j.LoggerFactory;
 
 import java.sql.*;
 import java.util.*;

--- a/src/main/mondrian/recorder/AbstractRecorder.java
+++ b/src/main/mondrian/recorder/AbstractRecorder.java
@@ -11,6 +11,7 @@
 package mondrian.recorder;
 
 import mondrian.resource.MondrianResource;
+import org.slf4j.Logger;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -29,7 +30,7 @@ public abstract class AbstractRecorder implements MessageRecorder {
         final String context,
         final String msg,
         final MsgType msgType,
-        final org.apache.log4j.Logger logger)
+        final Logger logger)
     {
         StringBuilder buf = new StringBuilder(64);
         buf.append(context);

--- a/src/main/mondrian/recorder/ListRecorder.java
+++ b/src/main/mondrian/recorder/ListRecorder.java
@@ -10,7 +10,8 @@
 */
 package mondrian.recorder;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.*;
 

--- a/src/main/mondrian/recorder/LoggerRecorder.java
+++ b/src/main/mondrian/recorder/LoggerRecorder.java
@@ -10,7 +10,8 @@
 */
 package mondrian.recorder;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Implementation of {@link MessageRecorder} that writes to a

--- a/src/main/mondrian/rolap/FastBatchingCellReader.java
+++ b/src/main/mondrian/rolap/FastBatchingCellReader.java
@@ -21,8 +21,9 @@ import mondrian.server.Locus;
 import mondrian.spi.*;
 import mondrian.util.*;
 
-import org.apache.log4j.Logger;
-import org.apache.log4j.MDC;
+import org.slf4j.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.*;
 import java.util.concurrent.Future;
@@ -42,7 +43,7 @@ import java.util.concurrent.Future;
  */
 public class FastBatchingCellReader implements CellReader {
     private static final Logger LOGGER =
-        Logger.getLogger(FastBatchingCellReader.class);
+        LoggerFactory.getLogger(FastBatchingCellReader.class);
 
     private final RolapCube cube;
 
@@ -522,7 +523,7 @@ public class FastBatchingCellReader implements CellReader {
  */
 class BatchLoader {
     private static final Logger LOGGER =
-        Logger.getLogger(FastBatchingCellReader.class);
+        LoggerFactory.getLogger(FastBatchingCellReader.class);
 
     private final Locus locus;
     private final SegmentCacheManager cacheMgr;
@@ -978,16 +979,14 @@ class BatchLoader {
             this.dialect = dialect;
             this.cube = cube;
             this.cellRequests = cellRequests;
-            if (MDC.getContext() != null) {
-                this.mdc.putAll(MDC.getContext());
+            if (MDC.getCopyOfContextMap() != null) {
+                this.mdc.putAll(MDC.getCopyOfContextMap());
             }
         }
 
         public LoadBatchResponse call() {
-            if (MDC.getContext() != null) {
-                final Map<String, Object> old = MDC.getContext();
-                old.clear();
-                old.putAll(mdc);
+            if (MDC.getCopyOfContextMap() != null) {
+                MDC.setContextMap(mdc);
             }
             return new BatchLoader(locus, cacheMgr, dialect, cube)
                 .load(cellRequests);
@@ -1063,7 +1062,7 @@ class BatchLoader {
         }
     }
 
-    private static final Logger BATCH_LOGGER = Logger.getLogger(Batch.class);
+    private static final Logger BATCH_LOGGER = LoggerFactory.getLogger(Batch.class);
 
     public static class RollupInfo {
         final RolapStar.Column[] constrainedColumns;

--- a/src/main/mondrian/rolap/NoCacheMemberReader.java
+++ b/src/main/mondrian/rolap/NoCacheMemberReader.java
@@ -18,7 +18,8 @@ import mondrian.rolap.sql.MemberChildrenConstraint;
 import mondrian.rolap.sql.TupleConstraint;
 import mondrian.util.ConcatenableList;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.*;
 
@@ -31,7 +32,7 @@ import java.util.*;
  */
 public class NoCacheMemberReader implements MemberReader, MemberCache {
     private static final Logger LOGGER =
-        Logger.getLogger(NoCacheMemberReader.class);
+        LoggerFactory.getLogger(NoCacheMemberReader.class);
 
     private final SqlConstraintFactory sqlConstraintFactory =
         SqlConstraintFactory.instance();

--- a/src/main/mondrian/rolap/RolapAttribute.java
+++ b/src/main/mondrian/rolap/RolapAttribute.java
@@ -13,7 +13,8 @@ import mondrian.olap.*;
 import mondrian.spi.*;
 import mondrian.spi.MemberFormatter;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.olap4j.metadata.Level;
 
@@ -28,7 +29,7 @@ import java.util.List;
  * @author jhyde
  */
 public interface RolapAttribute extends OlapElement {
-    final Logger LOGGER = Logger.getLogger(RolapAttribute.class);
+    final Logger LOGGER = LoggerFactory.getLogger(RolapAttribute.class);
 
     RolapDimension getDimension();
 

--- a/src/main/mondrian/rolap/RolapAttributeImpl.java
+++ b/src/main/mondrian/rolap/RolapAttributeImpl.java
@@ -14,7 +14,8 @@ import mondrian.spi.*;
 import mondrian.spi.MemberFormatter;
 import mondrian.util.CompositeList;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.olap4j.metadata.Level;
 

--- a/src/main/mondrian/rolap/RolapCell.java
+++ b/src/main/mondrian/rolap/RolapCell.java
@@ -20,7 +20,8 @@ import mondrian.server.*;
 import mondrian.server.monitor.SqlStatementEvent;
 import mondrian.spi.Dialect;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.olap4j.AllocationPolicy;
 import org.olap4j.Scenario;

--- a/src/main/mondrian/rolap/RolapConnection.java
+++ b/src/main/mondrian/rolap/RolapConnection.java
@@ -20,11 +20,11 @@ import mondrian.spi.*;
 import mondrian.spi.impl.JndiDataSourceResolver;
 import mondrian.util.*;
 
-import org.apache.log4j.Logger;
-
 import org.eigenbase.util.property.StringProperty;
 
 import org.olap4j.Scenario;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.PrintWriter;
 import java.lang.reflect.InvocationTargetException;
@@ -50,7 +50,7 @@ import javax.sql.DataSource;
  */
 public class RolapConnection extends ConnectionBase {
     private static final Logger LOGGER =
-        Logger.getLogger(RolapConnection.class);
+        LoggerFactory.getLogger(RolapConnection.class);
     private static final AtomicInteger ID_GENERATOR = new AtomicInteger();
 
     private final MondrianServer server;

--- a/src/main/mondrian/rolap/RolapCube.java
+++ b/src/main/mondrian/rolap/RolapCube.java
@@ -20,7 +20,8 @@ import mondrian.rolap.aggmatcher.ExplicitRules;
 import mondrian.rolap.cache.SoftSmartCache;
 import mondrian.server.Statement;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.olap4j.impl.NamedListImpl;
 import org.olap4j.mdx.IdentifierNode;
@@ -37,7 +38,7 @@ import java.util.*;
  */
 public class RolapCube extends CubeBase {
 
-    private static final Logger LOGGER = Logger.getLogger(RolapCube.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(RolapCube.class);
 
     private final RolapSchema schema;
     private final Larder larder;

--- a/src/main/mondrian/rolap/RolapDimension.java
+++ b/src/main/mondrian/rolap/RolapDimension.java
@@ -14,7 +14,8 @@ import mondrian.olap.*;
 import mondrian.olap.Dimension;
 import mondrian.util.Lazy;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.olap4j.metadata.NamedList;
 
@@ -53,7 +54,7 @@ import java.util.*;
  */
 class RolapDimension extends DimensionBase {
 
-    private static final Logger LOGGER = Logger.getLogger(RolapDimension.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(RolapDimension.class);
 
     final RolapSchema schema;
     private final Larder larder;

--- a/src/main/mondrian/rolap/RolapEvaluator.java
+++ b/src/main/mondrian/rolap/RolapEvaluator.java
@@ -20,7 +20,8 @@ import mondrian.server.Statement;
 import mondrian.spi.Dialect;
 import mondrian.util.Format;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.*;
 
@@ -63,7 +64,7 @@ import java.util.*;
  * @since 10 August, 2001
  */
 public class RolapEvaluator implements Evaluator {
-    private static final Logger LOGGER = Logger.getLogger(RolapEvaluator.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(RolapEvaluator.class);
 
     /**
      * Dummy value to represent null results in the expression cache.

--- a/src/main/mondrian/rolap/RolapGalaxy.java
+++ b/src/main/mondrian/rolap/RolapGalaxy.java
@@ -13,7 +13,8 @@ package mondrian.rolap;
 import mondrian.olap.*;
 import mondrian.util.Pair;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.*;
 
@@ -64,7 +65,7 @@ public class RolapGalaxy {
     private Map<RolapStar.Measure, BitKey> nonAdditiveMeasureSafeToRollup =
         new HashMap<RolapStar.Measure, BitKey>();
 
-    private static final Logger LOGGER = Logger.getLogger(RolapStar.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(RolapStar.class);
 
     RolapGalaxy(RolapCube cube) {
         this.cube = cube;

--- a/src/main/mondrian/rolap/RolapHierarchy.java
+++ b/src/main/mondrian/rolap/RolapHierarchy.java
@@ -23,7 +23,8 @@ import mondrian.rolap.sql.SqlQuery;
 import mondrian.spi.CellFormatter;
 import mondrian.spi.impl.Scripts;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.olap4j.impl.NamedListImpl;
 import org.olap4j.metadata.NamedList;
@@ -50,7 +51,7 @@ import java.util.*;
   */
 public class RolapHierarchy extends HierarchyBase {
 
-    private static final Logger LOGGER = Logger.getLogger(RolapHierarchy.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(RolapHierarchy.class);
 
     /**
      * The raw member reader. For a member reader which incorporates access

--- a/src/main/mondrian/rolap/RolapLevel.java
+++ b/src/main/mondrian/rolap/RolapLevel.java
@@ -13,7 +13,8 @@ package mondrian.rolap;
 import mondrian.olap.*;
 import mondrian.spi.MemberFormatter;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.*;
 
@@ -28,7 +29,7 @@ import java.util.*;
  */
 public class RolapLevel extends LevelBase {
 
-    private static final Logger LOGGER = Logger.getLogger(RolapLevel.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(RolapLevel.class);
 
     protected RolapAttribute attribute;
 

--- a/src/main/mondrian/rolap/RolapMemberBase.java
+++ b/src/main/mondrian/rolap/RolapMemberBase.java
@@ -20,7 +20,8 @@ import mondrian.spi.PropertyFormatter;
 import mondrian.util.*;
 
 import org.apache.commons.collections.map.Flat3Map;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.math.BigDecimal;
 import java.util.*;
@@ -44,7 +45,7 @@ public class RolapMemberBase
     private Comparable orderKey;
     private Boolean isParentChildLeaf;
 
-    private static final Logger LOGGER = Logger.getLogger(RolapMember.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(RolapMember.class);
     private static final Object[] EMPTY_OBJECT_ARRAY = new Object[0];
 
     /**

--- a/src/main/mondrian/rolap/RolapNativeSet.java
+++ b/src/main/mondrian/rolap/RolapNativeSet.java
@@ -20,7 +20,8 @@ import mondrian.rolap.cache.*;
 import mondrian.rolap.sql.*;
 import mondrian.spi.Dialect;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.*;
 import javax.sql.DataSource;
@@ -38,7 +39,7 @@ import javax.sql.DataSource;
   */
 public abstract class RolapNativeSet extends RolapNative {
     protected static final Logger LOGGER =
-        Logger.getLogger(RolapNativeSet.class);
+        LoggerFactory.getLogger(RolapNativeSet.class);
 
     private SmartCache<Object, TupleList> cache =
         new SoftSmartCache<Object, TupleList>();

--- a/src/main/mondrian/rolap/RolapProperty.java
+++ b/src/main/mondrian/rolap/RolapProperty.java
@@ -13,7 +13,8 @@ package mondrian.rolap;
 import mondrian.olap.*;
 import mondrian.spi.PropertyFormatter;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 
@@ -24,7 +25,7 @@ import java.util.Map;
  */
 class RolapProperty extends Property implements Annotated {
 
-    private static final Logger LOGGER = Logger.getLogger(RolapProperty.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(RolapProperty.class);
 
     private final PropertyFormatter formatter;
     private final Larder larder;

--- a/src/main/mondrian/rolap/RolapResult.java
+++ b/src/main/mondrian/rolap/RolapResult.java
@@ -25,7 +25,8 @@ import mondrian.server.Locus;
 import mondrian.spi.CellFormatter;
 import mondrian.util.*;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.*;
 
@@ -37,7 +38,7 @@ import java.util.*;
  */
 public class RolapResult extends ResultBase {
 
-    static final Logger LOGGER = Logger.getLogger(ResultBase.class);
+    static final Logger LOGGER = LoggerFactory.getLogger(ResultBase.class);
 
     private RolapEvaluator evaluator;
     RolapEvaluator slicerEvaluator;

--- a/src/main/mondrian/rolap/RolapSchema.java
+++ b/src/main/mondrian/rolap/RolapSchema.java
@@ -24,7 +24,8 @@ import mondrian.spi.*;
 import mondrian.spi.impl.*;
 import mondrian.util.*;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.eigenbase.xom.*;
 
@@ -49,7 +50,7 @@ import javax.sql.DataSource;
  * @since 26 July, 2001
  */
 public class RolapSchema extends OlapElementBase implements Schema {
-    static final Logger LOGGER = Logger.getLogger(RolapSchema.class);
+    static final Logger LOGGER = LoggerFactory.getLogger(RolapSchema.class);
 
     final String name;
 

--- a/src/main/mondrian/rolap/RolapSchemaLoader.java
+++ b/src/main/mondrian/rolap/RolapSchemaLoader.java
@@ -34,7 +34,8 @@ import mondrian.util.*;
 import mondrian.util.Bug;
 
 import org.apache.commons.collections.map.MultiValueMap;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.eigenbase.xom.*;
 
@@ -57,7 +58,7 @@ import static mondrian.olap.Util.first;
  * @author jhyde
  */
 public class RolapSchemaLoader {
-    private static final Logger LOGGER = Logger.getLogger(RolapSchema.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(RolapSchema.class);
 
     private static final Set<Access> schemaAllowed =
         Olap4jUtil.enumSetOf(

--- a/src/main/mondrian/rolap/RolapSchemaPool.java
+++ b/src/main/mondrian/rolap/RolapSchemaPool.java
@@ -16,7 +16,8 @@ import mondrian.rolap.aggmatcher.JdbcSchema;
 import mondrian.spi.DynamicSchemaProcessor;
 import mondrian.util.*;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.lang.ref.*;
@@ -31,7 +32,7 @@ import javax.sql.DataSource;
  * <code>RolapSchemaPool.{@link #instance}().{@link #get}</code>.</p>
  */
 class RolapSchemaPool {
-    static final Logger LOGGER = Logger.getLogger(RolapSchemaPool.class);
+    static final Logger LOGGER = LoggerFactory.getLogger(RolapSchemaPool.class);
 
     private static final RolapSchemaPool INSTANCE = new RolapSchemaPool();
 

--- a/src/main/mondrian/rolap/RolapSchemaReader.java
+++ b/src/main/mondrian/rolap/RolapSchemaReader.java
@@ -18,7 +18,8 @@ import mondrian.olap.type.StringType;
 import mondrian.rolap.sql.MemberChildrenConstraint;
 import mondrian.rolap.sql.TupleConstraint;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.eigenbase.util.property.Property;
 
@@ -46,7 +47,7 @@ public class RolapSchemaReader
     private final SqlConstraintFactory sqlConstraintFactory =
         SqlConstraintFactory.instance();
     private static final Logger LOGGER =
-        Logger.getLogger(RolapSchemaReader.class);
+        LoggerFactory.getLogger(RolapSchemaReader.class);
 
     /**
      * Creates a RolapSchemaReader.

--- a/src/main/mondrian/rolap/RolapSchemaUpgrader.java
+++ b/src/main/mondrian/rolap/RolapSchemaUpgrader.java
@@ -19,7 +19,8 @@ import mondrian.spi.Dialect;
 import mondrian.util.ByteString;
 import mondrian.util.Pair;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.eigenbase.xom.DOMWrapper;
 import org.eigenbase.xom.NodeDef;
@@ -48,7 +49,7 @@ public class RolapSchemaUpgrader {
         new HashMap<String, CubeInfo>();
 
     public static final Logger LOGGER =
-        Logger.getLogger(RolapSchemaUpgrader.class);
+        LoggerFactory.getLogger(RolapSchemaUpgrader.class);
 
     /**
      * Creates a RolapSchemaUpgrader; private because you should use
@@ -4052,7 +4053,7 @@ public class RolapSchemaUpgrader {
      */
     public static class HierarchyUsage {
         private static final Logger LOGGER =
-            Logger.getLogger(HierarchyUsage.class);
+            LoggerFactory.getLogger(HierarchyUsage.class);
 
         enum Kind {
             UNKNOWN,

--- a/src/main/mondrian/rolap/RolapStar.java
+++ b/src/main/mondrian/rolap/RolapStar.java
@@ -20,7 +20,8 @@ import mondrian.server.Locus;
 import mondrian.spi.*;
 
 import org.apache.commons.collections.map.ReferenceMap;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -42,7 +43,7 @@ import javax.sql.DataSource;
  * @since 12 August, 2001
  */
 public class RolapStar {
-    private static final Logger LOGGER = Logger.getLogger(RolapStar.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(RolapStar.class);
 
     private final RolapSchema schema;
 
@@ -1379,7 +1380,7 @@ public class RolapStar {
     }
 
     public static class Condition {
-        private static final Logger LOGGER = Logger.getLogger(Condition.class);
+        private static final Logger LOGGER = LoggerFactory.getLogger(Condition.class);
 
         private final RolapSchema.PhysExpr left;
         private final RolapSchema.PhysExpr right;

--- a/src/main/mondrian/rolap/RolapUtil.java
+++ b/src/main/mondrian/rolap/RolapUtil.java
@@ -21,7 +21,8 @@ import mondrian.server.*;
 import mondrian.spi.Dialect;
 import mondrian.util.ClassResolver;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.eigenbase.util.property.StringProperty;
 
@@ -39,14 +40,14 @@ import javax.sql.DataSource;
  * @since 22 December, 2001
  */
 public class RolapUtil {
-    public static final Logger MDX_LOGGER = Logger.getLogger("mondrian.mdx");
-    public static final Logger SQL_LOGGER = Logger.getLogger("mondrian.sql");
+    public static final Logger MDX_LOGGER = LoggerFactory.getLogger("mondrian.mdx");
+    public static final Logger SQL_LOGGER = LoggerFactory.getLogger("mondrian.sql");
     public static final Logger MONITOR_LOGGER =
-        Logger.getLogger("mondrian.server.monitor");
+        LoggerFactory.getLogger("mondrian.server.monitor");
     public static final Logger PROFILE_LOGGER =
-        Logger.getLogger("mondrian.profile");
+        LoggerFactory.getLogger("mondrian.profile");
 
-    static final Logger LOGGER = Logger.getLogger(RolapUtil.class);
+    static final Logger LOGGER = LoggerFactory.getLogger(RolapUtil.class);
     private static Semaphore querySemaphore;
 
     /**
@@ -372,12 +373,10 @@ public class RolapUtil {
             MondrianProperties.instance().AlertNativeEvaluationUnsupported;
         String alertValue = alertProperty.get();
 
-        if (alertValue.equalsIgnoreCase(
-                org.apache.log4j.Level.WARN.toString()))
+        if (alertValue.equalsIgnoreCase( "WARN" ))
         {
             LOGGER.warn(alertMsg);
-        } else if (alertValue.equalsIgnoreCase(
-                org.apache.log4j.Level.ERROR.toString()))
+        } else if (alertValue.equalsIgnoreCase( "ERROR" ))
         {
             LOGGER.error(alertMsg);
             throw MondrianResource.instance().NativeEvaluationUnsupported.ex(

--- a/src/main/mondrian/rolap/SqlStatement.java
+++ b/src/main/mondrian/rolap/SqlStatement.java
@@ -16,7 +16,8 @@ import mondrian.server.monitor.*;
 import mondrian.spi.Dialect;
 import mondrian.util.*;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Proxy;
 import java.sql.*;
@@ -55,7 +56,7 @@ import javax.sql.DataSource;
  * @since 2.3
  */
 public class SqlStatement {
-    private static final Logger LOG = Logger.getLogger(SqlStatement.class);
+    private static final Logger LOG = LoggerFactory.getLogger(SqlStatement.class);
     private static final String TIMING_NAME = "SqlStatement-";
 
     // used for SQL logging, allows for a SQL Statement UID

--- a/src/main/mondrian/rolap/SqlTupleReader.java
+++ b/src/main/mondrian/rolap/SqlTupleReader.java
@@ -28,7 +28,8 @@ import mondrian.server.monitor.SqlStatementEvent;
 import mondrian.spi.Dialect;
 import mondrian.util.Pair;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -76,7 +77,7 @@ import javax.sql.DataSource;
  */
 public class SqlTupleReader implements TupleReader {
     private static final Logger LOGGER =
-        Logger.getLogger(SqlTupleReader.class);
+        LoggerFactory.getLogger(SqlTupleReader.class);
     protected final TupleConstraint constraint;
     protected final List<Target> targets = new ArrayList<Target>();
     int maxRows = 0;

--- a/src/main/mondrian/rolap/agg/AggQuerySpec.java
+++ b/src/main/mondrian/rolap/agg/AggQuerySpec.java
@@ -19,7 +19,8 @@ import mondrian.rolap.aggmatcher.AggStar;
 import mondrian.rolap.sql.SqlQuery;
 import mondrian.util.Pair;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -34,7 +35,7 @@ import java.util.List;
  * @author Richard M. Emberson
  */
 class AggQuerySpec {
-    private static final Logger LOGGER = Logger.getLogger(AggQuerySpec.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(AggQuerySpec.class);
 
     private final AggStar aggStar;
     private final List<Segment> segments;

--- a/src/main/mondrian/rolap/agg/AggregationManager.java
+++ b/src/main/mondrian/rolap/agg/AggregationManager.java
@@ -23,7 +23,8 @@ import mondrian.rolap.aggmatcher.AggStar;
 import mondrian.server.Locus;
 import mondrian.util.Pair;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.PrintWriter;
 import java.util.*;
@@ -42,7 +43,7 @@ public class AggregationManager extends RolapAggregationManager {
         MondrianProperties.instance();
 
     private static final Logger LOGGER =
-        Logger.getLogger(AggregationManager.class);
+        LoggerFactory.getLogger(AggregationManager.class);
 
     public final SegmentCacheManager cacheMgr;
 

--- a/src/main/mondrian/rolap/agg/Segment.java
+++ b/src/main/mondrian/rolap/agg/Segment.java
@@ -16,7 +16,8 @@ import mondrian.olap.Util;
 import mondrian.rolap.*;
 import mondrian.spi.SegmentHeader;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.PrintWriter;
 import java.util.*;
@@ -111,7 +112,7 @@ public class Segment {
 
     private final SegmentHeader segmentHeader;
 
-    private static final Logger LOGGER = Logger.getLogger(Segment.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(Segment.class);
 
     /**
      * Creates a <code>Segment</code>; it's not loaded yet.

--- a/src/main/mondrian/rolap/agg/SegmentCacheManager.java
+++ b/src/main/mondrian/rolap/agg/SegmentCacheManager.java
@@ -21,7 +21,8 @@ import mondrian.spi.*;
 import mondrian.util.ByteString;
 import mondrian.util.Pair;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.PrintWriter;
 import java.util.*;
@@ -263,7 +264,7 @@ public class SegmentCacheManager {
     private final SegmentCacheIndexRegistry indexRegistry;
 
     private static final Logger LOGGER =
-        Logger.getLogger(AggregationManager.class);
+        LoggerFactory.getLogger(AggregationManager.class);
     private final MondrianServer server;
 
     public SegmentCacheManager(MondrianServer server) {
@@ -1029,7 +1030,7 @@ public class SegmentCacheManager {
                             event.acceptWithoutResponse(handler);
 
                             // Broadcast the event to anyone who is interested.
-                            RolapUtil.MONITOR_LOGGER.debug(message);
+                            RolapUtil.MONITOR_LOGGER.debug("{}", message);
                         }
                     } catch (Throwable e) {
                         // REVIEW: Somewhere better to send it?

--- a/src/main/mondrian/rolap/agg/SegmentCacheWorker.java
+++ b/src/main/mondrian/rolap/agg/SegmentCacheWorker.java
@@ -14,7 +14,8 @@ import mondrian.resource.MondrianResource;
 import mondrian.spi.*;
 import mondrian.util.*;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.*;
 
@@ -27,7 +28,7 @@ import java.util.*;
 public final class SegmentCacheWorker {
 
     private static final Logger LOGGER =
-        Logger.getLogger(SegmentCacheWorker.class);
+        LoggerFactory.getLogger(SegmentCacheWorker.class);
 
     private final SegmentCache cache;
     private final Thread cacheMgrThread;

--- a/src/main/mondrian/rolap/agg/SegmentLoader.java
+++ b/src/main/mondrian/rolap/agg/SegmentLoader.java
@@ -21,7 +21,8 @@ import mondrian.server.monitor.SqlStatementEvent;
 import mondrian.spi.*;
 import mondrian.util.*;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.Serializable;
 import java.sql.ResultSet;
@@ -48,7 +49,7 @@ import java.util.concurrent.*;
  */
 public class SegmentLoader {
 
-    private static final Logger LOGGER = Logger.getLogger(SegmentLoader.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(SegmentLoader.class);
 
     private final SegmentCacheManager cacheMgr;
 

--- a/src/main/mondrian/rolap/aggmatcher/AggGen.java
+++ b/src/main/mondrian/rolap/aggmatcher/AggGen.java
@@ -14,7 +14,8 @@ import mondrian.olap.Util;
 import mondrian.rolap.*;
 import mondrian.rolap.sql.SqlQuery;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -30,7 +31,7 @@ import java.util.*;
  * @author Richard M. Emberson
  */
 public class AggGen {
-    private static final Logger LOGGER = Logger.getLogger(AggGen.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(AggGen.class);
 
     private final String cubeName;
     private final RolapStar star;
@@ -167,7 +168,7 @@ public class AggGen {
         try {
             factTable.load();
         } catch (SQLException ex) {
-            getLogger().error(ex);
+            getLogger().error("Exception", ex);
             return;
         }
 
@@ -366,7 +367,7 @@ public class AggGen {
         try {
             jt.load();
         } catch (SQLException ex) {
-            getLogger().error(ex);
+            getLogger().error("Error", ex);
             return false;
         }
 
@@ -457,7 +458,7 @@ public class AggGen {
         try {
             jt.load();
         } catch (SQLException ex) {
-            getLogger().error(ex);
+            getLogger().error("Error", ex);
             return false;
         }
 
@@ -465,7 +466,7 @@ public class AggGen {
         try {
             jt.load();
         } catch (SQLException sqle) {
-            getLogger().error(sqle);
+            getLogger().error("Error", sqle);
             return false;
         }
 

--- a/src/main/mondrian/rolap/aggmatcher/AggStar.java
+++ b/src/main/mondrian/rolap/aggmatcher/AggStar.java
@@ -20,7 +20,8 @@ import mondrian.server.Execution;
 import mondrian.server.Locus;
 import mondrian.spi.Dialect;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -51,7 +52,7 @@ import javax.sql.DataSource;
  * @author Richard M. Emberson
  */
 public class AggStar extends RolapStar {
-    private static final Logger LOGGER = Logger.getLogger(AggStar.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(AggStar.class);
 
     static Logger getLogger() {
         return LOGGER;
@@ -420,7 +421,7 @@ public class AggStar extends RolapStar {
     }
 
     private static final Logger JOIN_CONDITION_LOGGER =
-            Logger.getLogger(AggStar.Table.JoinCondition.class);
+            LoggerFactory.getLogger(AggStar.Table.JoinCondition.class);
 
     /**
      * Base Table class for the FactTable and DimTable classes.

--- a/src/main/mondrian/rolap/aggmatcher/AggTableManager.java
+++ b/src/main/mondrian/rolap/aggmatcher/AggTableManager.java
@@ -15,7 +15,8 @@ import mondrian.recorder.*;
 import mondrian.resource.MondrianResource;
 import mondrian.rolap.*;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.sql.SQLException;
 import java.util.*;
@@ -40,7 +41,7 @@ import javax.sql.DataSource;
  */
 public class AggTableManager {
     private static final Logger LOGGER =
-        Logger.getLogger(AggTableManager.class);
+        LoggerFactory.getLogger(AggTableManager.class);
 
     private final RolapSchema schema;
 

--- a/src/main/mondrian/rolap/aggmatcher/DefaultRules.java
+++ b/src/main/mondrian/rolap/aggmatcher/DefaultRules.java
@@ -15,7 +15,8 @@ import mondrian.recorder.*;
 import mondrian.resource.MondrianResource;
 import mondrian.rolap.RolapStar;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.eigenbase.util.property.Property;
 import org.eigenbase.util.property.Trigger;
@@ -41,7 +42,7 @@ import java.util.Map;
  */
 public class DefaultRules {
 
-    private static final Logger LOGGER = Logger.getLogger(DefaultRules.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultRules.class);
 
     private static final MondrianResource mres = MondrianResource.instance();
     /**

--- a/src/main/mondrian/rolap/aggmatcher/ExplicitRules.java
+++ b/src/main/mondrian/rolap/aggmatcher/ExplicitRules.java
@@ -15,7 +15,8 @@ import mondrian.recorder.MessageRecorder;
 import mondrian.resource.MondrianResource;
 import mondrian.rolap.*;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -29,7 +30,7 @@ import java.util.regex.Pattern;
  * @author Richard M. Emberson
  */
 public class ExplicitRules {
-    private static final Logger LOGGER = Logger.getLogger(ExplicitRules.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ExplicitRules.class);
 
     private static final MondrianResource mres = MondrianResource.instance();
 

--- a/src/main/mondrian/rolap/aggmatcher/JdbcSchema.java
+++ b/src/main/mondrian/rolap/aggmatcher/JdbcSchema.java
@@ -16,7 +16,8 @@ import mondrian.rolap.*;
 import mondrian.spi.Dialect;
 import mondrian.util.ClassResolver;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.olap4j.impl.Olap4jUtil;
 
@@ -50,7 +51,7 @@ import javax.sql.DataSource;
  */
 public class JdbcSchema {
     private static final Logger LOGGER =
-        Logger.getLogger(JdbcSchema.class);
+        LoggerFactory.getLogger(JdbcSchema.class);
 
     private static final MondrianResource mres = MondrianResource.instance();
 
@@ -168,7 +169,7 @@ public class JdbcSchema {
                     } catch (Exception ex) {
                         // Should not happen, but might still like to
                         // know that something's funky.
-                        LOGGER.warn(ex);
+                        LOGGER.warn("Exception in sweepDB", ex);
                     }
                 }
             }

--- a/src/main/mondrian/rolap/aggmatcher/Recognizer.java
+++ b/src/main/mondrian/rolap/aggmatcher/Recognizer.java
@@ -16,7 +16,8 @@ import mondrian.resource.MondrianResource;
 import mondrian.rolap.*;
 import mondrian.rolap.sql.SqlQuery;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.*;
 
@@ -40,7 +41,7 @@ import java.util.*;
 abstract class Recognizer {
 
     private static final MondrianResource mres = MondrianResource.instance();
-    private static final Logger LOGGER = Logger.getLogger(Recognizer.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(Recognizer.class);
     /**
      * This is used to wrap column name matching rules.
      */

--- a/src/main/mondrian/rolap/sql/CrossJoinArgFactory.java
+++ b/src/main/mondrian/rolap/sql/CrossJoinArgFactory.java
@@ -17,7 +17,8 @@ import mondrian.olap.fun.*;
 import mondrian.olap.type.*;
 import mondrian.rolap.*;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.*;
 
@@ -29,7 +30,7 @@ import java.util.*;
  */
 public class CrossJoinArgFactory {
     protected static final Logger LOGGER =
-        Logger.getLogger(CrossJoinArgFactory.class);
+        LoggerFactory.getLogger(CrossJoinArgFactory.class);
 
     private final boolean restrictMemberTypes;
 

--- a/src/main/mondrian/server/DynamicContentFinder.java
+++ b/src/main/mondrian/server/DynamicContentFinder.java
@@ -15,7 +15,8 @@ import mondrian.tui.XmlaSupport;
 import mondrian.util.Pair;
 import mondrian.xmla.DataSourcesConfig;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -44,7 +45,7 @@ public class DynamicContentFinder
     protected DataSourcesConfig.DataSources dataSources;
 
     private static final Logger LOGGER =
-        Logger.getLogger(MondrianServer.class);
+        LoggerFactory.getLogger(MondrianServer.class);
 
     private final Timer timer;
 

--- a/src/main/mondrian/server/Execution.java
+++ b/src/main/mondrian/server/Execution.java
@@ -14,7 +14,9 @@ import mondrian.resource.MondrianResource;
 import mondrian.rolap.RolapConnection;
 import mondrian.server.monitor.*;
 
-import org.apache.log4j.MDC;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 
 import java.util.EmptyStackException;
 import java.util.HashMap;
@@ -111,7 +113,7 @@ public class Execution {
     public void copyMDC() {
         this.mdc.clear();
         final Map<String, Object> currentMdc =
-            MDC.getContext();
+            MDC.getCopyOfContextMap();
         if (currentMdc != null) {
             this.mdc.putAll(currentMdc);
         }
@@ -123,11 +125,7 @@ public class Execution {
      * RolapResultShepherd where original MDC needs to be retrieved
      */
     public void setContextMap() {
-        final Map<String, Object> old = MDC.getContext();
-        if (old != null) {
-            old.clear();
-            old.putAll(mdc);
-        }
+        MDC.setContextMap(mdc);
     }
 
     /**

--- a/src/main/mondrian/server/FileRepository.java
+++ b/src/main/mondrian/server/FileRepository.java
@@ -17,7 +17,8 @@ import mondrian.tui.XmlaSupport;
 import mondrian.util.*;
 import mondrian.xmla.DataSourcesConfig;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.olap4j.*;
 import org.olap4j.impl.Olap4jUtil;
@@ -41,7 +42,7 @@ public class FileRepository implements Repository {
     private static final Object SERVER_INFO_LOCK = new Object();
     private final RepositoryContentFinder repositoryContentFinder;
 
-    private static final Logger LOGGER = Logger.getLogger(MondrianServer.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(MondrianServer.class);
 
     private static final ScheduledExecutorService executorService =
         Util.getScheduledExecutorService(

--- a/src/main/mondrian/server/MondrianServerImpl.java
+++ b/src/main/mondrian/server/MondrianServerImpl.java
@@ -23,7 +23,8 @@ import mondrian.util.LockBox;
 import mondrian.xmla.*;
 
 import org.apache.commons.collections.map.ReferenceMap;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.olap4j.OlapConnection;
 
@@ -96,7 +97,7 @@ class MondrianServerImpl
     private boolean shutdown = false;
 
     private static final Logger LOGGER =
-        Logger.getLogger(MondrianServerImpl.class);
+        LoggerFactory.getLogger(MondrianServerImpl.class);
 
     private static final AtomicInteger ID_GENERATOR = new AtomicInteger();
 

--- a/src/main/mondrian/server/MonitorImpl.java
+++ b/src/main/mondrian/server/MonitorImpl.java
@@ -15,7 +15,8 @@ import mondrian.rolap.RolapUtil;
 import mondrian.server.monitor.*;
 import mondrian.util.Pair;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.*;
 import java.util.concurrent.ArrayBlockingQueue;
@@ -61,7 +62,7 @@ import java.util.concurrent.BlockingQueue;
 class MonitorImpl
     implements Monitor
 {
-    private static final Logger LOGGER = Logger.getLogger(MonitorImpl.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(MonitorImpl.class);
     private final Handler handler = new Handler();
 
     protected static final Util.MemoryInfo MEMORY_INFO = Util.getMemoryInfo();
@@ -602,7 +603,7 @@ class MonitorImpl
 
             // Since the connection info will no longer be in the table,
             // broadcast the final info to anyone who is interested.
-            RolapUtil.MONITOR_LOGGER.debug(conn.fix());
+            RolapUtil.MONITOR_LOGGER.debug("{}", conn.fix());
             return null;
         }
 
@@ -656,7 +657,7 @@ class MonitorImpl
 
             // Since the statement info will no longer be in the table,
             // broadcast the final info to anyone who is interested.
-            RolapUtil.MONITOR_LOGGER.debug(stmt.fix());
+            RolapUtil.MONITOR_LOGGER.debug("{}", stmt.fix());
             return null;
         }
 
@@ -739,7 +740,7 @@ class MonitorImpl
 
             // Since the execution info will no longer be in the table,
             // broadcast the final info to anyone who is interested.
-            RolapUtil.MONITOR_LOGGER.debug(exec.fix());
+            RolapUtil.MONITOR_LOGGER.debug("{}", exec.fix());
             return null;
         }
 
@@ -902,7 +903,7 @@ class MonitorImpl
 
             // Since the SQL statement info will no longer be in the table,
             // broadcast the final info to anyone who is interested.
-            RolapUtil.MONITOR_LOGGER.debug(sql.fix());
+            RolapUtil.MONITOR_LOGGER.debug("{}", sql.fix());
             return null;
         }
 
@@ -1048,7 +1049,7 @@ class MonitorImpl
                             responseQueue.put((Command) message, result);
                         } else {
                             // Broadcast the event to anyone who is interested.
-                            RolapUtil.MONITOR_LOGGER.debug(message);
+                            RolapUtil.MONITOR_LOGGER.debug("{}", message);
                         }
                         if (message instanceof ShutdownCommand) {
                             return;

--- a/src/main/mondrian/spi/VirtualFileHandler.java
+++ b/src/main/mondrian/spi/VirtualFileHandler.java
@@ -12,7 +12,8 @@ package mondrian.spi;
 import mondrian.olap.*;
 import mondrian.util.ClassResolver;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.*;
 import java.util.Arrays;
@@ -27,7 +28,7 @@ import java.util.Arrays;
  * @author jhyde
  */
 public interface VirtualFileHandler {
-    Logger LOGGER = Logger.getLogger(VirtualFileHandler.class);
+    Logger LOGGER = LoggerFactory.getLogger(VirtualFileHandler.class);
 
     String[] BUILTIN_IMPLEMENTATIONS = {
         "mondrian.spi.impl.ApacheVfsVirtualFileHandler",

--- a/src/main/mondrian/spi/impl/JdbcStatisticsProvider.java
+++ b/src/main/mondrian/spi/impl/JdbcStatisticsProvider.java
@@ -14,7 +14,8 @@ import mondrian.server.Execution;
 import mondrian.spi.Dialect;
 import mondrian.spi.StatisticsProvider;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.sql.*;
 import javax.sql.DataSource;
@@ -25,7 +26,7 @@ import javax.sql.DataSource;
  */
 public class JdbcStatisticsProvider implements StatisticsProvider {
     private static final Logger LOG =
-        Logger.getLogger(JdbcStatisticsProvider.class);
+        LoggerFactory.getLogger(JdbcStatisticsProvider.class);
     public int getTableCardinality(
         Dialect dialect,
         DataSource dataSource,

--- a/src/main/mondrian/tui/CmdRunner.java
+++ b/src/main/mondrian/tui/CmdRunner.java
@@ -18,9 +18,6 @@ import mondrian.olap.fun.FunInfo;
 import mondrian.olap.type.TypeUtil;
 import mondrian.rolap.*;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.*;
-
 import org.eigenbase.util.property.Property;
 
 import org.olap4j.CellSet;
@@ -36,6 +33,8 @@ import java.sql.*;
 import java.text.NumberFormat;
 import java.text.ParseException;
 import java.util.*;
+import java.util.logging.LogManager;
+import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -1679,7 +1678,11 @@ public class CmdRunner {
 
         String[] tokens = mdxCmd.split("\\s+");
 
-        if (tokens.length == 1) {
+
+        // TODO :
+        // This probably needs an actual SLF4j implementation - possibly logback.
+
+        /*if (tokens.length == 1) {
             Enumeration e = LogManager.getCurrentLoggers();
             while (e.hasMoreElements()) {
                 Logger logger = (Logger) e.nextElement();
@@ -1734,7 +1737,7 @@ public class CmdRunner {
             buf.append(nl);
             appendSet(buf);
         }
-
+          */
         return buf.toString();
     }
 

--- a/src/main/mondrian/tui/XmlaSupport.java
+++ b/src/main/mondrian/tui/XmlaSupport.java
@@ -20,7 +20,8 @@ import mondrian.xmla.*;
 import mondrian.xmla.Enumeration;
 import mondrian.xmla.impl.*;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.eigenbase.xom.*;
 import org.eigenbase.xom.Parser;
@@ -43,7 +44,7 @@ import javax.xml.transform.TransformerException;
  * @author Richard M. Emberson
  */
 public class XmlaSupport {
-    private static final Logger LOGGER = Logger.getLogger(XmlaSupport.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(XmlaSupport.class);
 
     public static final String nl = Util.nl;
     public static final String SOAP_PREFIX = XmlaConstants.SOAP_PREFIX;

--- a/src/main/mondrian/udf/InverseNormalUdf.java
+++ b/src/main/mondrian/udf/InverseNormalUdf.java
@@ -19,7 +19,8 @@ import mondrian.spi.UserDefinedFunction;
 import org.apache.commons.math.MathException;
 import org.apache.commons.math.distribution.NormalDistribution;
 import org.apache.commons.math.distribution.NormalDistributionImpl;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -43,7 +44,7 @@ import org.apache.log4j.Logger;
  */
 public class InverseNormalUdf implements UserDefinedFunction {
     private static final Logger LOGGER =
-        Logger.getLogger(InverseNormalUdf.class);
+        LoggerFactory.getLogger(InverseNormalUdf.class);
 
 
     // the zero arg constructor sets the mean equal to zero and standard

--- a/src/main/mondrian/util/AbstractMemoryMonitor.java
+++ b/src/main/mondrian/util/AbstractMemoryMonitor.java
@@ -11,7 +11,8 @@ package mondrian.util;
 
 import mondrian.olap.MondrianProperties;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.LinkedList;
 import java.util.ListIterator;

--- a/src/main/mondrian/util/Bug.java
+++ b/src/main/mondrian/util/Bug.java
@@ -13,7 +13,8 @@ import mondrian.olap.*;
 import mondrian.rolap.RolapSchemaLoader;
 import mondrian.spi.Dialect;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Holder for constants which indicate whether particular issues have been
@@ -269,7 +270,7 @@ public class Bug {
      * <p>This is because some tests involving parent-child hierarchies are
      * very slow. If we are running performance tests (indicated by the
      * {@code mondrian.test.PerforceTest} logger set at
-     * {@link org.apache.log4j.Level#DEBUG} or higher), we expect the suite to
+     * {@link ch.qos.logback.classic.Level#DEBUG} or higher), we expect the suite to
      * take a long time, so we enable the tests.
      *
      * <p>Fixing either {@link #BugMondrian759Fixed MONDRIAN-759} or
@@ -283,7 +284,7 @@ public class Bug {
         return
             !BugMondrian759Fixed
             && dialect.getDatabaseProduct() == Dialect.DatabaseProduct.LUCIDDB
-            && !Logger.getLogger("mondrian.test.PerformanceTest")
+            && !LoggerFactory.getLogger("mondrian.test.PerformanceTest")
                 .isDebugEnabled();
     }
 

--- a/src/main/mondrian/util/NotificationMemoryMonitor.java
+++ b/src/main/mondrian/util/NotificationMemoryMonitor.java
@@ -9,7 +9,8 @@
 */
 package mondrian.util;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.lang.management.*;
 import javax.management.*;
@@ -34,7 +35,7 @@ import javax.management.*;
  */
 public class NotificationMemoryMonitor extends AbstractMemoryMonitor {
     private static final Logger LOGGER =
-                Logger.getLogger(NotificationMemoryMonitor.class);
+                LoggerFactory.getLogger(NotificationMemoryMonitor.class);
 
 
     protected static final MemoryPoolMXBean TENURED_POOL;

--- a/src/main/mondrian/util/SlotFuture.java
+++ b/src/main/mondrian/util/SlotFuture.java
@@ -9,7 +9,8 @@
 */
 package mondrian.util;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.*;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -26,7 +27,7 @@ public class SlotFuture<V> implements Future<V> {
     private final CountDownLatch dataGate = new CountDownLatch(1);
     private final ReentrantReadWriteLock stateLock =
         new ReentrantReadWriteLock();
-    private static final Logger LOG = Logger.getLogger(SlotFuture.class);
+    private static final Logger LOG = LoggerFactory.getLogger(SlotFuture.class);
 
     /**
      * Creates a SlotFuture.

--- a/src/main/mondrian/util/UnsupportedList.java
+++ b/src/main/mondrian/util/UnsupportedList.java
@@ -11,7 +11,8 @@ package mondrian.util;
 
 import mondrian.olap.Util;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.*;
 
@@ -35,7 +36,7 @@ import java.util.*;
  */
 public abstract class UnsupportedList<T> implements List<T> {
     private static final Logger LOGGER =
-        Logger.getLogger(UnsupportedList.class);
+        LoggerFactory.getLogger(UnsupportedList.class);
 
     protected UnsupportedList() {
     }

--- a/src/main/mondrian/util/UtilCompatibleJdk14.java
+++ b/src/main/mondrian/util/UtilCompatibleJdk14.java
@@ -13,7 +13,8 @@ import mondrian.olap.Util;
 import mondrian.resource.MondrianResource;
 import mondrian.rolap.RolapUtil;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Method;
 import java.math.BigDecimal;
@@ -34,7 +35,7 @@ import java.util.*;
  * @since Feb 5, 2007
  */
 public class UtilCompatibleJdk14 implements UtilCompatible {
-    private static final Logger LOGGER = Logger.getLogger(Util.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(Util.class);
     private static String previousUuid = "";
     private static final String UUID_BASE =
         Long.toHexString(new Random().nextLong());
@@ -144,7 +145,7 @@ public class UtilCompatibleJdk14 implements UtilCompatible {
                 return;
             }
             if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug(
+                LOGGER.debug("Error {}",
                     MondrianResource.instance()
                         .ExecutionStatementCleanupException
                             .ex(e.getMessage(), e),
@@ -155,7 +156,7 @@ public class UtilCompatibleJdk14 implements UtilCompatible {
             stmt.close();
         } catch (SQLException e) {
             if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug(
+                LOGGER.debug("Error {}",
                     MondrianResource.instance()
                         .ExecutionStatementCleanupException
                             .ex(e.getMessage(), e),

--- a/src/main/mondrian/util/UtilCompatibleJdk15.java
+++ b/src/main/mondrian/util/UtilCompatibleJdk15.java
@@ -13,7 +13,8 @@ import mondrian.olap.Util;
 import mondrian.resource.MondrianResource;
 import mondrian.rolap.RolapUtil;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.lang.annotation.Annotation;
 import java.lang.management.*;
@@ -40,7 +41,7 @@ import java.util.regex.Pattern;
  * @since Feb 5, 2007
  */
 public class UtilCompatibleJdk15 implements UtilCompatible {
-    private static final Logger LOGGER = Logger.getLogger(Util.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(Util.class);
 
     /**
      * This generates a BigDecimal with a precision reflecting
@@ -151,7 +152,7 @@ public class UtilCompatibleJdk15 implements UtilCompatible {
                 return;
             }
             if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug(
+                LOGGER.debug("Error {}",
                     MondrianResource.instance()
                         .ExecutionStatementCleanupException
                             .ex(e.getMessage(), e),
@@ -162,7 +163,7 @@ public class UtilCompatibleJdk15 implements UtilCompatible {
             stmt.close();
         } catch (SQLException e) {
             if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug(
+                LOGGER.debug("Error {}",
                     MondrianResource.instance()
                         .ExecutionStatementCleanupException
                             .ex(e.getMessage(), e),

--- a/src/main/mondrian/util/UtilCompatibleJdk16.java
+++ b/src/main/mondrian/util/UtilCompatibleJdk16.java
@@ -13,7 +13,8 @@ import mondrian.olap.Util;
 import mondrian.resource.MondrianResource;
 import mondrian.rolap.RolapUtil;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -35,7 +36,7 @@ import javax.script.*;
  */
 public class UtilCompatibleJdk16 extends UtilCompatibleJdk15 {
     private static final Logger LOGGER =
-        Logger.getLogger(Util.class);
+        LoggerFactory.getLogger(Util.class);
 
     public <T> T compileScript(
         Class<T> iface,
@@ -67,7 +68,7 @@ public class UtilCompatibleJdk16 extends UtilCompatibleJdk15 {
             }
         } catch (SQLException e) {
             if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug(
+                LOGGER.debug("Error {}",
                     MondrianResource.instance()
                         .ExecutionStatementCleanupException
                             .ex(e.getMessage(), e),
@@ -80,7 +81,7 @@ public class UtilCompatibleJdk16 extends UtilCompatibleJdk15 {
             }
         } catch (SQLException e) {
             if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug(
+                LOGGER.debug("Error {}",
                     MondrianResource.instance()
                         .ExecutionStatementCleanupException
                             .ex(e.getMessage(), e),

--- a/src/main/mondrian/web/taglib/DomBuilder.java
+++ b/src/main/mondrian/web/taglib/DomBuilder.java
@@ -12,7 +12,8 @@ package mondrian.web.taglib;
 
 import mondrian.olap.*;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.w3c.dom.*;
 
@@ -31,7 +32,7 @@ import javax.xml.transform.stream.StreamSource;
  * @author Andreas Voss, 22 March, 2002
  */
 public class DomBuilder {
-    private static final Logger LOGGER = Logger.getLogger(DomBuilder.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(DomBuilder.class);
 
     Document factory;
     Result result;

--- a/src/main/mondrian/web/taglib/ResultCache.java
+++ b/src/main/mondrian/web/taglib/ResultCache.java
@@ -13,7 +13,8 @@ package mondrian.web.taglib;
 import mondrian.olap.*;
 import mondrian.spi.impl.ServletContextCatalogLocator;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.w3c.dom.Document;
 
@@ -27,7 +28,7 @@ import javax.xml.parsers.ParserConfigurationException;
  * @author Andreas Voss, 22 March, 2002
  */
 public class ResultCache implements HttpSessionBindingListener {
-    private static final Logger LOGGER = Logger.getLogger(ResultCache.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ResultCache.class);
     private static final String ATTR_NAME = "mondrian.web.taglib.ResultCache.";
     private Query query = null;
     private Result result = null;
@@ -86,7 +87,7 @@ public class ResultCache implements HttpSessionBindingListener {
             }
             return document;
         } catch (ParserConfigurationException e) {
-            LOGGER.error(e);
+            LOGGER.error("Error", e);
             throw new RuntimeException(e.toString());
         }
     }

--- a/src/main/mondrian/xmla/impl/MondrianXmlaServlet.java
+++ b/src/main/mondrian/xmla/impl/MondrianXmlaServlet.java
@@ -16,6 +16,8 @@ import mondrian.server.UrlRepositoryContentFinder;
 import mondrian.spi.CatalogLocator;
 import mondrian.spi.impl.ServletContextCatalogLocator;
 import mondrian.xmla.XmlaHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.net.MalformedURLException;
@@ -29,6 +31,9 @@ import javax.servlet.*;
  * @author jhyde
  */
 public class MondrianXmlaServlet extends DefaultXmlaServlet {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MondrianXmlaServlet.class);
+
     public static final String DEFAULT_DATASOURCE_FILE = "datasources.xml";
 
     protected MondrianServer server;

--- a/testsrc/main/mondrian/olap/fun/FunctionTest.java
+++ b/testsrc/main/mondrian/olap/fun/FunctionTest.java
@@ -20,7 +20,8 @@ import mondrian.util.Bug;
 import junit.framework.Assert;
 import junit.framework.ComparisonFailure;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.eigenbase.xom.StringEscaper;
 
@@ -35,7 +36,7 @@ import java.util.*;
  */
 public class FunctionTest extends FoodMartTestCase {
 
-    private static final Logger LOGGER = Logger.getLogger(FunctionTest.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(FunctionTest.class);
 
     public static final boolean FILTER_SNOWFLAKE = Util.deprecated(true, false);
 

--- a/testsrc/main/mondrian/olap/fun/PartialSortTest.java
+++ b/testsrc/main/mondrian/olap/fun/PartialSortTest.java
@@ -15,7 +15,8 @@ import junit.framework.TestCase;
 
 import org.apache.commons.collections.ComparatorUtils;
 import org.apache.commons.collections.comparators.ReverseComparator;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.*;
 

--- a/testsrc/main/mondrian/rolap/aggmatcher/AggGenTest.java
+++ b/testsrc/main/mondrian/rolap/aggmatcher/AggGenTest.java
@@ -9,12 +9,17 @@
 */
 package mondrian.rolap.aggmatcher;
 
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.Appender;
+import ch.qos.logback.core.OutputStreamAppender;
 import mondrian.olap.*;
 import mondrian.rolap.RolapConnection;
 import mondrian.test.FoodMartTestCase;
 
-import org.apache.log4j.*;
-import org.apache.log4j.Level;
+import org.slf4j.LoggerFactory;
+
 
 import java.io.StringWriter;
 import java.sql.Connection;
@@ -38,9 +43,9 @@ public class AggGenTest extends FoodMartTestCase {
         testCallingLoadColumnsInAddCollapsedColumnOrAddzSpecialCollapsedColumn()
         throws Exception
     {
-        Logger logger = Logger.getLogger(AggGen.class);
-        StringWriter writer = new StringWriter();
-        Appender myAppender = new WriterAppender(new SimpleLayout(), writer);
+        Logger logger = (Logger) LoggerFactory.getLogger(AggGen.class);
+
+        OutputStreamAppender<ILoggingEvent> myAppender = new OutputStreamAppender<ILoggingEvent>();
         logger.addAppender(myAppender);
         propSaver.setAtLeast(logger, Level.DEBUG);
 
@@ -59,7 +64,7 @@ public class AggGenTest extends FoodMartTestCase {
                 "select {[Measures].[Count]} on columns from [HR]");
         rolapConn.execute(query);
 
-        logger.removeAppender(myAppender);
+        logger.detachAppender(myAppender);
 
         final DataSource dataSource = rolapConn.getDataSource();
         Connection sqlConnection = null;
@@ -70,7 +75,7 @@ public class AggGenTest extends FoodMartTestCase {
             final String catalogName = jdbcSchema.getCatalogName();
             final String schemaName = jdbcSchema.getSchemaName();
 
-            String log = writer.toString();
+            String log = myAppender.getOutputStream().toString();
             Pattern p = Pattern.compile(
                 "DEBUG - Init: Column: [^:]+: `(\\w+)`.`(\\w+)`"
                 + Util.nl

--- a/testsrc/main/mondrian/rolap/aggmatcher/DefaultRuleTest.java
+++ b/testsrc/main/mondrian/rolap/aggmatcher/DefaultRuleTest.java
@@ -13,7 +13,8 @@ import mondrian.recorder.ListRecorder;
 
 import junit.framework.TestCase;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.eigenbase.xom.*;
 
@@ -28,7 +29,7 @@ import java.util.Iterator;
  */
 public class DefaultRuleTest extends TestCase {
     private static final Logger LOGGER =
-        Logger.getLogger(DefaultRuleTest.class);
+        LoggerFactory.getLogger(DefaultRuleTest.class);
     private static final String DIRECTORY =
         "testsrc/main/mondrian/rolap/aggmatcher";
     private static final String TEST_RULE_XML = "TestRule.xml";

--- a/testsrc/main/mondrian/test/ConcurrentMdxTest.java
+++ b/testsrc/main/mondrian/test/ConcurrentMdxTest.java
@@ -14,7 +14,8 @@ import mondrian.olap.*;
 import mondrian.server.UrlRepositoryContentFinder;
 import mondrian.xmla.test.XmlaTestContext;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.olap4j.*;
 
@@ -32,7 +33,7 @@ import java.util.concurrent.*;
  */
 public class ConcurrentMdxTest extends FoodMartTestCase {
     private static final Logger LOGGER =
-        Logger.getLogger(FoodMartTestCase.class);
+        LoggerFactory.getLogger(FoodMartTestCase.class);
 
     static final QueryAndResult[] mdxQueries = {
         new QueryAndResult(
@@ -1316,7 +1317,7 @@ public class ConcurrentMdxTest extends FoodMartTestCase {
 
     private synchronized void logStatus() {
         if (count % 1000 == 0) {
-            LOGGER.debug(count);
+            LOGGER.debug("{}", count);
         }
         count++;
     }

--- a/testsrc/main/mondrian/test/Main.java
+++ b/testsrc/main/mondrian/test/Main.java
@@ -36,7 +36,8 @@ import mondrian.xmla.test.XmlaTest;
 import junit.framework.Test;
 import junit.framework.*;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.PrintWriter;
 import java.lang.reflect.Method;
@@ -52,7 +53,7 @@ import java.util.*;
  * @author jhyde
  */
 public class Main extends TestSuite {
-    private static final Logger logger = Logger.getLogger(Main.class);
+    private static final Logger logger = LoggerFactory.getLogger(Main.class);
 
     /** Scratch area to store information on the emerging test suite. */
     private static Map<TestSuite, String> testSuiteInfo =

--- a/testsrc/main/mondrian/test/PerformanceTest.java
+++ b/testsrc/main/mondrian/test/PerformanceTest.java
@@ -16,7 +16,8 @@ import mondrian.spi.UserDefinedFunction;
 import mondrian.util.Bug;
 
 import org.apache.commons.collections.ComparatorUtils;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -33,7 +34,7 @@ public class PerformanceTest extends FoodMartTestCase {
      * higher.
      */
     public static final Logger LOGGER =
-        Logger.getLogger(PerformanceTest.class);
+        LoggerFactory.getLogger(PerformanceTest.class);
 
     public PerformanceTest(String name) {
         super(name);

--- a/testsrc/main/mondrian/test/PropertySaver.java
+++ b/testsrc/main/mondrian/test/PropertySaver.java
@@ -10,11 +10,12 @@
 */
 package mondrian.test;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
 import mondrian.olap.MondrianProperties;
 import mondrian.rolap.RolapUtil;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+
 
 import org.eigenbase.util.property.*;
 

--- a/testsrc/main/mondrian/test/SchemaTest.java
+++ b/testsrc/main/mondrian/test/SchemaTest.java
@@ -9,6 +9,12 @@
 */
 package mondrian.test;
 
+import ch.qos.logback.classic.filter.LevelFilter;
+import ch.qos.logback.classic.filter.ThresholdFilter;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.Appender;
+import ch.qos.logback.core.OutputStreamAppender;
+import ch.qos.logback.core.filter.Filter;
 import mondrian.olap.*;
 import mondrian.rolap.RolapCube;
 import mondrian.rolap.RolapMeasureGroup;
@@ -19,11 +25,16 @@ import mondrian.util.*;
 
 import junit.framework.Assert;
 
-import org.apache.log4j.Appender;
-import org.apache.log4j.Logger;
-import org.apache.log4j.SimpleLayout;
-import org.apache.log4j.WriterAppender;
-import org.apache.log4j.varia.LevelRangeFilter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.olap4j.OlapConnection;
 import org.olap4j.impl.ArrayMap;
@@ -1958,13 +1969,14 @@ Test that get error if a dimension has more than one hierarchy with same name.
         if (!MondrianProperties.instance().ReadAggregates.get()) {
             return;
         }
-        final Logger logger = Logger.getLogger(AggTableManager.class);
-        propSaver.setAtLeast(logger, org.apache.log4j.Level.WARN);
-        final StringWriter sw = new StringWriter();
-        final Appender appender =
-            new WriterAppender(new SimpleLayout(), sw);
-        final LevelRangeFilter filter = new LevelRangeFilter();
-        filter.setLevelMin(org.apache.log4j.Level.WARN);
+        final ch.qos.logback.classic.Logger logger = (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(AggTableManager.class);
+        propSaver.setAtLeast(logger, ch.qos.logback.classic.Level.WARN);
+
+        final OutputStreamAppender<ILoggingEvent> appender = new OutputStreamAppender<ILoggingEvent>();
+
+        final LevelFilter filter = new LevelFilter();
+
+        filter.setLevel(ch.qos.logback.classic.Level.WARN);
         appender.addFilter(filter);
         logger.addAppender(appender);
         try {
@@ -2018,7 +2030,7 @@ Test that get error if a dimension has more than one hierarchy with same name.
                 + "{}\n"
                 + "225,627.23");
         } finally {
-            logger.removeAppender(appender);
+            logger.detachAppender(appender);
         }
         // Note that 'product_id' is NOT one of the columns with unknown usage.
         // It is used as a level in the degenerate dimension [Time Degenerate].
@@ -2028,20 +2040,20 @@ Test that get error if a dimension has more than one hierarchy with same name.
             + "WARN - Recognizer.checkUnusedColumns: Candidate aggregate table 'agg_c_10_sales_fact_1997' for fact table 'sales_fact_1997' has a column 'quarter' with unknown usage.\n"
             + "WARN - Recognizer.checkUnusedColumns: Candidate aggregate table 'agg_c_10_sales_fact_1997' for fact table 'sales_fact_1997' has a column 'the_year' with unknown usage.\n"
             + "WARN - Recognizer.checkUnusedColumns: Candidate aggregate table 'agg_c_10_sales_fact_1997' for fact table 'sales_fact_1997' has a column 'unit_sales' with unknown usage.\n",
-            sw.toString());
+            appender.getOutputStream().toString());
     }
 
     public void testUnknownUsages1() {
         if (!MondrianProperties.instance().ReadAggregates.get()) {
             return;
         }
-        final Logger logger = Logger.getLogger(AggTableManager.class);
-        propSaver.setAtLeast(logger, org.apache.log4j.Level.WARN);
-        final StringWriter sw = new StringWriter();
-        final Appender appender =
-            new WriterAppender(new SimpleLayout(), sw);
-        final LevelRangeFilter filter = new LevelRangeFilter();
-        filter.setLevelMin(org.apache.log4j.Level.WARN);
+        final ch.qos.logback.classic.Logger logger = (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(AggTableManager.class);
+        propSaver.setAtLeast(logger, ch.qos.logback.classic.Level.WARN);
+
+        final OutputStreamAppender<ILoggingEvent> appender =
+            new OutputStreamAppender<ILoggingEvent>();
+        final LevelFilter filter = new LevelFilter();
+        filter.setLevel(ch.qos.logback.classic.Level.WARN);
         appender.addFilter(filter);
         logger.addAppender(appender);
         try {
@@ -2103,11 +2115,11 @@ Test that get error if a dimension has more than one hierarchy with same name.
                 + "{}\n"
                 + "225,627.23");
         } finally {
-            logger.removeAppender(appender);
+            logger.detachAppender(appender);
         }
         TestContext.assertEqualsVerbose(
             "WARN - Recognizer.checkUnusedColumns: Candidate aggregate table 'agg_l_03_sales_fact_1997' for fact table 'sales_fact_1997' has a column 'time_id' with unknown usage.\n",
-            sw.toString());
+                appender.getOutputStream().toString());
     }
 
     public void testDegenerateDimension() {

--- a/testsrc/main/mondrian/test/SteelWheelsPerformanceTest.java
+++ b/testsrc/main/mondrian/test/SteelWheelsPerformanceTest.java
@@ -11,7 +11,8 @@ package mondrian.test;
 
 import junit.framework.TestCase;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Those performance tests use the steel wheels schema
@@ -24,7 +25,7 @@ public class SteelWheelsPerformanceTest extends TestCase {
      * Certain tests are enabled only if logging is enabled.
      */
     private static final Logger LOGGER =
-        Logger.getLogger(SteelWheelsPerformanceTest.class);
+        LoggerFactory.getLogger(SteelWheelsPerformanceTest.class);
 
     public SteelWheelsPerformanceTest(String name) {
         super(name);

--- a/testsrc/main/mondrian/test/TestContext.java
+++ b/testsrc/main/mondrian/test/TestContext.java
@@ -28,7 +28,8 @@ import mondrian.util.Pair;
 import junit.framework.*;
 import junit.framework.Test;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.olap4j.*;
 import org.olap4j.impl.CoordinateIterator;
@@ -1831,7 +1832,7 @@ public class TestContext {
     }
 
     public Logger getLogger() {
-        return Logger.getLogger(FoodMartTestCase.class);
+        return LoggerFactory.getLogger(FoodMartTestCase.class);
     }
 
     /**

--- a/testsrc/main/mondrian/test/loader/CsvLoader.java
+++ b/testsrc/main/mondrian/test/loader/CsvLoader.java
@@ -10,7 +10,8 @@
 */
 package mondrian.test.loader;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.*;
 import java.util.ArrayList;
@@ -72,7 +73,7 @@ import java.util.List;
  * @author <a>Richard M. Emberson</a>
  */
 public class CsvLoader {
-    protected static final Logger LOGGER = Logger.getLogger(CsvLoader.class);
+    protected static final Logger LOGGER = LoggerFactory.getLogger(CsvLoader.class);
     public static final char DEFAULT_SEPARATOR = ',';
     public static final char DOUBLE_QUOTE = '"';
     public static final char SINGLE_QUOTE = '\'';

--- a/testsrc/main/mondrian/test/loader/DBLoader.java
+++ b/testsrc/main/mondrian/test/loader/DBLoader.java
@@ -16,7 +16,8 @@ import mondrian.rolap.RolapUtil;
 import mondrian.spi.Dialect;
 import mondrian.spi.DialectManager;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.*;
 import java.math.BigDecimal;
@@ -161,7 +162,7 @@ import java.util.regex.Pattern;
  * @author Richard M. Emberson
  */
 public abstract class DBLoader {
-    protected static final Logger LOGGER = Logger.getLogger(DBLoader.class);
+    protected static final Logger LOGGER = LoggerFactory.getLogger(DBLoader.class);
     public static final String nl = System.getProperty("line.separator");
     private static final int DEFAULT_BATCH_SIZE = 50;
 

--- a/testsrc/main/mondrian/test/loader/MondrianFoodMartLoader.java
+++ b/testsrc/main/mondrian/test/loader/MondrianFoodMartLoader.java
@@ -10,12 +10,18 @@
 */
 package mondrian.test.loader;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.PatternLayout;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.ConsoleAppender;
+import ch.qos.logback.core.Layout;
 import mondrian.olap.Util;
 import mondrian.resource.MondrianResource;
 import mondrian.spi.Dialect;
 import mondrian.spi.DialectManager;
 
-import org.apache.log4j.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.*;
 import java.math.BigDecimal;
@@ -72,8 +78,8 @@ import java.util.regex.Pattern;
 public class MondrianFoodMartLoader {
     // Constants
 
-    private static final Logger LOGGER =
-        Logger.getLogger(MondrianFoodMartLoader.class);
+    private static final ch.qos.logback.classic.Logger LOGGER =
+            (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(MondrianFoodMartLoader.class);
     private static final String nl = Util.nl;
 
     /**
@@ -149,19 +155,19 @@ public class MondrianFoodMartLoader {
         StringBuilder parametersMessage = new StringBuilder();
 
         // Add a console appender for error messages.
-        final ConsoleAppender consoleAppender =
-            new ConsoleAppender(
-                // Formats the message on its own line,
-                // omits timestamp, priority etc.
-                new PatternLayout("%m%n"),
-                "System.out");
-        consoleAppender.setThreshold(Level.ERROR);
+        final ConsoleAppender<ILoggingEvent> consoleAppender = new ConsoleAppender();
+        Layout<ILoggingEvent> layout = new PatternLayout();
+
+        consoleAppender.setTarget("System.out");
+        consoleAppender.setLayout(layout);
+
+        LOGGER.setLevel(Level.ERROR);
         LOGGER.addAppender(consoleAppender);
 
         for (String arg : args) {
             if (arg.equals("-verbose")) {
                 // Make sure the logger is passing at least debug events.
-                consoleAppender.setThreshold(Level.DEBUG);
+                LOGGER.setLevel(Level.DEBUG);
                 if (!LOGGER.isDebugEnabled()) {
                     LOGGER.setLevel(Level.DEBUG);
                 }

--- a/testsrc/main/mondrian/xmla/test/XmlaTest.java
+++ b/testsrc/main/mondrian/xmla/test/XmlaTest.java
@@ -19,7 +19,8 @@ import mondrian.xmla.impl.DefaultXmlaResponse;
 
 import junit.framework.*;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.custommonkey.xmlunit.XMLAssert;
 import org.custommonkey.xmlunit.XMLUnit;
@@ -43,7 +44,7 @@ import javax.xml.transform.stream.StreamResult;
 public class XmlaTest extends TestCase {
 
     private static final Logger LOGGER =
-            Logger.getLogger(XmlaTest.class);
+            LoggerFactory.getLogger(XmlaTest.class);
 
     static {
         XMLUnit.setControlParser(

--- a/testsrc/main/mondrian/xmla/test/XmlaTestContext.java
+++ b/testsrc/main/mondrian/xmla/test/XmlaTestContext.java
@@ -17,7 +17,8 @@ import mondrian.test.DiffRepository;
 import mondrian.test.TestContext;
 import mondrian.xmla.DataSourcesConfig;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.eigenbase.xom.*;
 
@@ -38,7 +39,7 @@ import java.util.regex.Pattern;
 public class XmlaTestContext {
 
     private static final Logger LOGGER =
-        Logger.getLogger(XmlaTestContext.class);
+        LoggerFactory.getLogger(XmlaTestContext.class);
 
     public static final String CATALOG_NAME = "FoodMart";
     public static final String DATASOURCE_NAME = "FoodMart";


### PR DESCRIPTION
I hit MONDRIAN-1171, and I wasn't able to patch the relevant 3rd party JARs, so I thought I'd fix Mondrian to use slf4j natively.

This is a work in progress commit for comment; - I suspect the tests don't work as I can't run them. It shouldn't be much work to make them work. If you can give me some pointers to how to run them, I can adjust the patch. 
