### PR TITLE
Fix for MONDRIAN-1123.  Added test suggested by Julian to Olap4jTest whi...

### DIFF
--- a/src/main/mondrian/olap/Property.java
+++ b/src/main/mondrian/olap/Property.java
@@ -292,7 +292,7 @@ public class Property extends EnumeratedValues.BasicValue {
      */
     public static final Property MEMBER_TYPE =
         new Property(
-            "MEMBER_TYPE", Datatype.TYPE_STRING, MEMBER_TYPE_ORDINAL, false,
+            "MEMBER_TYPE", Datatype.TYPE_NUMERIC, MEMBER_TYPE_ORDINAL, false,
             true, false,
             "Required. Type of the member. Can be one of the following values: "
             + "MDMEMBER_TYPE_REGULAR, MDMEMBER_TYPE_ALL, "

--- a/src/main/mondrian/olap4j/MondrianOlap4jCube.java
+++ b/src/main/mondrian/olap4j/MondrianOlap4jCube.java
@@ -126,8 +126,17 @@ class MondrianOlap4jCube
                     measuresLevel.level,
                     true);
             for (mondrian.olap.Member member : levelMembers) {
-                measures.add(
-                    (Measure) olap4jConnection.toOlap4j(member));
+                // This corrects MONDRIAN-1123, a ClassCastException (see below)
+                // that occurs when you create a calculated member on a
+                // dimension other than Measures:
+                // java.lang.ClassCastException:
+                // mondrian.olap4j.MondrianOlap4jMember cannot be cast to
+                // org.olap4j.metadata.Measure
+                MondrianOlap4jMember olap4jMember = olap4jConnection.toOlap4j(
+                    member);
+                if (olap4jMember instanceof Measure) {
+                    measures.add((Measure) olap4jMember);
+                }
             }
             return measures;
         } catch (OlapException e) {

--- a/testsrc/main/mondrian/test/Olap4jTest.java
+++ b/testsrc/main/mondrian/test/Olap4jTest.java
@@ -14,6 +14,7 @@ import mondrian.xmla.XmlaHandler;
 
 import org.olap4j.*;
 import org.olap4j.Cell;
+import org.olap4j.Position; 
 import org.olap4j.mdx.IdentifierNode;
 import org.olap4j.mdx.SelectNode;
 import org.olap4j.mdx.parser.*;
@@ -522,6 +523,62 @@ public class Olap4jTest extends FoodMartTestCase {
             finished.set(true);
         }
     }
+
+    /**
+     * Test case for bug <a href="http://jira.pentaho.com/browse/MONDRIAN-1123">
+     * MONDRIAN-1123, "ClassCastException for calculated members that are not
+     * part of the measures dimension"</a>.
+     *
+     * @throws java.sql.SQLException on error
+     */
+    public void testCalcMemberInCube() throws SQLException {
+        final OlapConnection testContext =
+            TestContext.instance().createSubstitutingCube(
+                "Sales",
+                null,
+                "<CalculatedMember name='H1 1997' formula='Aggregate([Time].[1997].[Q1]:[Time].[1997].[Q2])' dimension='Time' />")
+            .getOlap4jConnection();
+        final Cube cube = testContext.getOlapSchema().getCubes().get("Sales");
+        final List<Measure> measureList = cube.getMeasures();
+        StringBuilder buf = new StringBuilder();
+        for (Measure measure : measureList) {
+            buf.append(measure.getName()).append(";");
+        }
+        // Calc member in the Time dimension does not appear in the list.
+        // Never did, as far as I can tell.
+        assertEquals(
+            "Unit Sales;Store Cost;Store Sales;Sales Count;Customer Count;"
+            + "Promotion Sales;Profit;Profit last Period;Profit Growth;",
+            buf.toString());
+
+        final CellSet cellSet = testContext.createStatement().executeOlapQuery(
+            "select AddCalculatedMembers([Time].[Time].Members) on 0 from [Sales]");
+        int n = 0, n2 = 0;
+        for (Position position : cellSet.getAxes().get(0).getPositions()) {
+            if (position.getMembers().get(0).getName().equals("H1 1997")) {
+                ++n;
+            }
+            ++n2;
+        }
+        assertEquals(1, n);
+        assertEquals(35, n2);
+
+        final CellSet cellSet2 = testContext.createStatement().executeOlapQuery(
+            "select Filter(\n"
+            + " AddCalculatedMembers([Time].[Time].Members),\n"
+            + " [Time].[Time].CurrentMember.Properties('MEMBER_TYPE') = 4) on 0\n"
+            + "from [Sales]");
+        n = 0;
+        n2 = 0;
+        for (Position position : cellSet2.getAxes().get(0).getPositions()) {
+            if (position.getMembers().get(0).getName().equals("H1 1997")) {
+                ++n;
+            }
+            ++n2;
+        }
+        assertEquals(1, n);
+        assertEquals(1, n2);
+    } 
 }
 
 // End Olap4jTest.java


### PR DESCRIPTION
Fix for MONDRIAN-1123.  Added test suggested by Julian to Olap4jTest which
replicated the error in the 3.5 branch.  The real problem seems to be the
schema reader including these members, but I wanted my change to be very
low risk.  The change simply avoids the ClassCastException by testing the
member via instanceof before the cast.  It's unclear if any other bugs
exist due to the underlying issue with the SchemaReader, but apparently
this bug is fixed in the 4.0 branch anyways, so it might be irrelevant.
