### PR TITLE
PSW-179 - Added the pentaho launcher jar back into the distribution

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -33,6 +33,7 @@ dependency.kettle.revision=TRUNK-SNAPSHOT
 dependency.pentaho-xul.revision=TRUNK-SNAPSHOT
 dependency.pentaho-launcher.revision=1.0.2
 dependency.schemaworkbench-plugins.revision=1.1-SNAPSHOT
+dependency.pentaho-launcher.revision=TRUNK-SNAPSHOT
 
 # Uncomment to use yDoc doclet for enhanced javadoc (requires commercial
 # license).

--- a/workbench/ivy.xml
+++ b/workbench/ivy.xml
@@ -45,6 +45,10 @@
         <dependency org="com.sun.jersey"           name="jersey-core"       rev="1.16" transitive="false"/>
         <dependency org="com.sun.jersey"           name="jersey-client"     rev="1.16" transitive="false"/>
         <dependency org="com.sun.jersey.contribs"  name="jersey-multipart"  rev="1.16" transitive="false"/>
+        
+        <!-- Pentaho Application Launcher -->
+        <dependency org="pentaho" name="pentaho-application-launcher" rev="${dependency.pentaho-launcher.revision}" changing="true"/>
+
 
         <!--Exclusions-->
         <exclude org="jaxme" module="jaxme-api"/>


### PR DESCRIPTION
This change will enable the Mac .app file to work again. It is currently failing because the launcher.jar file is not in the classpath (because it is not in the project at all)
