### PR TITLE
PSW-167 - Added esapi.jar to the workbench distribution as kettle requires it now.

### DIFF
--- a/workbench/ivy.xml
+++ b/workbench/ivy.xml
@@ -45,6 +45,7 @@
           <exclude org="hsqldb" module="hsqldb"/>
         </dependency>
 
+	<dependency org="org.owasp.esapi" name="esapi" rev="2.0.1" transitive="false"/>
         <dependency org="xerces" name="xercesImpl" rev="2.9.1"/>
 
         <!--  internal runtime dependencies -->


### PR DESCRIPTION
Added esapi.jar to the workbench distribution as kettle requires it as a dependency. Without this, we can not re-open an existing model.
