### PR TITLE
Moved Util.maskVersion() to the XmlaBaseTestCase, since it's a test util...

### DIFF
--- a/src/main/mondrian/olap/Util.java
+++ b/src/main/mondrian/olap/Util.java
@@ -1359,20 +1359,6 @@ public class Util extends XOMUtil {
     }
 
     /**
-     * Masks Mondrian's version number from a string.
-     *
-     * @param str String
-     * @return String with each occurrence of mondrian's version number
-     *    (e.g. "2.3.0.0") replaced with "${mondrianVersion}"
-     */
-    public static String maskVersion(String str) {
-        MondrianServer.MondrianVersion mondrianVersion =
-            MondrianServer.forId(null).getVersion();
-        String versionString = mondrianVersion.getVersionString();
-        return replace(str, versionString, "${mondrianVersion}");
-    }
-
-    /**
      * Converts a list of SQL-style patterns into a Java regular expression.
      *
      * <p>For example, {"Foo_", "Bar%BAZ"} becomes "Foo.|Bar.*BAZ".


### PR DESCRIPTION
...ity and shouldn't be outside of testsrc.  Also switched to using a regex replace to avoid some possible false matches

(when the version string appears in other contexts).

```
(cherry picked from commit 38f5d67)
```
