### PR TITLE
[MONDRIAN]  Changes to support building mondrian w/o bringing in workbench dependencies (e.g.kettle-core),

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -405,6 +405,7 @@ demo/access/MondrianFoodMart.mdb"/>
       <ivy:retrieve symlink="${symlink}" type="source,javadoc"
           pattern="${lib.dir}/[module]-[type].[ext]"/>
   </target>
+
   <target name="resolve-for-workbench" depends="prepare" unless="skip.download">
       <!-- Use symbolic links, rather than copying, on unix. -->
       <condition property="symlink" value="true">
@@ -418,6 +419,16 @@ demo/access/MondrianFoodMart.mdb"/>
           pattern="${wb.plugins.dir}/[module].[ext]"/>
       <ivy:retrieve symlink="${symlink}" type="source,javadoc"
           pattern="${wb.plugins.dir}/[module]-[type].[ext]"/>
+  </target>
+
+  <target name="resolve-workbench-runtime-deps" depends="prepare" 
+          unless="skip.download"
+          description="Resolves runtime dependencies not required for compilation.">
+    <ivy:resolve file="workbench/assembly_ivy.xml"/>
+    <ivy:retrieve symlink="${symlink}" type="jar"
+                  pattern="${wb.plugins.dir}/[module].[ext]"/>
+    <ivy:retrieve symlink="${symlink}" type="source,javadoc"
+                  pattern="${wb.plugins.dir}/[module]-[type].[ext]"/>
   </target>
 
 
@@ -1728,8 +1739,9 @@ xalan.jar"/>
     </java>
   </target>
 
+
   <target name="workbench-dist" 
-      depends="version,workbench">
+      depends="resolve-workbench-runtime-deps,version,workbench">
     <mkdir dir="${dist.dir}" />
     <delete file="${dist.dir}/${workbench.zip-dist.file}"/>
     <zip destfile="${dist.dir}/${workbench.zip-dist.file}">

--- a/workbench/assembly_ivy.xml
+++ b/workbench/assembly_ivy.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="http://ivyrep.jayasoft.org/ivy-doc.xsl"?>
+<!--
+  == This software is subject to the terms of the Eclipse Public License v1.0
+  == Agreement, available at the following URL:
+  == http://www.eclipse.org/legal/epl-v10.html.
+  == You must accept the terms of that agreement to use this software.
+  ==
+  == Copyright (C) 2008-2012 Pentaho
+  == All Rights Reserved.
+  -->
+<ivy-module
+    version="2.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="http://ant.apache.org/ivy/schemas/ivy.xsd">
+
+    <info organisation="pentaho" module="mondrian-workbench" revision="${project.revision}">
+        <license name="EPL" url="http://www.eclipse.org/legal/epl-v10.html"/>
+        <ivyauthor name="Julian Hyde" />
+        <repository name="pentaho-rep" url="http://repo.pentaho.org"/>
+        <description homepage="http://mondrian.pentaho.com">
+            Mondrian workbench.
+        </description>
+    </info>
+    <dependencies defaultconf="default->default">
+        <dependency org="pentaho" name="pentaho-mondrianschemaworkbench-plugins" rev="${dependency.schemaworkbench-plugins.revision}" transitive="false" changing="true"/>
+    </dependencies>
+</ivy-module>

--- a/workbench/ivy.xml
+++ b/workbench/ivy.xml
@@ -32,7 +32,6 @@
         <dependency org="junit" name="junit" rev="4.0"/>
         <dependency org="org.codehaus.groovy" name="groovy-all" rev="1.5.6" transitive="false"/>
 
-        <dependency org="pentaho" name="pentaho-mondrianschemaworkbench-plugins" rev="${dependency.schemaworkbench-plugins.revision}" transitive="false" changing="true"/>
         <dependency org="pentaho" name="pentaho-xul-core" rev="${dependency.pentaho-xul.revision}" changing="true" />
         <dependency org="pentaho" name="pentaho-xul-swing" rev="${dependency.pentaho-xul.revision}" changing="true" />
 	    <dependency org="commons-beanutils" name="commons-beanutils" rev="1.6" transitive="false"/>


### PR DESCRIPTION
as well as a change to allow workbench.jar to be created without bringing in a circular dependence on pentaho-mondrianschemaworkbench-plugins.  
