### PR TITLE
 [MONDRIAN-1587] Drillthrough SQL is invalid on hsqldb.

### DIFF
--- a/src/main/mondrian/rolap/RolapCell.java
+++ b/src/main/mondrian/rolap/RolapCell.java
@@ -179,6 +179,7 @@ public class RolapCell implements Cell {
                     "Error while counting drill-through"));
         try {
             ResultSet rs = stmt.getResultSet();
+            assert rs.getMetaData().getColumnCount() == 1;
             rs.next();
             ++stmt.rowCount;
             return rs.getInt(1);

--- a/src/main/mondrian/rolap/agg/AndPredicate.java
+++ b/src/main/mondrian/rolap/agg/AndPredicate.java
@@ -4,7 +4,7 @@
 // http://www.eclipse.org/legal/epl-v10.html.
 // You must accept the terms of that agreement to use this software.
 //
-// Copyright (C) 2007-2011 Pentaho
+// Copyright (C) 2007-2013 Pentaho
 // All Rights Reserved.
 */
 package mondrian.rolap.agg;
@@ -132,7 +132,7 @@ public class AndPredicate extends ListPredicate {
         return inListRHSBitKey;
     }
 
-    /*
+    /**
      * Generate value list for this predicate to be used in an IN-list
      * sql predicate.
      *
@@ -146,16 +146,17 @@ public class AndPredicate extends ListPredicate {
         BitKey inListRHSBitKey)
     {
         boolean firstValue = true;
-        buf.append("(");
-        /*
-         * Arranging children according to the bit position. This is required
-         * as RHS of IN list needs to list the column values in the same order.
-         */
+        final boolean multiValueInList = children.size() > 1;
+        if (multiValueInList) {
+            buf.append("(");
+        }
+         // Arranging children according to the bit position. This is required
+         // as RHS of IN list needs to list the column values in the same order.
         Set<ValueColumnPredicate> sortedPredicates =
             new TreeSet<ValueColumnPredicate>();
 
         for (StarPredicate predicate : children) {
-            // inListPossible() checks gaurantees that predicate is of type
+            // inListPossible() checks guarantees that predicate is of type
             // ValueColumnPredicate
             assert predicate instanceof ValueColumnPredicate;
             if (inListRHSBitKey.get(
@@ -176,7 +177,9 @@ public class AndPredicate extends ListPredicate {
                 buf, predicate.getValue(),
                 predicate.getConstrainedColumn().getDatatype());
         }
-        buf.append(")");
+        if (multiValueInList) {
+            buf.append(")");
+        }
     }
 
     protected String getOp() {

--- a/testsrc/main/mondrian/test/DrillThroughTest.java
+++ b/testsrc/main/mondrian/test/DrillThroughTest.java
@@ -13,12 +13,12 @@
 package mondrian.test;
 
 import mondrian.olap.*;
-import mondrian.resource.MondrianResource;
 import mondrian.rolap.*;
 import mondrian.spi.Dialect;
 
 import java.sql.*;
 import javax.sql.DataSource;
+
 
 /**
  * Test generation of SQL to access the fact table data underlying an MDX
@@ -184,6 +184,41 @@ public class DrillThroughTest extends FoodMartTestCase {
             + "where [Product].[My Food Drink]");
         cell = result.getCell(new int[] {0, 0});
         assertFalse(cell.canDrillThrough());
+    }
+
+    public void testDrillthroughCompoundSlicer() {
+        // Tests a case associated with
+        // http://jira.pentaho.com/browse/MONDRIAN-1587
+        // hsqldb was failing with SQL that included redundant parentheses
+        // around IN list items.
+
+        propSaver.set(propSaver.properties.GenerateFormattedSql, true);
+        Result result = executeQuery(
+            "select from sales where "
+            + "{[Promotion Media].[Bulk Mail],[Promotion Media].[Cash Register Handout]}");
+        final Cell cell = result.getCell(new int[]{});
+        assertTrue(cell.canDrillThrough());
+        assertEquals(3584, cell.getDrillThroughCount());
+        getTestContext().assertSqlEquals(
+            "select\n"
+            + "    time_by_day.the_year as Year,\n"
+            + "    sales_fact_1997.unit_sales as Unit Sales\n"
+            + "from\n"
+            + "    time_by_day =as= time_by_day,\n"
+            + "    sales_fact_1997 =as= sales_fact_1997,\n"
+            + "    promotion =as= promotion\n"
+            + "where\n"
+            + "    sales_fact_1997.time_id = time_by_day.time_id\n"
+            + "and\n"
+            + "    time_by_day.the_year = 1997\n"
+            + "and\n"
+            + "    sales_fact_1997.promotion_id = promotion.promotion_id\n"
+            + "and\n"
+            + "    ((promotion.media_type in "
+            + "('Bulk Mail', 'Cash Register Handout')))\n"
+            + "order by\n"
+            + "    time_by_day.the_year ASC",
+            cell.getDrillThroughSQL(false), 3584);
     }
 
     public void testDrillThrough() {


### PR DESCRIPTION
SQL formerly included redundant parentheses in cases where drillthrough was gener
    Validated changes against postgres, greenplum, mysql, oracle, sqlserver and hsqld
    (cherry picked from commit e411d5b)
    Excludes overlapping changes for MONDRIAN-1226 from master.
