### PR TITLE
Moved Util.maskVersion() to the XmlaBaseTestCase, since it's a test util...

### DIFF
--- a/src/main/mondrian/olap/Util.java
+++ b/src/main/mondrian/olap/Util.java
@@ -1406,20 +1406,6 @@ public class Util extends XOMUtil {
     }
 
     /**
-     * Masks Mondrian's version number from a string.
-     *
-     * @param str String
-     * @return String with each occurrence of mondrian's version number
-     *    (e.g. "2.3.0.0") replaced with "${mondrianVersion}"
-     */
-    public static String maskVersion(String str) {
-        MondrianServer.MondrianVersion mondrianVersion =
-            MondrianServer.forId(null).getVersion();
-        String versionString = mondrianVersion.getVersionString();
-        return replace(str, versionString, "${mondrianVersion}");
-    }
-
-    /**
      * Converts a list of SQL-style patterns into a Java regular expression.
      *
      * <p>For example, {"Foo_", "Bar%BAZ"} becomes "Foo.|Bar.*BAZ".

--- a/testsrc/main/mondrian/xmla/XmlaBaseTestCase.java
+++ b/testsrc/main/mondrian/xmla/XmlaBaseTestCase.java
@@ -144,7 +144,7 @@ System.out.println("requestText=" + requestText);
         Document gotDoc = XmlUtil.parse(bytes);
         gotDoc = replaceLastSchemaUpdateDate(gotDoc);
         String gotStr = XmlUtil.toString(gotDoc, true);
-        gotStr = Util.maskVersion(gotStr);
+        gotStr = maskVersion(gotStr);
         gotStr = testContext.upgradeActual(gotStr);
         if (expectedDoc == null) {
             if (replace) {
@@ -686,7 +686,7 @@ System.out.println("Got CONTINUE");
 
         String gotStr = new String(bytes);
         gotStr = ignoreLastUpdateDate(gotStr);
-        gotStr = Util.maskVersion(gotStr);
+        gotStr = maskVersion(gotStr);
         gotStr = testContext.upgradeActual(gotStr);
         if (expectedStr != null) {
             // Let DiffRepository do the comparison. It will output
@@ -801,6 +801,29 @@ System.out.println("Got CONTINUE");
             throws Exception
         {
         }
+    }
+
+    /**
+     * Masks Mondrian's version number from a string.
+     * Note that this method does a mostly blind replacement
+     * of the version string and may replace strings that
+     * just happen to have the same sequence.
+     *
+     * @param str String
+     * @return String with each occurrence of mondrian's version number
+     *    (e.g. "2.3.0.0") replaced with "${mondrianVersion}"
+     */
+    public static String maskVersion(String str) {
+        MondrianServer.MondrianVersion mondrianVersion =
+            MondrianServer.forId(null).getVersion();
+        String versionString = mondrianVersion.getVersionString();
+        // regex characters that wouldn't be expected before or after the
+        // version string.  This avoids a false match when the version
+        // string digits appear in other contexts (e.g. $3.56)
+        String charsOutOfContext = "([^,\\$\\d])";
+        String matchString = charsOutOfContext + versionString
+            + charsOutOfContext;
+        return str.replaceAll(matchString, "$1\\${mondrianVersion}$2");
     }
 }
 


### PR DESCRIPTION
...ity and shouldn't be outside of testsrc.  Also switched to using a regex replace to avoid some possible false matches (when the version string appears in other contexts).

(cherry picked from commit 38f5d67)
