### PR TITLE
Fix null comparison

### DIFF
--- a/src/main/mondrian/rolap/RolapUtil.java
+++ b/src/main/mondrian/rolap/RolapUtil.java
@@ -33,6 +33,7 @@ import java.sql.SQLException;
 import java.util.*;
 
 import javax.sql.DataSource;
+import org.apache.commons.collections.comparators.NullComparator;
 
 /**
  * Utility methods for classes in the <code>mondrian.rolap</code> package.
@@ -163,8 +164,16 @@ public class RolapUtil {
     private static final class RolapUtilComparator<T extends Comparable<T>>
         implements Comparator<T>
     {
+
+        private static final NullComparator NULL_COMPARATOR = new NullComparator(false);
+
         public int compare(T o1, T o2) {
             try {
+
+                if (o1 == null || o2 == null) {
+                    return NULL_COMPARATOR.compare(o1, o2);
+                }
+
                 return o1.compareTo(o2);
             } catch (ClassCastException cce) {
                 if (o2 == RolapUtilComparable.INSTANCE) {


### PR DESCRIPTION
This patch fix a `NullPointerException` after cleaning up a `CellRegion`
Probably this isn't the best approach to fix the problem.

Given the following schema, after run a cache clean using the cache api, 
All MDX queries that hit the evicted region are going to crashes...

Please let me know if a can do something better 
or if i'm doing some wrong while using the cache API..

Cheers..

``` xml

<Dimension type="TimeDimension" visible="true" highCardinality="false" name="DATE_PERIODS" caption="Date Period">
  <Hierarchy name="DATE_PERIODS" visible="true" hasAll="true" allMemberName="All Dates" allMemberCaption="All Dates" primaryKey="date_key" caption="Date Periods">
    <Table name="dim_date" />
    <!-- .... -->
  </Hierarchy>
</Dimension>

<Cube name="CLICKS" caption="Clicks" visible="true" cache="true" enabled="true">
  <Table name="fact_click">
    <AggName name="fact_click_agg" ignorecase="true">
      <!-- .... -->
    </AggName>
  </Table>
  <DimensionUsage source="DATE_PERIODS" name="DATE_PERIODS" caption="Date Period" visible="true" foreignKey="date_key" highCardinality="false" />
  <Measure name="UNIQUE_CLICKS" column="unique_click" datatype="Numeric" formatString="#,##0" aggregator="sum" caption="Unique Clicks" visible="true" />
  <Measure name="RAW_CLICKS" column="raw_click" datatype="Numeric" formatString="#,##0" aggregator="sum" caption="Raw Clicks" visible="true" />
  <!-- .... -->
</Cube>
```

``` java
public void clearCache(String cubeName)
{
    String date = "2013-10-25";
    String y    = "2013";
    String m    = "10";
    String q    = "4"

    Schema schema   = conn.getSchema();
    Cube cube       = schema.lookupCube(cubeName, true);

    CacheControl cacheControl = conn.getCacheControl(null);
    SchemaReader schemaReader = cube.getSchemaReader(null).withLocus();
    List<Id.Segment> segments = Id.Segment.toList("DATE_PERIODS", y, q, m, date);
    Member member             = schemaReader.getMemberByUniqueName(segments, true);

    CellRegion measuresRegion = cacheControl.createMeasuresRegion(cube);
    CellRegion memberRegion   = cacheControl.createMemberRegion(member, true);
    CellRegion joinRegion     = cacheControl.createCrossjoinRegion(measuresRegion, memberRegion);

    cacheControl.flush(joinRegion);

   MemberSet delMemberSet       = cacheControl.createMemberSet(member, true);
   MemberEditCommand delCommand = cacheControl.createDeleteCommand(delMemberSet);

   cacheControl.execute(delCommand);
}
```

``` shell
at mondrian.resource.MondrianResource$_Def0.ex(MondrianResource.java:972)
    at mondrian.olap.Util.newInternal(Util.java:2421)
    at mondrian.olap.Util.newError(Util.java:2437)
    at mondrian.rolap.RolapConnection.executeInternal(RolapConnection.java:715)
    at mondrian.rolap.RolapConnection.access$000(RolapConnection.java:51)
    at mondrian.rolap.RolapConnection$1.call(RolapConnection.java:631)
    at mondrian.rolap.RolapConnection$1.call(RolapConnection.java:630)
    at java.util.concurrent.FutureTask$Sync.innerRun(FutureTask.java:334)
    at java.util.concurrent.FutureTask.run(FutureTask.java:166)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
    ... 1 more
Caused by: java.lang.NullPointerException
    at mondrian.rolap.RolapUtil$RolapUtilComparator.compare(RolapUtil.java:165)
    at mondrian.rolap.RolapUtil$RolapUtilComparator.compare(RolapUtil.java:160)
    at java.util.Arrays.binarySearch0(Arrays.java:1585)
    at java.util.Arrays.binarySearch(Arrays.java:1570)
    at mondrian.util.UtilCompatibleJdk16.binarySearch(UtilCompatibleJdk16.java:107)
    at mondrian.olap.Util.binarySearch(Util.java:2206)
    at mondrian.util.ArraySortedSet.contains(ArraySortedSet.java:225)
    at mondrian.rolap.cache.SegmentCacheIndexImpl.matches(SegmentCacheIndexImpl.java:284)
    at mondrian.rolap.cache.SegmentCacheIndexImpl.locate(SegmentCacheIndexImpl.java:124)
    at mondrian.rolap.BatchLoader.loadFromCaches(FastBatchingCellReader.java:628)
    at mondrian.rolap.BatchLoader.recordCellRequest2(FastBatchingCellReader.java:576)
    at mondrian.rolap.BatchLoader.load(FastBatchingCellReader.java:859)
    at mondrian.rolap.BatchLoader$LoadBatchCommand.call(FastBatchingCellReader.java:1000)
    at mondrian.rolap.BatchLoader$LoadBatchCommand.call(FastBatchingCellReader.java:966)
    at mondrian.rolap.agg.SegmentCacheManager$Actor.run(SegmentCacheManager.java:1014)
    ... 1 more
```
