### PR TITLE
 [MONDRIAN-1587] Drillthrough SQL is invalid on hsqldb. SQL formerly inc...

### DIFF
--- a/src/main/mondrian/rolap/RolapCell.java
+++ b/src/main/mondrian/rolap/RolapCell.java
@@ -174,6 +174,7 @@ public class RolapCell implements Cell {
                     "Error while counting drill-through"));
         try {
             ResultSet rs = stmt.getResultSet();
+            assert rs.getMetaData().getColumnCount() == 1;
             rs.next();
             ++stmt.rowCount;
             return rs.getInt(1);

--- a/src/main/mondrian/rolap/agg/AndPredicate.java
+++ b/src/main/mondrian/rolap/agg/AndPredicate.java
@@ -4,7 +4,7 @@
 // http://www.eclipse.org/legal/epl-v10.html.
 // You must accept the terms of that agreement to use this software.
 //
-// Copyright (C) 2007-2012 Pentaho
+// Copyright (C) 2007-2013 Pentaho
 // All Rights Reserved.
 */
 package mondrian.rolap.agg;
@@ -154,8 +154,10 @@ public class AndPredicate extends ListPredicate {
         StringBuilder buf,
         BitKey inListRhsBitKey)
     {
-        buf.append("(");
-
+        final boolean multiValueInList = children.size() > 1;
+        if (multiValueInList) {
+            buf.append("(");
+        }
         // Arranging children according to the bit position. This is required
         // as RHS of IN list needs to list the column values in the same order.
         Set<ValueColumnPredicate> sortedPredicates =
@@ -183,7 +185,9 @@ public class AndPredicate extends ListPredicate {
                 predicate.getValue(),
                 predicate.getColumn().physColumn.getDatatype());
         }
-        buf.append(")");
+        if (multiValueInList) {
+            buf.append(")");
+        }
     }
 
     protected String getOp() {

--- a/testsrc/main/mondrian/test/DrillThroughTest.ref.xml
+++ b/testsrc/main/mondrian/test/DrillThroughTest.ref.xml
@@ -78,6 +78,27 @@ group by
     `product`.`product_name`]]>
         </Resource>
     </TestCase>
+    <TestCase name="testDrillthroughCompoundSlicer">
+        <Resource name="sql">
+            <![CDATA[select
+    `time_by_day`.`the_year` as `Year`,
+    sum(`sales_fact_1997`.`unit_sales`) as `Unit Sales`
+from
+    `time_by_day` as `time_by_day`,
+    `sales_fact_1997` as `sales_fact_1997`,
+    `promotion` as `promotion`
+where
+    `sales_fact_1997`.`time_id` = `time_by_day`.`time_id`
+and
+    `time_by_day`.`the_year` = 1997
+and
+    `sales_fact_1997`.`promotion_id` = `promotion`.`promotion_id`
+and
+    ((`promotion`.`media_type` in ('Bulk Mail', 'Cash Register Handout')))
+group by
+    `time_by_day`.`the_year`]]>
+        </Resource>
+    </TestCase>
     <TestCase name="testDrillThrough">
         <Resource name="sql">
             <![CDATA[select


### PR DESCRIPTION
...luded redundant parentheses in cases where drillthrough was generating a single field IN list, for example "field" IN ( ('item1'), ('item2' ).

Merged from e411d5b
