### PR TITLE
CM-371 - Removed the use of .tar.gz in favor of using .zip with file permissions stored in the zip file.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -68,7 +68,6 @@
   <property name="workbench.jar.file" value="${lib.dir}/workbench.jar"/>
   <property name="workbench.dist.name" value="workbench-${project.revision}"/>
   <property name="workbench.zip-dist.file" value="${workbench.dist.name}.zip"/>
-  <property name="workbench.tar-dist.file" value="${workbench.dist.name}.tar.gz"/>
   <property name="workbench.main.class" value="mondrian.gui.Workbench"/>
   <property name="resource.jar.file" value="${lib.dir}/eigenbase-resgen.jar"/>
   <property name="xom.jar.file" value="${lib.dir}/eigenbase-xom.jar"/>
@@ -1699,45 +1698,9 @@ xalan.jar"/>
       depends="version,workbench">
     <mkdir dir="${dist.dir}" />
     <delete file="${dist.dir}/${workbench.zip-dist.file}"/>
-    <zip zipfile="${dist.dir}/${workbench.zip-dist.file}">
-      <zipfileset
-          dir="."
-          prefix="${workbench.dist.name}"
-          includes="
-			${doc.dir}/**/*.pdf,
-			lib/mondrian.jar,
-			lib/workbench.jar,
-			lib/log4j.jar,
-			lib/x*.jar,
-			lib/eigenbase*.jar,
-			lib/commons*.jar,
-			lib/javacup.jar,
-			lib/jlfgr.jar,
-			lib/olap4j.jar,
-			lib/pentaho-application-launcher.jar,
-			lib/*.dtd,
-			lib/*.xsd,
-			demo/FoodMart.xml,
-			LICENSE.html"
-          excludes="
-			**/*~,
-			**/_vti*/*,
-			**/*.psp,
-			${doc.dir}/api/src-html/**/*"/>
-      <zipfileset
-          dir="workbench"
-          prefix="${workbench.dist.name}"
-          includes="**/*"
-          excludes="**/*-sources.jar"/>
-      <zipfileset
-          dir="src/main"
-          prefix="${workbench.dist.name}/src"
-          includes="mondrian/gui/**/*"/>
-    </zip>
-    <delete file="${dist.dir}/${workbench.tar-dist.file}"/>
-    <tar destfile="${dist.dir}/${workbench.tar-dist.file}" longfile="gnu" compression="gzip">
-        <tarfileset dir="." prefix="${workbench.dist.name}" mode="755" includes="*.sh"/>
-	    <tarfileset dir="."  prefix="${workbench.dist.name}" includes="
+    <zip destfile="${dist.dir}/${workbench.zip-dist.file}">
+        <zipfileset dir="." prefix="${workbench.dist.name}" filemode="755" includes="*.sh"/>
+	    <zipfileset dir="."  prefix="${workbench.dist.name}" includes="
 				${doc.dir}/**/*.pdf,
 				lib/mondrian.jar,
 				lib/workbench.jar,
@@ -1760,24 +1723,24 @@ xalan.jar"/>
 	    		**/*.sh,
 	    		**/JavaApplicationStub,
 				${doc.dir}/api/src-html/**/*"/>
-      	<tarfileset mode="755"
+      	<zipfileset filemode="755"
           dir="workbench"
           prefix="${workbench.dist.name}">
             <include name="**/*.sh" />
             <include name="**/JavaApplicationStub" />
-   		</tarfileset>      		
-      	<tarfileset
+   		</zipfileset>
+      	<zipfileset
           dir="workbench"
           prefix="${workbench.dist.name}">
       		<include name="**/*" />
             <exclude name="**/*.sh" />
             <exclude name="**/JavaApplicationStub" />
-   		</tarfileset>
-      	<tarfileset
+   		</zipfileset>
+      	<zipfileset
           dir="src/main"
           prefix="${workbench.dist.name}/src"
           includes="mondrian/gui/**/*"/>
-    </tar>
+    </zip>
   </target>
 
   <!--


### PR DESCRIPTION
Updated the build.xml to remove the generation of a .tar.gz for the workbench distribution and updated the .zip distribution to include the file permissions (executable for *_/_.sh and **/JavaApplicationStub)
