### PR TITLE
[MONDRIAN-1471]  Switched RolapSchemaReader.getMemberReader() from being...

### DIFF
--- a/src/main/mondrian/rolap/RolapSchemaReader.java
+++ b/src/main/mondrian/rolap/RolapSchemaReader.java
@@ -79,6 +79,18 @@ public class RolapSchemaReader
         return getLevelMembers(firstLevel, true);
     }
 
+    /**
+     * This method uses a double-checked locking idiom to avoid making the
+     * method fully synchronized, or potentially creating the same MemberReader
+     * more than once.  Double-checked locking can cause issues if
+     * a second thread accesses the field without either a shared lock in
+     * place or the field being specified as volatile.
+     * In this case, hierarchyReaders is a ConcurrentHashMap,
+     * which internally uses volatile load semantics for read operations.
+     * This assures values written by one thread will be visible when read by
+     * others.
+     * http://en.wikipedia.org/wiki/Double-checked_locking
+     */
     public MemberReader getMemberReader(Hierarchy hierarchy) {
         MemberReader memberReader = hierarchyReaders.get(hierarchy);
         if (memberReader == null) {


### PR DESCRIPTION
... synchronized at the method level to using a double-checked lock instead.  getMemberReader() is called frequently inside of nested loops;
this approach should reduce some amount of thread contention.
