### PR TITLE
MONDRIAN-1653 - Internal Statements never closed / removed from mondrianServer

### DIFF
--- a/src/main/mondrian/rolap/RolapConnection.java
+++ b/src/main/mondrian/rolap/RolapConnection.java
@@ -171,6 +171,9 @@ public class RolapConnection extends ConnectionBase {
                 }
             } finally {
                 Locus.pop(locus);
+                if (locus.execution.getMondrianStatement() != null) {
+                    locus.execution.getMondrianStatement().close();
+                }
                 bootstrapStatement.close();
             }
             internalStatement =
@@ -774,8 +777,8 @@ public class RolapConnection extends ConnectionBase {
             return queryPart;
         } finally {
             Locus.pop(locus);
-            if (statement != null) {
-                statement.close();
+            if (locus.execution.getMondrianStatement() != null) {
+                locus.execution.getMondrianStatement().close();
             }
         }
     }


### PR DESCRIPTION
When we currently try and close the InternalStatements the Locus fails to set the context correctly and therefore at both places its null and fails to close the statement properly

I checked the mondrianServer.statementMap at various places of my executions and now it seems to be "clean" - no leftovers in there
