### PR TITLE
MONDRIAN-1658

### DIFF
--- a/src/main/mondrian/rolap/RolapNativeSet.java
+++ b/src/main/mondrian/rolap/RolapNativeSet.java
@@ -275,6 +275,7 @@ public abstract class RolapNativeSet extends RolapNative {
                 // This is used to push down the "1 = 0" predicate
                 // into the emerging CJ so that the entire CJ can
                 // be natively evaluated.
+                tr.incrementEmptySets();
                 return;
             }
 

--- a/src/main/mondrian/rolap/SqlTupleReader.java
+++ b/src/main/mondrian/rolap/SqlTupleReader.java
@@ -90,6 +90,7 @@ public class SqlTupleReader implements TupleReader {
      * manage to load any more members.
      */
     private int missedMemberCount;
+    private int emptySets = 0;
 
     /**
      * Helper class for SqlTupleReader;
@@ -424,6 +425,10 @@ public class SqlTupleReader implements TupleReader {
         this.constraint = constraint;
     }
 
+    public void incrementEmptySets() {
+        emptySets++;
+    }
+
     public void addLevelMembers(
         RolapCubeLevel level,
         MemberBuilder memberBuilder,
@@ -697,9 +702,9 @@ public class SqlTupleReader implements TupleReader {
         }
 
         TupleList tupleList =
-            n == 1
+            n + emptySets == 1
                 ? new UnaryTupleList(members)
-                : new ListTupleList(n, members);
+                : new ListTupleList(n + emptySets, members);
 
         // need to hierarchize the columns from the enumerated targets
         // since we didn't necessarily add them in the order in which

--- a/src/main/mondrian/rolap/TupleReader.java
+++ b/src/main/mondrian/rolap/TupleReader.java
@@ -139,6 +139,11 @@ public interface TupleReader {
      */
     Object getCacheKey();
 
+    /**
+     * Indicates that there was an empty argument somewhere in the tuple.
+     */
+    void incrementEmptySets();
+
 }
 
 // End TupleReader.java

--- a/testsrc/main/mondrian/rolap/NonEmptyTest.java
+++ b/testsrc/main/mondrian/rolap/NonEmptyTest.java
@@ -5001,6 +5001,43 @@ public class NonEmptyTest extends BatchTestCase {
            + "Row #2: \n"
            + "Row #3: \n");
    }
+
+    /**
+     * Test case for
+     * <a href="http://jira.pentaho.com/browse/MONDRIAN-1658">MONDRIAN-1658</a>
+     *
+     * <p>Error: Tuple length does not match arity
+     *
+     * <p>An empty set argument to crossjoin caused native evaluation to return
+     * an incorrect type which in turn caused the types for each argument to
+     * union to be different
+     *
+     */
+    public void testMondrian1658() {
+        propSaver.set(MondrianProperties.instance().ExpandNonNative, true);
+        String mdx =
+            "Select\n"
+            + "  [Measures].[Unit Sales] on columns,\n"
+            + "  Non Empty \n"
+            + "  Union(\n"
+            + "    {([Gender].[M],[Time].[1997].[Q1])},\n"
+            + "      Union(\n"
+            + "        CrossJoin({[Gender].[F]},{}),\n"
+            + "          {([Gender].[F],[Time].[1997].[Q2])}))\n"
+            + "  on rows\n"
+            + "From [Sales]\n";
+        String expected =
+            "Axis #0:\n"
+            + "{}\n"
+            + "Axis #1:\n"
+            + "{[Measures].[Unit Sales]}\n"
+            + "Axis #2:\n"
+            + "{[Customer].[Gender].[M], [Time].[Time].[1997].[Q1]}\n"
+            + "{[Customer].[Gender].[F], [Time].[Time].[1997].[Q2]}\n"
+            + "Row #0: 33,381\n"
+            + "Row #1: 30,992\n";
+        assertQueryReturns(mdx, expected);
+    }
 }
 
 // End NonEmptyTest.java


### PR DESCRIPTION
handling the case where a crossjoin is given an empty set for one of its parameters.  Cherry picked from master c5c26bfe5b8ed87f553bc48f4eaeef1abc02f0db
