### PR TITLE
[MONDRIAN-1568] Fixing failure due to infinite loop while determining aggregate star

### DIFF
--- a/src/main/mondrian/rolap/RolapUtil.java
+++ b/src/main/mondrian/rolap/RolapUtil.java
@@ -691,39 +691,52 @@ public class RolapUtil {
         // so that we can pick the correct agg table.
         for (Member curMember : members) {
             if (curMember instanceof LimitedRollupMember) {
-                List<Member> lowestMembers =
-                    ((RolapHierarchy)curMember.getHierarchy())
-                        .getLowestMembersForAccess(
-                            evaluator,
-                            ((LimitedRollupMember)curMember).hierarchyAccess,
-                            FunUtil.getNonEmptyMemberChildrenWithDetails(
+                final int savepoint = evaluator.savepoint();
+                try {
+                    // set NonEmpty to false to avoid the possibility of
+                    // constraining member retrieval by context, which itself
+                    // requires determination of limited members, resulting
+                    // in infinite loop.
+                    evaluator.setNonEmpty(false);
+                    List<Member> lowestMembers =
+                        ((RolapHierarchy)curMember.getHierarchy())
+                            .getLowestMembersForAccess(
                                 evaluator,
-                                curMember));
+                                ((LimitedRollupMember)curMember)
+                                    .hierarchyAccess,
+                                FunUtil.getNonEmptyMemberChildrenWithDetails(
+                                    evaluator,
+                                    curMember));
 
-                assert lowestMembers.size() > 0;
+                    assert lowestMembers.size() > 0;
 
-                Member lowMember = lowestMembers.get(0);
+                    Member lowMember = lowestMembers.get(0);
 
-                while (true) {
-                    RolapStar.Column curColumn =
-                        ((RolapCubeLevel)lowMember.getLevel())
-                            .getBaseStarKeyColumn(cube);
+                    while (true) {
+                        RolapStar.Column curColumn =
+                            ((RolapCubeLevel)lowMember.getLevel())
+                                .getBaseStarKeyColumn(cube);
 
-                    if (curColumn != null) {
-                        levelBitKey.set(curColumn.getBitPosition());
-                    }
+                        if (curColumn != null) {
+                            levelBitKey.set(curColumn.getBitPosition());
+                        }
 
-                    // If the level doesn't have unique members, we have to
-                    // add the parent levels until the keys are unique,
-                    // or all of them are added.
-                    if (!((RolapCubeLevel)lowMember.getLevel()).isUnique()) {
-                        lowMember = lowMember.getParentMember();
-                        if (lowMember.isAll()) {
+                        // If the level doesn't have unique members, we have to
+                        // add the parent levels until the keys are unique,
+                        // or all of them are added.
+                        if (!((RolapCubeLevel)lowMember
+                            .getLevel()).isUnique())
+                        {
+                            lowMember = lowMember.getParentMember();
+                            if (lowMember.isAll()) {
+                                break;
+                            }
+                        } else {
                             break;
                         }
-                    } else {
-                        break;
                     }
+                } finally {
+                    evaluator.restore(savepoint);
                 }
             }
         }


### PR DESCRIPTION
Looking up the agg star when role-limited members are in context requires finding the set of accessible members in order to set the complete bitkey.  Determining those members when using a context constraint requires looking up the agg star.  

To side-step the issue, set NonEmpty to false when looking for accessible members while setting
the constraintBitKey, which avoids use of a context constraint.
