### PR TITLE
[MONDRIAN-1226] Set on slicer axis with different behavior than aggregat...

### DIFF
--- a/src/main/mondrian/rolap/RolapResult.java
+++ b/src/main/mondrian/rolap/RolapResult.java
@@ -388,14 +388,16 @@ public class RolapResult extends ResultBase {
                                 return pos0.size();
                             }
                         };
-                    evaluator.addCalculation(
-                        new RolapTupleCalculation(hierarchyList, calc), true);
 
                     // replace the slicer set with a placeholder to avoid
                     // interaction between the aggregate calc we just created
                     // and any calculated members that might be present in
                     // the slicer.
-                    setPlaceholderSlicerAxis(hierarchyList.get(0));
+                    // Arbitrarily picks the first dim of the first tuple
+                    // to use as placeholder.
+                    Member placeholder = setPlaceholderSlicerAxis(
+                        (RolapMember)tupleList.get(0).get(0), calc);
+                    evaluator.setContext(placeholder);
                 }
             } while (phase());
 
@@ -510,18 +512,41 @@ public class RolapResult extends ResultBase {
     }
 
     /**
-     * Sets slicerAxis to contain a dummy placeholder RolapAxis containing
+     * Sets slicerAxis to a dummy placeholder RolapAxis containing
      * a single item TupleList with the null member of hierarchy.
      * This is used with compound slicer evaluation to avoid the slicer
      * tuple list from interacting with the aggregate calc which rolls up
-     * the set.
-     * @param hierarchy the hierarchy to use for the placeholder slicer
+     * the set.  This member will contain the AggregateCalc which rolls
+     * up the set on the slicer.
      */
-    private void setPlaceholderSlicerAxis(RolapHierarchy hierarchy) {
-        Member nullMember = hierarchy.getNullMember();
+    private Member setPlaceholderSlicerAxis(
+        final RolapMember member, final Calc calc)
+    {
+        ValueFormatter formatter;
+        if (member.getDimension().isMeasures()) {
+            formatter = ((RolapMeasure)member).getFormatter();
+        } else {
+            formatter = null;
+        }
+
+        CompoundSlicerRolapMember placeholderMember =
+            new CompoundSlicerRolapMember(
+                (RolapMember)member.getHierarchy().getNullMember(),
+                calc, formatter);
+
+
+        placeholderMember.setProperty(
+            Property.FORMAT_STRING.getName(),
+            member.getPropertyValue(Property.FORMAT_STRING.getName()));
+        placeholderMember.setProperty(
+            Property.FORMAT_EXP_PARSED.getName(),
+            member.getPropertyValue(Property.FORMAT_EXP_PARSED.getName()));
+
         TupleList dummyList = TupleCollections.createList(1);
-        dummyList.addTuple(nullMember);
+        dummyList.addTuple(placeholderMember);
+
         this.slicerAxis = new RolapAxis(dummyList);
+        return placeholderMember;
     }
 
     private boolean phase() {
@@ -1964,6 +1989,51 @@ public class RolapResult extends ResultBase {
         return list;
     }
 
+    /**
+     * Member which holds the AggregateCalc used when evaluating
+     * a compound slicer.  This is used to better handle some cases
+     * where calculated members elsewhere in the query can override
+     * the context of the slicer members.
+     * See MONDRIAN-1226.
+     */
+    private class CompoundSlicerRolapMember extends DelegatingRolapMember
+    implements RolapMeasure
+    {
+        private final Calc calc;
+        private final ValueFormatter valueFormatter;
+
+        public CompoundSlicerRolapMember(
+            RolapMember placeholderMember, Calc calc, ValueFormatter formatter)
+        {
+            super(placeholderMember);
+            this.calc = calc;
+            valueFormatter = formatter;
+        }
+
+        @Override
+        public boolean isEvaluated() {
+            return true;
+        }
+
+        @Override
+        public Exp getExpression() {
+            return new DummyExp(calc.getType());
+        }
+
+        @Override
+        public Calc getCompiledExpression(RolapEvaluatorRoot root) {
+            return calc;
+        }
+
+        @Override
+        public int getSolveOrder() {
+            return 0;
+        }
+
+        public ValueFormatter getFormatter() {
+            return valueFormatter;
+        }
+    }
 }
 
 // End RolapResult.java

--- a/testsrc/main/mondrian/test/CompoundSlicerTest.java
+++ b/testsrc/main/mondrian/test/CompoundSlicerTest.java
@@ -199,6 +199,97 @@ public class CompoundSlicerTest extends FoodMartTestCase {
             + "Row #2: 4,051\n"
             + "Row #2: 131,164\n");
     }
