### PR TITLE
[MONDRIAN-1703]  Determination of the aggStar in SqlTupleReader is independent of the determination...

### DIFF
--- a/src/main/mondrian/rolap/RolapNativeFilter.java
+++ b/src/main/mondrian/rolap/RolapNativeFilter.java
@@ -89,7 +89,9 @@ public class RolapNativeFilter extends RolapNativeSet {
                 new RolapNativeSql(
                     sqlQuery, aggStar, getEvaluator(), args[0].getLevel());
             String filterSql = sql.generateFilterCondition(filterExpr);
-            sqlQuery.addHaving(filterSql);
+            if (filterSql != null) {
+                sqlQuery.addHaving(filterSql);
+            }
             super.addConstraint(sqlQuery, baseCube, aggStar);
         }
 

--- a/src/main/mondrian/rolap/RolapNativeSql.java
+++ b/src/main/mondrian/rolap/RolapNativeSql.java
@@ -5,7 +5,7 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2004-2005 TONBELLER AG
-// Copyright (C) 2006-2009 Pentaho
+// Copyright (C) 2006-2013 Pentaho
 // All Rights Reserved.
 */
 package mondrian.rolap;
@@ -46,9 +46,15 @@ public class RolapNativeSql {
      * the constraints from RolapAggregationManager. Also
      * make sure all measures live in the same star.
      *
+     * @return false if one or more saved measures are not
+     * from the same star (or aggStar if defined), true otherwise.
+     *
      * @see RolapAggregationManager#makeRequest(RolapEvaluator)
      */
     private boolean saveStoredMeasure(RolapStoredMeasure m) {
+        if (aggStar != null && !storedMeasureIsPresentOnAggStar(m)) {
+            return false;
+        }
         if (storedMeasure != null) {
             RolapStar star1 = getStar(storedMeasure);
             RolapStar star2 = getStar(m);
@@ -58,6 +64,13 @@ public class RolapNativeSql {
         }
         this.storedMeasure = m;
         return true;
+    }
+
+    private boolean storedMeasureIsPresentOnAggStar(RolapStoredMeasure m) {
+        RolapStar.Column column =
+            (RolapStar.Column) m.getStarMeasure();
+        int bitPos = column.getBitPosition();
+        return  aggStar.lookupColumn(bitPos) != null;
     }
 
     private RolapStar getStar(RolapStoredMeasure m) {
@@ -283,14 +296,12 @@ public class RolapNativeSql {
                     : rolapLevel.nameExp == null
                         ? rolapLevel.keyExp
                         : rolapLevel.nameExp;
-                /*
-                 * If an aggregation table is used, it might be more efficient
-                 * to use only the aggregate table and not the hierarchy table.
-                 * Try to lookup the column bit key. If that fails, we will
-                 * link the aggregate table to the hierarchy table. If no
-                 * aggregate table is used, we can use the column expression
-                 * directly.
-                 */
+                 // If an aggregation table is used, it might be more efficient
+                 // to use only the aggregate table and not the hierarchy table.
+                 // Try to lookup the column bit key. If that fails, we will
+                 // link the aggregate table to the hierarchy table. If no
+                 // aggregate table is used, we can use the column expression
+                 // directly.
                 String sourceExp;
                 if (aggStar != null
                     && rolapLevel instanceof RolapCubeLevel

--- a/testsrc/main/mondrian/rolap/NativeFilterMatchingTest.java
+++ b/testsrc/main/mondrian/rolap/NativeFilterMatchingTest.java
@@ -4,7 +4,7 @@
 // http://www.eclipse.org/legal/epl-v10.html.
 // You must accept the terms of that agreement to use this software.
 //
-// Copyright (C) 2011-2012 Pentaho
+// Copyright (C) 2011-2013 Pentaho
 // All Rights Reserved.
 */
 package mondrian.rolap;
@@ -21,10 +21,8 @@ import mondrian.test.TestContext;
 public class NativeFilterMatchingTest extends BatchTestCase {
     public void testPositiveMatching() throws Exception {
         if (!MondrianProperties.instance().EnableNativeFilter.get()) {
-            /*
-             * No point testing these if the native filters
-             * are turned off.
-             */
+            // No point testing these if the native filters
+            // are turned off.
             return;
         }
         final String sqlOracle =
@@ -108,10 +106,8 @@ public class NativeFilterMatchingTest extends BatchTestCase {
 
     public void testNegativeMatching() throws Exception {
         if (!MondrianProperties.instance().EnableNativeFilter.get()) {
-            /*
-             * No point testing these if the native filters
-             * are turned off.
-             */
+             // No point testing these if the native filters
+             // are turned off.
             return;
         }
         final String sqlOracle =
@@ -204,6 +200,94 @@ public class NativeFilterMatchingTest extends BatchTestCase {
             + "{[Product].[*TOTAL_MEMBER_SEL~SUM]}\n"
             + "Row #0: \n");
     }
+
+    public void testNativeFilterAgainstAggTableWithNotAllMeasures() {
+        // http://jira.pentaho.com/browse/MONDRIAN-1703
+        // If a filter condition contains one or more measures that are
+        // not present in the aggregate table, the SQL should omit the
+        // having clause altogether.
+
+        if (!MondrianProperties.instance().UseAggregates.get()
+            || !MondrianProperties.instance().EnableNativeFilter.get())
+        {
+            // test is not applicable
+            return;
+        }
+        propSaver.set(
+            propSaver.properties.GenerateFormattedSql,
+            true);
+
+        String sqlMysqlNoHaving =
+            "select\n"
+            + "    `agg_c_10_sales_fact_1997`.`the_year` as `c0`,\n"
+            + "    `agg_c_10_sales_fact_1997`.`quarter` as `c1`\n"
+            + "from\n"
+            + "    `agg_c_10_sales_fact_1997` as `agg_c_10_sales_fact_1997`\n"
+            + "where\n"
+            + "    (`agg_c_10_sales_fact_1997`.`the_year` = 1997)\n"
+            + "group by\n"
+            + "    `agg_c_10_sales_fact_1997`.`the_year`,\n"
+            + "    `agg_c_10_sales_fact_1997`.`quarter`\n"
+            + "order by\n"
+            + "    ISNULL(`agg_c_10_sales_fact_1997`.`the_year`) ASC, `agg_c_10_sales_fact_1997`.`the_year` ASC,\n"
+            + "    ISNULL(`agg_c_10_sales_fact_1997`.`quarter`) ASC, `agg_c_10_sales_fact_1997`.`quarter` ASC";
+
+        SqlPattern[] patterns = {
+            new SqlPattern(
+                Dialect.DatabaseProduct.MYSQL,
+                sqlMysqlNoHaving,
+                sqlMysqlNoHaving.length())
+        };
+
+        // This query should hit the agg_c_10_sales_fact_1997 agg table,
+        // which has [unit sales] but not [store count], so should
+        // not include the filter condition in the having.
+        assertQuerySqlOrNot(
+            getTestContext(),
+            "select filter(Time.[1997].children,  "
+            + "measures.[Sales Count] +  measures.[unit sales] > 0) on 0 "
+            + "from [sales]",
+            patterns,
+            false,
+            true,
+            true);
+
+        String mySqlWithHaving =
+            "select\n"
+            + "    `agg_c_10_sales_fact_1997`.`the_year` as `c0`,\n"
+            + "    `agg_c_10_sales_fact_1997`.`quarter` as `c1`\n"
+            + "from\n"
+            + "    `agg_c_10_sales_fact_1997` as `agg_c_10_sales_fact_1997`\n"
+            + "where\n"
+            + "    (`agg_c_10_sales_fact_1997`.`the_year` = 1997)\n"
+            + "group by\n"
+            + "    `agg_c_10_sales_fact_1997`.`the_year`,\n"
+            + "    `agg_c_10_sales_fact_1997`.`quarter`\n"
+            + "having\n"
+            + "    ((sum(`agg_c_10_sales_fact_1997`.`store_sales`) + sum(`agg_c_10_sales_fact_1997`.`unit_sales`)) > 0)\n"
+            + "order by\n"
+            + "    ISNULL(`agg_c_10_sales_fact_1997`.`the_year`) ASC, `agg_c_10_sales_fact_1997`.`the_year` ASC,\n"
+            + "    ISNULL(`agg_c_10_sales_fact_1997`.`quarter`) ASC, `agg_c_10_sales_fact_1997`.`quarter` ASC";
+
+        patterns[0] = new SqlPattern(
+            Dialect.DatabaseProduct.MYSQL,
+            mySqlWithHaving,
+            mySqlWithHaving.length());
+
+        // both measures are present on the agg table, so this one *should*
+        // include having.
+        assertQuerySqlOrNot(
+            getTestContext(),
+            "select filter(Time.[1997].children,  "
+            + "measures.[Store Sales] +  measures.[unit sales] > 0) on 0 "
+            + "from [sales]",
+            patterns,
+            false,
+            true,
+            true);
+    }
+
+
 }
 
 // End NativeFilterMatchingTest.java


### PR DESCRIPTION
...of the measures present in a native filter.  This left open the possibility that one or more measures could be missing from the aggregate table that was selected, since only one of the measures is set in context.
    E.g. filter (<set>, measure.[a] > measure.[b]) can be natively evaluated only if the columns for both measure [a] and [b] are present in the agg table.
    To side step the issue, this fix omits the having constraint if we determine that a measure is not present.
    (cherry picked from commit b0b54cf)
