### PR TITLE
Merging in a fix from master.

### DIFF
--- a/src/main/mondrian/olap/fun/AggregateFunDef.java
+++ b/src/main/mondrian/olap/fun/AggregateFunDef.java
@@ -145,7 +145,7 @@ public class AggregateFunDef extends AbstractAggregateFunDef {
                 // very slow.  May want to revisit this if someone
                 // improves the algorithm.
             } else {
-                tupleList = optimizeTupleList(evaluator, tupleList);
+                tupleList = optimizeTupleList(evaluator, tupleList, true);
             }
 
             // Can't aggregate distinct-count values in the same way
@@ -190,8 +190,7 @@ public class AggregateFunDef extends AbstractAggregateFunDef {
         }
 
         public static TupleList optimizeTupleList(
-            Evaluator evaluator,
-            TupleList tupleList)
+            Evaluator evaluator, TupleList tupleList, boolean checkSize)
         {
             if (!canOptimize(evaluator, tupleList)) {
                 return tupleList;
@@ -212,7 +211,9 @@ public class AggregateFunDef extends AbstractAggregateFunDef {
                     tupleList,
                     evaluator.getSchemaReader(),
                     evaluator.getMeasureGroup());
-            checkIfAggregationSizeIsTooLarge(tupleList);
+            if (checkSize) {
+                checkIfAggregationSizeIsTooLarge(tupleList);
+            }
             return tupleList;
         }
 

--- a/src/main/mondrian/rolap/RolapResult.java
+++ b/src/main/mondrian/rolap/RolapResult.java
@@ -360,7 +360,8 @@ public class RolapResult extends ResultBase {
                     tupleList =
                         AggregateFunDef.AggregateCalc.optimizeTupleList(
                             slicerEvaluator,
-                            tupleList);
+                            tupleList,
+                            false);
 
                     final Calc valueCalc =
                         new ValueCalc(

--- a/testsrc/main/mondrian/rolap/agg/AggregationOnDistinctCountMeasuresTest.java
+++ b/testsrc/main/mondrian/rolap/agg/AggregationOnDistinctCountMeasuresTest.java
@@ -505,9 +505,9 @@ public class AggregationOnDistinctCountMeasuresTest extends BatchTestCase {
             + "Axis #1:\n"
             + "{[Measures].[Unit Sales]}\n"
             + "Axis #2:\n"
-            + "{[Product].[Drink]}\n"
-            + "{[Product].[Food]}\n"
-            + "{[Product].[Non-Consumable]}\n"
+            + "{[Product].[Products].[Drink]}\n"
+            + "{[Product].[Products].[Food]}\n"
+            + "{[Product].[Products].[Non-Consumable]}\n"
             + "Row #0: 458\n"
             + "Row #1: 3,746\n"
             + "Row #2: 937\n");


### PR DESCRIPTION
Fix bug MONDRIAN-1122, "Aggregation is not supported over a list with more than 1000 predicates". We should not check the size of the list of constraints for composite slicer; it is only a problem if we are evaluating distinct-count measures, and they are relatively unusual.
(cherry picked from commit 5b5dbac)
