### PR TITLE
[Mondrian-1592] read version file closest to classloader

### DIFF
--- a/src/main/mondrian/olap/Util.java
+++ b/src/main/mondrian/olap/Util.java
@@ -3987,6 +3987,37 @@ public class Util extends XOMUtil {
         };
     }
 
+    /**
+     * Similar to {@link ClassLoader#getResource(String)}, except the lookup
+     *  is in reverse order.<br>
+     *  i.e. returns the resource from the supplied classLoader or the
+     *  one closest to it in the hierarchy, instead of the closest to the root
+     *  class loader
+     * @param classLoader The class loader to fetch from
+     * @param name The resource name
+     * @return A URL object for reading the resource, or null if the resource
+     * could not be found or the invoker doesn't have adequate privileges to get
+     * the resource.
+     * @see ClassLoader#getResource(String)
+     * @see ClassLoader#getResources(String)
+     */
+    public static URL getClosestResource(ClassLoader classLoader, String name) {
+        URL resource = null;
+        try {
+            // The last resource will be from the nearest ClassLoader.
+            Enumeration<URL> resourceCandidates =
+                classLoader.getResources(name);
+            while (resourceCandidates.hasMoreElements()) {
+                resource = resourceCandidates.nextElement();
+            }
+        } catch (IOException ioe) {
+            // ignore exception - it's OK if file is not found
+            // just keep getResource contract and return null
+            Util.discard(ioe);
+        }
+        return resource;
+    }
+
     public static abstract class AbstractFlatList<T>
         implements List<T>, RandomAccess
     {

--- a/src/main/mondrian/server/MondrianServerRegistry.java
+++ b/src/main/mondrian/server/MondrianServerRegistry.java
@@ -124,8 +124,9 @@ public class MondrianServerRegistry {
         String title = "Unknown Database";
         String vendor = "Unknown Vendor";
         URL resource =
-            MondrianServerImpl.class.getClassLoader()
-                .getResource("DefaultRules.xml");
+            Util.getClosestResource(
+                MondrianServerImpl.class.getClassLoader(),
+                "DefaultRules.xml");
         if (resource != null) {
             try {
                 String path = resource.getPath();


### PR DESCRIPTION
fixes issue with schema validation when using mondrian4 and mondrian3 on
same classloader hierarchy
