### PR TITLE
[MONDRIAN-1729][SP-632]  "Query required more than 12 iterations" error when query should complete.

### DIFF
--- a/src/main/mondrian/rolap/agg/SegmentBuilder.java
+++ b/src/main/mondrian/rolap/agg/SegmentBuilder.java
@@ -18,6 +18,8 @@ import mondrian.spi.Dialect.Datatype;
 import mondrian.util.ArraySortedSet;
 import mondrian.util.Pair;
 
+import org.olap4j.impl.UnmodifiableArrayList;
+
 import java.lang.ref.WeakReference;
 import java.util.*;
 import java.util.Map.Entry;
@@ -197,7 +199,13 @@ public class SegmentBuilder {
             int src;
             boolean lostPredicate;
         }
-        final SegmentHeader firstHeader = map.keySet().iterator().next();
+        assert allHeadersHaveSameDimensionality(map.keySet());
+
+        // store the map values in a list to assure the first header
+        // loaded here is consistent w/ the first segment processed below.
+        List<Map.Entry<SegmentHeader, SegmentBody>>  segments =
+            UnmodifiableArrayList.of(map.entrySet());
+        final SegmentHeader firstHeader = segments.get(0).getKey();
         final AxisInfo[] axes =
             new AxisInfo[keepColumns.size()];
         int z = 0, j = 0;
