### PR TITLE
[MONDRIAN-1727]  Dimensions with a closure table have an additional hier...

### DIFF
--- a/src/main/mondrian/olap/fun/FunUtil.java
+++ b/src/main/mondrian/olap/fun/FunUtil.java
@@ -275,7 +275,30 @@ public class FunUtil extends Util {
         if (dimension.getHierarchyList().size() == 1) {
             return dimension.getHierarchyList().get(0);
         }
+        List<Hierarchy> nonClosureHierarchies =
+            getNonClosureHierarchies(dimension);
+        if (nonClosureHierarchies.size() == 1) {
+            return nonClosureHierarchies.get(0);
+        }
         return null;
+    }
+
+    /**
+     * Returns the list of hierarchies in a dimension, excluding
+     * any with a defined closureFor.
+     */
+    private static List<Hierarchy> getNonClosureHierarchies(
+        Dimension dimension)
+    {
+        List<Hierarchy> hierarchies = new ArrayList<Hierarchy>();
+        for (Hierarchy hierarchy : dimension.getHierarchyList()) {
+            if (hierarchy instanceof RolapHierarchy
+                && ((RolapHierarchy)hierarchy).closureFor == null)
+            {
+                hierarchies.add(hierarchy);
+            }
+        }
+        return hierarchies;
     }
 
     static List<Member> addMembers(

--- a/src/main/mondrian/rolap/RolapCubeHierarchy.java
+++ b/src/main/mondrian/rolap/RolapCubeHierarchy.java
@@ -60,7 +60,7 @@ public class RolapCubeHierarchy extends RolapHierarchy {
             uniqueName,
             rolapHierarchy.isVisible(),
             rolapHierarchy.hasAll(),
-            null,
+            rolapHierarchy.closureFor,
             rolapHierarchy.attribute,
             larder);
         this.ordinal = ordinal;

--- a/src/main/mondrian/rolap/RolapHierarchy.java
+++ b/src/main/mondrian/rolap/RolapHierarchy.java
@@ -64,7 +64,7 @@ public class RolapHierarchy extends HierarchyBase {
     private static final int NULL_LEVEL_CARDINALITY = 1;
     final RolapAttribute attribute;
     private final Larder larder;
-    final RolapHierarchy closureFor;
+    public final RolapHierarchy closureFor;
 
     final NamedList<RolapLevel> levelList = new NamedListImpl<RolapLevel>();
 

--- a/src/main/mondrian/rolap/RolapSchemaLoader.java
+++ b/src/main/mondrian/rolap/RolapSchemaLoader.java
@@ -3630,7 +3630,7 @@ public class RolapSchemaLoader {
         }
 
         final RolapClosure closure =
-            createClosure(cube, relation, xmlLevel, dimension);
+            createClosure(cube, relation, xmlLevel, hierarchy);
 
         final RolapLevel level =
             new RolapLevel(
@@ -3659,12 +3659,13 @@ public class RolapSchemaLoader {
         RolapCube cube,
         RolapSchema.PhysRelation relation,
         MondrianDef.Level xmlLevel,
-        RolapDimension dimension)
+        RolapHierarchy hierarchy)
     {
         final MondrianDef.Closure xmlClosure = xmlLevel.getClosure();
         if (xmlClosure == null) {
             return null;
         }
+        RolapDimension dimension = hierarchy.getDimension();
         final Map<String, RolapAttribute> attributeMap = dimension.attributeMap;
         MondrianDef.Attribute xmlParentAttribute =
             (MondrianDef.Attribute) validator.map.get(
@@ -3795,7 +3796,7 @@ public class RolapSchemaLoader {
                 Util.makeFqName(closureDim, closureDim.getName()),
                 closureDim.isVisible(),
                 true,
-                null, // Not so sure about this.
+                hierarchy, // closureFor hierarchy
                 null,
                 Larders.create(
                     closureDim.getName(),


### PR DESCRIPTION
...archy, which was causing failures in cases where the default hierarchy is being retrieved.

RolapHierarchy has a "closureFor" field which formerly was always set to null.  This change sets the value when appropriate, and uses it to filter out closures when determining which hierarchy is the default.
