### PR TITLE
Whoops.  Forgot to escape the version string in XmlaBaseTestCase.maskVer...

### DIFF
--- a/testsrc/main/mondrian/xmla/XmlaBaseTestCase.java
+++ b/testsrc/main/mondrian/xmla/XmlaBaseTestCase.java
@@ -25,6 +25,7 @@ import org.xml.sax.SAXException;
 
 import java.io.*;
 import java.util.*;
+import java.util.regex.Pattern;
 
 import javax.servlet.*;
 import javax.servlet.http.HttpServletRequest;
@@ -821,7 +822,7 @@ System.out.println("Got CONTINUE");
         // version string.  This avoids a false match when the version
         // string digits appear in other contexts (e.g. $3.56)
         String charsOutOfContext = "([^,\\$\\d])";
-        String matchString = charsOutOfContext + versionString
+        String matchString = charsOutOfContext + Pattern.quote(versionString)
             + charsOutOfContext;
         return str.replaceAll(matchString, "$1\\${mondrianVersion}$2");
     }


### PR DESCRIPTION
...sion(), causing the period to be treated as a wildcard.
