### PR TITLE
[MONDRIAN-1729][SP-632] "Query required more than 12 iterations" error when query should complete.

### DIFF
--- a/testsrc/main/mondrian/test/Main.java
+++ b/testsrc/main/mondrian/test/Main.java
@@ -204,6 +204,7 @@ public class Main extends TestSuite {
                 addTest(suite, Base64Test.class);
                 return suite;
             }
+            addTest(suite, SegmentBuilderTest.class);
             addTest(suite, NativeFilterMatchingTest.class);
             addTest(suite, RolapConnectionTest.class);
             addTest(suite, FilteredIterableTest.class);


### PR DESCRIPTION
Pull req for 3.5 branch.

This change addresses a case where the ordering in which segments are processed by SegmentBuilder.rollup() could impact the resulting segment.  In some cases,
if a column of the second axis was wildcarded, it could incorrectly result in the axis being set as having incompatible predicates (lostPredicate=true).  Similarly,
the intersecting values could be mishandled, depending on the ordering of segments with wildcarded columns.
Test cases committed with this change check for equivalent rollups with segments processed in forward and reverse order.
(cherry picked from commit 2cdffbe, 2b5bf5aa, e507584)