+    public void testCompoundSlicerWithCellFormatter() {
+        String xmlMeasure =
+            "<Measure name='Unit Sales Foo Bar' column='unit_sales'\n"
+            + "    aggregator='sum' formatString='Standard' formatter='"
+            + UdfTest.FooBarCellFormatter.class.getName()
+            + "'/>";
+        TestContext tc =
+            TestContext.instance().legacy().createSubstitutingCube(
+                "Sales", null, xmlMeasure, null, null);
+
+        // the cell formatter for the measure should still be used
+        tc.assertQueryReturns(
+            "select from sales where "
+            + " measures.[Unit Sales Foo Bar] * {[Gender].F, [Gender].M} ",
+            "Axis #0:\n"
+            + "{[Measures].[Unit Sales Foo Bar], [Gender].[Gender].[F]}\n"
+            + "{[Measures].[Unit Sales Foo Bar], [Gender].[Gender].[M]}\n"
+            + "foo266773.0bar");
+
+        tc.assertQueryReturns(
+            "select from sales where "
+            + " {[Gender].F, [Gender].M}  * measures.[Unit Sales Foo Bar]",
+            "Axis #0:\n"
+            + "{[Gender].[Gender].[F], [Measures].[Unit Sales Foo Bar]}\n"
+            + "{[Gender].[Gender].[M], [Measures].[Unit Sales Foo Bar]}\n"
+            + "foo266773.0bar");
+    }
+
+
+    public void testMondrian1226() {
+        assertQueryReturns(
+            "with \n"
+            +    "member Measures.x1 as ([Time].[1997].[Q1],"
+            + "[Measures].[Store Sales])\n"
+            +    "member Measures.x2 as ([Time].[1997].[Q2],"
+            + " [Measures].[Store Sales])\n"
+            +    "set products as TopCount("
+            + "Product.[Product Name].Members,1,Measures.[Store Sales])\n"
+            +    "SELECT\n"
+            +    "NON EMPTY products ON 1,\n"
+            +    "NON EMPTY {[Measures].[Store Sales], "
+            + "Measures.x1, Measures.x2} ON 0\n"
+            +    "FROM [Sales]\n"
+            +    "where ([Time].[1997].[Q1] : [Time].[1997].[Q2])",
+            "Axis #0:\n"
+            + "{[Time].[Time].[1997].[Q1]}\n"
+            + "{[Time].[Time].[1997].[Q2]}\n"
+            + "Axis #1:\n"
+            + "{[Measures].[Store Sales]}\n"
+            + "{[Measures].[x1]}\n"
+            + "{[Measures].[x2]}\n"
+            + "Axis #2:\n"
+            + "{[Product].[Products].[Food].[Eggs].[Eggs].[Eggs]"
+            + ".[Urban].[Urban Small Eggs]}\n"
+            + "Row #0: 497.42\n"
+            + "Row #0: 235.62\n"
+            + "Row #0: 261.80\n");
+    }
+
+     public void _testMondrian1226Variation() {
+         // Currently broke.  Below are two queries with two dimensions
+         // in the compound slicer.
+         //  The first has a measure which overrides the Time context,
+         // and gives expected results (since the Time dimension is
+         // the "placeholder" dimension.
+         assertQueryReturns(
+             "with member measures.HalfTime as '[Time].[1997].[Q1]/2'"
+             + " select measures.HalfTime on 0 from sales where "
+             + "({[Time].[1997].[Q1] : [Time].[1997].[Q2]} * gender.[All Gender]) ",
+             "Axis #0:\n"
+             + "{[Time].[Time].[1997].[Q1], [Customer].[Gender].[All Gender]}\n"
+             + "{[Time].[Time].[1997].[Q2], [Customer].[Gender].[All Gender]}\n"
+             + "Axis #1:\n"
+             + "{[Measures].[HalfTime]}\n"
+             + "Row #0: 33,146\n");
+
+         // The second query has a measure overriding gender, which
+         // fails since context is not set appropriately for gender.
+         assertQueryReturns(
+             "with member measures.HalfMan as 'Gender.m/2'"
+             +    " select measures.HalfMan on 0 from sales where "
+             +    "({[Time].[1997].[Q1] : [Time].[1997].[Q2]} "
+             + "* gender.[All Gender]) ",
+             "Axis #0:\n"
+             + "{[Time].[Time].[1997].[Q1], [Customer].[Gender].[M]}\n"
+             + "{[Time].[Time].[1997].[Q2], [Customer].[Gender].[M]}\n"
+             + "Axis #1:\n"
+             + "{[Measures].[HalfMan]}\n"
+             + "Row #0: 32,500\n");
+     }
+
 
     /**
      * Tests a query with a compond slicer over tuples. (Multiple rows, each


### PR DESCRIPTION
...ed member of same set in the slicer. Modified so that the calculated members which override context are treated correctly in the scenario in the defect: if the overriden member is from the first hierarchy found in the compound slicer's tuple list. If there is more than one hierarchy in the slicer there is still the possibility that calc members which override context won't be handled correctly. See _test1226Variation for an example.  Merged from 56b4ec.
