### PR TITLE
[BISERVER-9545]  JPivot plugin support.  Corrected a Mondrian issue expo...

### DIFF
--- a/src/main/mondrian/rolap/RolapConnection.java
+++ b/src/main/mondrian/rolap/RolapConnection.java
@@ -562,7 +562,7 @@ public class RolapConnection extends ConnectionBase {
     }
 
     public SchemaReader getSchemaReader() {
-        return schemaReader;
+        return schemaReader.withLocus();
     }
 
     public Object getProperty(String name) {


### PR DESCRIPTION
...sed when testing the JPivot plugin against a role restricted cube.  Usage of Connection.getSchemaReader() would not set locus, causing downstream errors

where a locus is expected.