@@ -213,7 +221,7 @@ public class SegmentBuilder {
 
         // Compute the sets of values in each axis of the target segment. These
         // are the intersection of the input axes.
-        for (Map.Entry<SegmentHeader, SegmentBody> entry : map.entrySet()) {
+        for (Map.Entry<SegmentHeader, SegmentBody> entry : segments) {
             final SegmentHeader header = entry.getKey();
             for (AxisInfo axis : axes) {
                 final SortedSet<Comparable> values =
@@ -234,22 +242,27 @@ public class SegmentBuilder {
                     if (axis.requestedValues == null) {
                         filteredValues = values;
                         filteredHasNull = hasNull;
+                        axis.column = headerColumn;
+                    } else if (requestedValues == null) {
+                        // this axis is wildcarded
+                        filteredValues = axis.requestedValues;
+                        filteredHasNull = axis.hasNull;
                     } else {
                         filteredValues = Util.intersect(
-                            values,
+                            requestedValues,
                             axis.requestedValues);
 
                         // SegmentColumn predicates cannot ask for the null
                         // value (at present).
                         filteredHasNull = false;
                     }
-                    axis.valueSet.addAll(filteredValues);
+                    axis.valueSet = filteredValues;
                     axis.hasNull = axis.hasNull || filteredHasNull;
                     if (!Util.equals(axis.requestedValues, requestedValues)) {
                         if (axis.requestedValues == null) {
                             // Downgrade from wildcard to a specific list.
                             axis.requestedValues = requestedValues;
-                        } else {
+                        } else if (requestedValues != null) {
                             // Segment requests have incompatible predicates.
                             // Best we can say is "we must have asked for the
                             // values that came back".
@@ -490,6 +503,21 @@ public class SegmentBuilder {
                 Collections.<SegmentColumn>emptyList());
 
         return Pair.of(header, body);
+    }
+
+    private static boolean allHeadersHaveSameDimensionality(
+        Set<SegmentHeader> headers)
+    {
+        final Iterator<SegmentHeader> headerIter = headers.iterator();
+        final SegmentHeader firstHeader = headerIter.next();
+        BitKey bitKey = firstHeader.getConstrainedColumnsBitKey();
+        while (headerIter.hasNext()) {
+            final SegmentHeader nextHeader = headerIter.next();
+            if (!bitKey.equals(nextHeader.getConstrainedColumnsBitKey())) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private static int[] computeAxisMultipliers(

--- a/testsrc/main/mondrian/rolap/agg/SegmentBuilderTest.java
+++ b/testsrc/main/mondrian/rolap/agg/SegmentBuilderTest.java
@@ -12,11 +12,9 @@ package mondrian.rolap.agg;
 
 import mondrian.olap.*;
 import mondrian.rolap.*;
-import mondrian.spi.Dialect;
-import mondrian.spi.SegmentBody;
-import mondrian.spi.SegmentColumn;
-import mondrian.spi.SegmentHeader;
+import mondrian.spi.*;
 import mondrian.test.PerformanceTest;
+import mondrian.test.TestContext;
 import mondrian.util.ByteString;
 import mondrian.util.Pair;
 
@@ -41,12 +39,10 @@ public class SegmentBuilderTest extends BatchTestCase {
             MondrianProperties.instance().SparseSegmentCountThreshold, 1000);
     }
 
-    public void _testSparseRollup() {
+    public void testSparseRollup() {
         // functional test for a case that causes OOM if rollup creates
         // a dense segment.
-        // Leaving disabled pending removal of HighCardSqlTupleReader.
-        // Currently this query will never complete due to an issue w/
-        // HCSTR
+        // This takes several seconds to run
 
         if (PerformanceTest.LOGGER.isDebugEnabled()) {
             // load the cache with a segment for the subsequent rollup
@@ -68,7 +64,6 @@ public class SegmentBuilderTest extends BatchTestCase {
                 + "Crossjoin( [product].[products].[product name].members, "
                 + " [Customer].[Customers].[Name].members))))) on 1, "
                 + "{ measures.[unit sales] } on 0 from [Sales]");
-
             // second query will throw OOM if .rollup() attempts
             // to create a dense segment
         }
@@ -128,6 +123,291 @@ public class SegmentBuilderTest extends BatchTestCase {
         assertTrue(rollup.right instanceof DenseDoubleSegmentBody);
     }
 
+    public void testSameRollupRegardlessOfSegmentOrderWithEmptySegmentBody() {
+        // http://jira.pentaho.com/browse/MONDRIAN-1729
+        // rollup of segments {A, B} should produce the same resulting segment
+        // regardless of whether rollup processes them in the order A,B or B,A.
+        // MONDRIAN-1729 involved a case where the rollup segment was invalid
+        // if processed in a particular order.
+        // This tests a wildcarded segment (on year) rolled up w/ a seg
+        // containing a single val.
+        // The resulting segment contains only empty results (for 1998)
+        runRollupTest(
+            // queries to populate the cache with segments which will be rolled
+            // up
+            new String[]{
+                "select "
+                + "{[Time].[1998].[Q1].[2],[Time].[1998].[Q1].[3],"
+                + "[Time].[1998].[Q2].[4],[Time].[1998].[Q2].[5],"
+                + "[Time].[1998].[Q2].[5],[Time].[1998].[Q2].[6],"
+                + "[Time].[1998].[Q3].[7]} on 0 from sales",
+                "select "
+                + "{[Time].[1997].[Q1].[1], [Time].[1997].[Q3].[8], [Time].[1997].[Q3].[9], "
+                + "[Time].[1997].[Q4].[10], [Time].[1997].[Q4].[11], [Time].[1997].[Q4].[12],"
+                + "[Time].[1998].[Q1].[1], [Time].[1998].[Q3].[8], [Time].[1998].[Q3].[9], "
+                + "[Time].[1998].[Q4].[10], [Time].[1998].[Q4].[11], [Time].[1998].[Q4].[12]}"
+                + "on 0 from sales"},
+            new String[] {
+                "6806cee8561ece016f1acee39e2481c933aae4de7d4bd8bf28aee0b15dc894ce",
+                "ce2f10efe351f9c3b01fe54665bde120b5e7df7474b2363f3f7f3b3a3a93a733"
+            },
+            new String[]{
+                // rollup columns
+                "`time_by_day`.`the_year`"
+            },
+            // expected header of the rolled up segment
+            "*Segment Header\n"
+            + "Schema:[FoodMart]\n"
+            + "Checksum:[06389f41d543e685b98dc75f54237772]\n"
+            + "Cube:[Sales]\n"
+            + "Measure:[Unit Sales]\n"
+            + "Axes:[\n"
+            + "    {`time_by_day`.`the_year`=('1998')}]\n"
+            + "Excluded Regions:[]\n"
+            + "Compound Predicates:[]\n"
+            + "ID:[51a45f2e2a5e2c71f8479cd7806c9afd765be3c80a4881d7516d5576a0973b34]\n");
+    }
+
+    public void testSameRollupRegardlessOfSegmentOrderWithData() {
+        // http://jira.pentaho.com/browse/MONDRIAN-1729
+        // Tests a wildcarded segment rolled up w/ a seg containing a single
+        // val.  Both segments are associated w/ non empty results.
+        runRollupTest(
+            new String[]{
+                "select {{[Product].[Drink].[Alcoholic Beverages]},\n"
+                + "{[Product].[Drink].[Beverages]},\n"
+                + "{[Product].[Food].[Baked Goods]},\n"
+                + "{[Product].[Non-Consumable].[Periodicals]}}\n on 0 from sales",
+                "select "
+                + "\n"
+                + "{[Product].[Drink].[Dairy]}"
+                + "on 0 from sales"},
+            new String[] {
+              "8f8f28faa78d9688b5f2bf0419302b858039544690ed71fd270e2f1c2697fb0a",
+              "e0800d8f9d3fff381152fa2b5d2b5499d5a3a9993cc3aec0ab28995debefbeca"
+            },
+            new String[]{
+                "`product_class`.`product_family`"
+            },
+            "*Segment Header\n"
+            + "Schema:[FoodMart]\n"
+            + "Checksum:[06389f41d543e685b98dc75f54237772]\n"
+            + "Cube:[Sales]\n"
+            + "Measure:[Unit Sales]\n"
+            + "Axes:[\n"
+            + "    {`product_class`.`product_family`=('Drink')}]\n"
+            + "Excluded Regions:[]\n"
+            + "Compound Predicates:[]\n"
+            + "ID:[244bbda98dbfee5000205fdcfee"
+            + "f1b4076e3d50f6ad2cd70d1ec7667031a51f0]\n");
+    }
+
+    public void testSameRollupRegardlessOfSegmentOrderNoWildcards() {
+        // http://jira.pentaho.com/browse/MONDRIAN-1729
+        // Tests 2 segments, each w/ no wildcarded values.
+        runRollupTest(
+            new String[]{
+                "select {{[Product].[Drink].[Alcoholic Beverages]},\n"
+                + "{[Product].[Drink].[Beverages]},\n"
+                + "{[Product].[Non-Consumable].[Periodicals]}}\n on 0 from sales",
+                "select "
+                + "\n"
+                + "{[Product].[Drink].[Dairy]}"
+                + "on 0 from sales"},
+            new String[] {
+                "b9cd57a8b7b3db1021a72c540da1f64382cce469742095b04d023a0d3c8f0096",
+                "8f8f28faa78d9688b5f2bf0419302b858039544690ed71fd270e2f1c2697fb0a"
+            },
+            new String[]{
+                "`product_class`.`product_family`"
+            },
+            "*Segment Header\n"
+            + "Schema:[FoodMart]\n"
+            + "Checksum:[06389f41d543e685b98dc75f54237772]\n"
+            + "Cube:[Sales]\n"
+            + "Measure:[Unit Sales]\n"
+            + "Axes:[\n"
+            + "    {`product_class`.`product_family`=('Drink')}]\n"
+            + "Excluded Regions:[]\n"
+            + "Compound Predicates:[]\n"
+            + "ID:[244bbda98dbfee5000205fdcfeef1b"
+            + "4076e3d50f6ad2cd70d1ec7667031a51f0]\n");
+    }
+
+    public void testSameRollupRegardlessOfSegmentOrderThreeSegs() {
+        // http://jira.pentaho.com/browse/MONDRIAN-1729
+        // Tests 3 segments, each w/ no wildcarded values.
+        runRollupTest(
+            new String[]{
+                "select {{[Product].[Drink].[Alcoholic Beverages]},\n"
+                + "{[Product].[Non-Consumable].[Periodicals]}}\n on 0 from sales",
+                "select "
+                + "\n"
+                + "{[Product].[Drink].[Dairy]}"
+                + "on 0 from sales",
+                " select "
+                + "{[Product].[Drink].[Beverages]} on 0 from sales"},
+            new String[] {
+                "4472479a34c350cd2c208d369fae0968f860f61e8a893575f310144b87c7ceb5",
+                "b19558359f411085f94692daefb46806e8bd0c3f95ff491eac0f8274bc655198",
+                "8f8f28faa78d9688b5f2bf0419302b858039544690ed71fd270e2f1c2697fb0a"
+            },
+            new String[]{
+                "`product_class`.`product_family`"
+            },
+            "*Segment Header\n"
+            + "Schema:[FoodMart]\n"
+            + "Checksum:[06389f41d543e685b98dc75f54237772]\n"
+            + "Cube:[Sales]\n"
+            + "Measure:[Unit Sales]\n"
+            + "Axes:[\n"
+            + "    {`product_class`.`product_family`=('Drink')}]\n"
+            + "Excluded Regions:[]\n"
+            + "Compound Predicates:[]\n"
+            + "ID:[244bbda98dbfee5000205fdc"
+            + "feef1b4076e3d50f6ad2cd70d1ec7667031a51f0]\n");
+    }
+
+
+
+    /**
+     * Loads the cache with the results of the queries
+     * in cachePopulatingQueries, and then attempts to rollup all
+     * cached segments based on the keepColumns array, checking
+     * against expectedHeader.  Rolls up loading segment
+     * in both forward and reverse order and verifies
+     * same results both ways.
+     * @return the rolled up SegmentHeader/SegmentBody pair
+     */
+    private Pair<SegmentHeader, SegmentBody> runRollupTest(
+        String[] cachePopulatingQueries,
+        String[] segmentIdsToRollup,
+        String[] keepColumns,
+        String expectedHeader)
+    {
+        propSaver.set(
+            MondrianProperties.instance().OptimizePredicates,
+            false);
+        TestContext context = loadCacheWithQueries(cachePopulatingQueries);
+        Map<SegmentHeader, SegmentBody> map = getReversibleTestMap(
+            context, Order.FORWARD, segmentIdsToRollup);
+        Set<String> keepColumnsSet = new HashSet<String>();
+        keepColumnsSet.addAll(Arrays.asList(keepColumns));
+        Pair<SegmentHeader, SegmentBody> rolledForward = SegmentBuilder.rollup(
+            map,
+            keepColumnsSet,
+                   // bitkey does not factor into rollup logic, so it's safe to
+                   // use a dummy
+            BitKey.Factory.makeBitKey(new BitSet()),
+            RolapAggregator.Sum,
+            Dialect.Datatype.Numeric);
+        // Now try reversing the order the segments are retrieved
+        context = loadCacheWithQueries(cachePopulatingQueries);
+        map = getReversibleTestMap(context, Order.REVERSE, segmentIdsToRollup);
+        Pair<SegmentHeader, SegmentBody> rolledReverse = SegmentBuilder.rollup(
+            map,
+            keepColumnsSet,
+            BitKey.Factory.makeBitKey(new BitSet()),
+            RolapAggregator.Sum,
+            Dialect.Datatype.Numeric);
+        assertEquals(expectedHeader, rolledForward.getKey().toString());
+        // the header of the rolled up segment should be the same
+        // regardless of the order the segments were processed
+        assertEquals(rolledForward.getKey(), rolledReverse.getKey());
+        assertEquals(
+            rolledForward.getValue().getValueMap().size(),
+            rolledReverse.getValue().getValueMap().size());
+        propSaver.reset();
+        return rolledForward;
+    }
+
+    private TestContext loadCacheWithQueries(String [] queries) {
+        getTestContext().flushSchemaCache();
+        TestContext context = getTestContext().withFreshConnection();
+        for (String query : queries) {
+            context.executeQuery(query);
+        }
+        return context;
+    }
+
+    enum Order {
+        FORWARD, REVERSE
+    }
+    /**
+     * Creates a Map<SegmentHeader,SegmentBody> based on the set of
+     * segments currently in the cache.  The Map overrides the entrySet()
+     * method to provide an ordered set of elements based
+     * on Header.getUniqueID(), ordered according to the order param.
+     * @param context  The test context
+     * @param order  The order to sort the elements returned by entrySet(),
+     *               FORWARD or REVERSE
+     * @param segmentIdsToInclude  The IDs of currently cached segments to
+     *                             include in the map.
+     */
+    private Map<SegmentHeader, SegmentBody> getReversibleTestMap(
+        TestContext context, final Order order, String[] segmentIdsToInclude)
+    {
+        SegmentCache cache = MondrianServer.forConnection(
+            context.getConnection()).getAggregationManager()
+            .cacheMgr.compositeCache;
+
+        List<SegmentHeader> headers = cache.getSegmentHeaders();
+        Map<SegmentHeader, SegmentBody> testMap =
+            new HashMap<SegmentHeader, SegmentBody>() {
+            public Set<Map.Entry<SegmentHeader, SegmentBody>> entrySet() {
+                List<Map.Entry<SegmentHeader, SegmentBody>> list =
+                    new ArrayList<Map.Entry<SegmentHeader, SegmentBody>>();
+                list.addAll(super.entrySet());
+                Collections.sort(
+                    list,
+                    new Comparator<Map.Entry<SegmentHeader, SegmentBody>>() {
+                        public int compare(
+                            Map.Entry<SegmentHeader, SegmentBody> o1,
+                            Map.Entry<SegmentHeader, SegmentBody> o2)
+                        {
+                            int ret = o1.getKey().getUniqueID().compareTo(
+                                o2.getKey().getUniqueID());
+                            return order == Order.REVERSE ? -ret : ret;
+                        }
+                    });
+                LinkedHashSet<Map.Entry<SegmentHeader, SegmentBody>>
+                    orderedSet =
+                    new LinkedHashSet<Map.Entry<SegmentHeader, SegmentBody>>();
+                orderedSet.addAll(list);
+                return orderedSet;
+            }
+            public Set<SegmentHeader> keySet() {
+                List<SegmentHeader> list = new ArrayList<SegmentHeader>();
+                list.addAll(super.keySet());
+                Collections.sort(
+                    list,
+                    new Comparator<SegmentHeader>() {
+                        public int compare(
+                            SegmentHeader o1,
+                            SegmentHeader o2)
+                        {
+                            int ret = o1.getUniqueID().compareTo(
+                                o2.getUniqueID());
+                            return order == Order.REVERSE ? ret : -ret;
+                        }
+                    });
+                LinkedHashSet<SegmentHeader>
+                    orderedSet =
+                    new LinkedHashSet<SegmentHeader>();
+                orderedSet.addAll(list);
+                return orderedSet;
+            }
+        };
+        for (SegmentHeader header : headers) {
+            for (String segmentId : segmentIdsToInclude) {
+                if (header.getUniqueID().toString().equals(segmentId)) {
+                    testMap.put(header, cache.get(header));
+                }
+            }
+        }
+        return testMap;
+    }
+
     /**
      * Creates a rough segment map for testing purposes, containing
      * the array of column names passed in, with numValsPerCol dummy
@@ -140,8 +420,8 @@ public class SegmentBuilderTest extends BatchTestCase {
     {
         Pair<SegmentHeader, SegmentBody> headerBody = makeDummyHeaderBodyPair(
             colNames,
-            dummyColumnValues(
-                colNames.length, numValsPerCol), numPopulatedCells);
+            dummyColumnValues(colNames.length, numValsPerCol),
+            numPopulatedCells);
         Map<SegmentHeader, SegmentBody> map =
             new HashMap<SegmentHeader, SegmentBody>();
         map.put(headerBody.left, headerBody.right);
@@ -151,9 +431,6 @@ public class SegmentBuilderTest extends BatchTestCase {
     private Pair<SegmentHeader, SegmentBody> makeDummyHeaderBodyPair(
         String[] colExps, String[][] colVals, int numCellVals)
     {
-        final Map<CellKey, Object> data =
-            new HashMap<CellKey, Object>();
-
         final List<SegmentColumn> constrainedColumns =
             new ArrayList<SegmentColumn>();
 
@@ -161,33 +438,30 @@ public class SegmentBuilderTest extends BatchTestCase {
             new ArrayList<Pair<SortedSet<Comparable>, Boolean>>();
         for (int i = 0; i < colVals.length; i++) {
             String colExp = colExps[i];
-            SortedSet<Comparable> vals = new TreeSet<Comparable>();
-            for (int j = 0; j < colVals[i].length; j++) {
-                vals.add(new String(colVals[i][j]));
-            }
+            SortedSet<Comparable> vals =
+                new TreeSet<Comparable>(Arrays.<Comparable>asList(colVals[i]));
             constrainedColumns.add(
                 new SegmentColumn(
                     colExp,
                     colVals[i].length,
                     vals));
-            axes.add(new Pair<SortedSet<Comparable>,
-                Boolean>(vals, Boolean.FALSE));
+            axes.add(Pair.of(vals, Boolean.FALSE));
         }
 
         Object [] cells = new Object[numCellVals];
         for (int i = 0; i < numCellVals; i++) {
             cells[i] = 123.123; // assign a non-null val
         }
-        return new Pair<SegmentHeader, SegmentBody> (
+        return Pair.<SegmentHeader, SegmentBody>of(
             new SegmentHeader(
                 "dummySchemaName",
-                new ByteString(new byte[] {}),
+                new ByteString(new byte[]{}),
                 "dummyCubeName",
                 "dummyMeasureName",
                 constrainedColumns,
                 Collections.<String>emptyList(),
                 "dummyFactTable",
-                null,
+                BitKey.Factory.makeBitKey(3),
                 Collections.<SegmentColumn>emptyList()),
             new DenseObjectSegmentBody(
                 cells,
@@ -204,4 +478,5 @@ public class SegmentBuilderTest extends BatchTestCase {
         return dummyColVals;
     }
 }
+
 // End SegmentBuilderTest.java


### PR DESCRIPTION
Pull req for lagunitas

This change addresses a case where the ordering in which segments are processed by SegmentBuilder.rollup() could impact the resulting segment.  In some cases,
if a column of the second axis was wildcarded, it could incorrectly result in the axis being set as having incompatible predicates (lostPredicate=true).  Similarly,
the intersecting values could be mishandled, depending on the ordering of segments with wildcarded columns.
Test cases committed with this change check for equivalent rollups with segments processed in forward and reverse order.
(cherry picked from commits 2cdffbe, 25eba12, 76eb9a3)
