### PR TITLE
[MONDRIAN-1568] Role restrictions using native cj/topcount/filter are not applied consistently.

### DIFF
--- a/src/main/mondrian/rolap/RolapNativeCrossJoin.java
+++ b/src/main/mondrian/rolap/RolapNativeCrossJoin.java
@@ -214,22 +214,7 @@ public class RolapNativeCrossJoin extends RolapNativeSet {
         final int savepoint = evaluator.savepoint();
 
         try {
-            Member[] evalMembers = evaluator.getMembers().clone();
-            for (RolapLevel level : levels) {
-                RolapHierarchy hierarchy = level.getHierarchy();
-                memberLoop:
-                for (int i = 0; i < evalMembers.length; ++i) {
-                    Dimension evalMemberDimension =
-                        evalMembers[i].getHierarchy().getDimension();
-                    if (evalMemberDimension == hierarchy.getDimension()
-                        && !evalMembers[i].isAll())
-                    {
-                        evalMembers[i] = hierarchy.getAllMember();
-                        break memberLoop;
-                    }
-                }
-            }
-            evaluator.setContext(evalMembers);
+            overrideContext(evaluator, cjArgs, null);
 
             // Use the combined CrossJoinArg for the tuple constraint,
             // which will be translated to the SQL WHERE clause.

--- a/src/main/mondrian/rolap/RolapNativeSet.java
+++ b/src/main/mondrian/rolap/RolapNativeSet.java
@@ -359,10 +359,28 @@ public abstract class RolapNativeSet extends RolapNative {
         for (CrossJoinArg carg : cargs) {
             RolapLevel level = carg.getLevel();
             if (level != null) {
-                Hierarchy hierarchy = level.getHierarchy();
-                Member defaultMember =
-                    schemaReader.getHierarchyDefaultMember(hierarchy);
-                evaluator.setContext(defaultMember);
+                RolapHierarchy hierarchy = level.getHierarchy();
+
+                final Member contextMember;
+                if (hierarchy.hasAll()
+                    || schemaReader.getRole()
+                    .getAccess(hierarchy) == Access.ALL)
+                {
+                    // The hierarchy may have access restrictions.
+                    // If it does, calling .substitute() will retrieve an
+                    // appropriate LimitedRollupMember.
+                    contextMember =
+                        schemaReader.substitute(hierarchy.getAllMember());
+                } else {
+                    // If there is no All member on a role restricted hierarchy,
+                    // use a restricted member based on the set of accessible
+                    // root members.
+                    contextMember = new RestrictedMemberReader
+                        .MultiCardinalityDefaultMember(
+                            hierarchy.getMemberReader()
+                                .getRootMembers().get(0));
+                }
+                evaluator.setContext(contextMember);
             }
         }
         if (storedMeasure != null) {

--- a/testsrc/main/mondrian/test/TestContext.java
+++ b/testsrc/main/mondrian/test/TestContext.java
@@ -1042,6 +1042,24 @@ public class TestContext {
     }
 
     /**
+     * Executes a query and checks that the result is a given string,
+     * displaying a message if result does not match desiredResult.
+     */
+    public void assertQueryReturns(
+        String message, String query, String desiredResult)
+    {
+        Result result = executeQuery(query);
+        String resultString = toString(result);
+        if (desiredResult != null) {
+            assertEqualsVerbose(
+                desiredResult,
+                upgradeActual(resultString),
+                true, message);
+        }
+    }
+
+
+    /**
      * Executes a very simple query.
      *
      * <p>This forces the schema to be loaded and performs a basic sanity check.


### PR DESCRIPTION
There were 2 issues causing either too much or too little data to be returned in some scenarios:
1)  In cases where a hierarchy has custom access with rollupPolicy!=FULL, native topcount and native filter would attempt to set the context to a role limited member so that a restricted constraint would be in place when
loading tuples (see calls to RolapNativeSet.overrideContext).  Unlike native topcount/filter, native cj was never setting a restricted member into context, so if a CJ was handled natively it was possible to access members
that should be hidden.

2)  RolapNativeSet.overrideContext() was setting the default member of each hierarchy into the context, retrieved from the schema reader.  The default member is usually [all], so in most cases where role restrictions
on a hierarchy are in place this would return a restricted member that would correctly limit the context.  The default member may not be [all], though, and may not have a restriction on it even if other members of the
 hierarchy do.  This could cause the wrong constraint to be used when retrieving native topcount/filter results.  For example, a default member of [Store].[USA].[CA] would cause [CA] to be in the constraint used
 by SqlTupleReader.
(cherry picked from commit 98e60d8)
