### PR TITLE
MONDRIAN-1728

### DIFF
--- a/src/main/mondrian/olap/Member.java
+++ b/src/main/mondrian/olap/Member.java
@@ -182,6 +182,7 @@ public interface Member extends OlapElement, Comparable, Annotated {
 
     /**
      * Returns the ordinal of the member.
+     * @deprecated Use {@link #getOrderKey()}.
      */
     int getOrdinal();
 

--- a/src/main/mondrian/olap/fun/FunUtil.java
+++ b/src/main/mondrian/olap/fun/FunUtil.java
@@ -1915,9 +1915,16 @@ public class FunUtil extends Util {
             //noinspection unchecked
             return k1.compareTo(k2);
         }
-        int c = Util.compare(m1.getOrdinal(), m2.getOrdinal());
-        if (c != 0) {
-            return c;
+
+        Util.deprecated("ordinal to be replaced with order key", false);
+        int m1Ordinal = m1.getOrdinal();
+        int m2Ordinal = m2.getOrdinal();
+
+        if (m1Ordinal >= 0 && m2Ordinal >= 0) {
+            int c = Util.compare(m1Ordinal, m2Ordinal);
+            if (c != 0) {
+                return c;
+            }
         }
         //noinspection unchecked
         return m1.compareTo(m2);


### PR DESCRIPTION
ignoring ordinal for comparison when it has not been set.  Deprecating ordinal in favor of order key.  We can't completely replace ordinal until olap4j gets order key into it's api.
