### PR TITLE
Changes to make Mondrian an OSGI-compatible bundle.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -373,7 +373,7 @@ mondrian/olap/ParserSym.java"/>
     <mkdir dir="${dist.dir}"/>
   </target>
 
-  <target name="resolve" unless="skip.download">
+  <target name="resolve" depends="install-ivy" unless="skip.download">
       <!-- Use symbolic links, rather than copying, on unix. -->
       <condition property="symlink" value="true">
           <os family="unix"/>
@@ -386,6 +386,9 @@ mondrian/olap/ParserSym.java"/>
           pattern="${lib.dir}/[module].[ext]"/>
       <ivy:retrieve symlink="${symlink}" type="source,javadoc"
           pattern="${lib.dir}/[module]-[type].[ext]"/>
+
+      <ivy:resolve file="${ivyfile}" conf="test" />
+      <ivy:retrieve conf="test" pattern="${testlib.dir}/[module]-[revision](-[classifier]).[ext]" symlink="${symlink}" />
   </target>
 
   <target name="cmdrunner" depends="jar">
@@ -523,11 +526,12 @@ copy"/>
             todir="${classes.dir}"/>
     <copy file="src/main/mondrian/rolap/aggmatcher/DefaultRulesSchema.xml"
         todir="${classes.dir}"/>
-    <copy todir="${classes.dir}">
+    <copy todir="${classes.dir}" overwrite="true">
       <fileset
           dir="${java.dir}"
           includes="
-META-INF/**"/>
+META-INF/**,
+OSGI-INF/**"/>
     </copy>
     <copy todir="${testclasses.dir}">
       <fileset
@@ -1145,7 +1149,8 @@ must be run under JDK 1.7." />
 **/*.class,
 **/*.properties,
 **/*.xml,
-META-INF/**"/>
+META-INF/**,
+OSGI-INF/**"/>
       <zipfileset
           dir="${testclasses.dir}"
           includes="
@@ -1173,8 +1178,18 @@ VERSION.txt"/>
         </section>
       </manifest>
     </jar>
-    <copy file="${jar.file}"
-        tofile="${dist.dir}/${ivy.artifact.id}-${project.revision}.jar"/>
+
+    <!-- Wrap the jar as a bundle using the BND tool. -->
+    <exec executable="java" failonerror="true">
+      <arg value="-jar" />
+      <arg value="lib/bnd.jar" />
+      <arg value="wrap" />
+      <arg value="--properties" />
+      <arg value="mondrian.bnd" />
+      <arg value="--output" />
+      <arg value="${dist.dir}/${ivy.artifact.id}-${project.revision}.jar" />
+      <arg value="${jar.file}" />
+    </exec>
   </target>
 
   <target name="xml_schema"

--- a/ivy.xml
+++ b/ivy.xml
@@ -51,9 +51,9 @@
         <dependency org="net.java.dev.javacc" name="javacc" rev="5.0"/>
         <dependency org="dom4j" name="dom4j" rev="1.6.1"/>
         <dependency org="javax.validation" name="validation-api" rev="1.0.0.GA"/>
-        <dependency org="eigenbase" name="eigenbase-xom" rev="1.3.1"/>
-        <dependency org="eigenbase" name="eigenbase-properties" rev="1.1.2"/>
-        <dependency org="eigenbase" name="eigenbase-resgen" rev="1.3.1"/>
+        <dependency org="eigenbase" name="eigenbase-xom" rev="1.3.2"/>
+        <dependency org="eigenbase" name="eigenbase-properties" rev="1.1.3"/>
+        <dependency org="eigenbase" name="eigenbase-resgen" rev="1.3.2"/>
         <dependency org="sun" name="jlfgr" rev="1.0"/>
         <dependency org="com.sun" name="rt-jdk1.5" rev="1.5.0_22" conf="codegen->default" />
         <dependency org="net.java.openjdk" name="ctsym-java6" rev="1.6.0_24" conf="codegen->default" />
@@ -81,7 +81,12 @@
         <dependency org="xalan" name="xalan" rev="2.6.0"/>
         <dependency org="xerces" name="xercesImpl" rev="2.9.1"/>
 
-        <!-- JDK 1.4 backwards compatibility jars -->
+        <dependency org="biz.aQute" name="bnd" rev="2.3.0" conf="codegen->default">
+          <artifact name="bnd" ext="jar"/>
+        </dependency>
+
+
+      <!-- JDK 1.4 backwards compatibility jars -->
         <dependency org="backport-util-concurrent" 
                 name="backport-util-concurrent" rev="3.1"
                 conf="default-jdk1.4->default"/>

--- a/mondrian.bnd
+++ b/mondrian.bnd
@@ -1,0 +1,5 @@
+Import-Package: !org.junit.*,!junit.*,org.olap4j.driver.xmla;resolution:=optional,org.olap4j.driver.xmla.proxy;resolution:=optional,org.olap4j.test;resolution:=optional,mondrian.xmla,mondrian.xmla.impl,*
+Export-Package: !mondrian.xmla, !mondrian.xmla.*,*
+DynamicImport-Package: *
+Bundle-Name: mondrian
+Bundle-SymbolicName: mondrian

--- a/src/main/OSGI-INF/blueprint/beans.xml
+++ b/src/main/OSGI-INF/blueprint/beans.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bp:blueprint xmlns="http://www.springframework.org/schema/beans"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:cm="http://www.eclipse.org/gemini/blueprint/schema/blueprint-compendium"
+           xmlns:bp="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+           xsi:schemaLocation="
+           http://www.eclipse.org/gemini/blueprint/schema/blueprint-compendium http://www.eclipse.org/gemini/blueprint/schema/blueprint-compendium/gemini-blueprint-compendium.xsd
+           http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
+           http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd"
+           default-activation="eager">
+
+<bean class="mondrian.osgi.PropertiesService" id="props">
+  <!-- inject properties -->
+  <property name="properties">
+    <cm:cm-properties persistent-id="mondrian"/>
+  </property>
+
+  <!-- re-inject properties on update -->
+  <cm:managed-properties persistent-id="mondrian" autowire-on-update="true"
+                         update-method="setProperties"/>
+</bean>
+
+<!-- Declare then publish Mondrian Olap4J Driver -->
+<bean class="mondrian.olap4j.MondrianOlap4jDriver" id="driver"/>
+
+<bp:service interface="java.sql.Driver" ref="driver">
+  <bp:service-properties>
+    <entry key="name" value="mondrian4"/>
+  </bp:service-properties>
+</bp:service>
+
+</bp:blueprint>
+
+

--- a/src/main/mondrian/osgi/PropertiesService.java
+++ b/src/main/mondrian/osgi/PropertiesService.java
@@ -1,0 +1,31 @@
+/*
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (C) 2013-2013 Pentaho
+// All Rights Reserved.
+*/
+package mondrian.osgi;
+
+import mondrian.olap.MondrianProperties;
+
+import java.util.Map;
+
+/**
+ * Recives an OSGI Configuration Admin managed map of properties. setProperties
+ * will be call once on initialization and again for any change to the
+ * "mondrian" OSGI configuration.
+ *
+ * User: nbaker
+ * Date: 11/12/13
+ */
+public class PropertiesService {
+
+  public void setProperties(Map<String, ?> properties) {
+    MondrianProperties.instance().clear();
+    MondrianProperties.instance().putAll(properties);
+  }
+}
+// End PropertiesService.java

--- a/src/main/mondrian/util/ClassResolver.java
+++ b/src/main/mondrian/util/ClassResolver.java
@@ -44,7 +44,7 @@ public interface ClassResolver {
     Iterable<URL> getResources(String lookupName) throws IOException;
 
     /** Default resolver. */
-    ClassResolver INSTANCE = new ThreadContextClassResolver();
+    ClassResolver INSTANCE = new LocalClassloaderClassResolver();
 
     /** Implementation of {@link ClassResolver} that calls
      * {@link Thread#getContextClassLoader()} on the current thread. */
@@ -52,6 +52,15 @@ public interface ClassResolver {
         protected ClassLoader getClassLoader() {
             return Thread.currentThread().getContextClassLoader();
         }
+    }
+
+    /** Implementation of {@link ClassResolver} that which returns
+     * this class' ClassLoader. */
+    class LocalClassloaderClassResolver extends AbstractClassResolver {
+      final ClassLoader classLoader = getClass().getClassLoader();
+      protected ClassLoader getClassLoader() {
+        return classLoader;
+      }
     }
 
     /** Partial implementation of {@link ClassResolver}. Derived class just


### PR DESCRIPTION
- Mondrin Configuration and service exposure is done through a standard Blueprint XML beans file. PropertiesService serves as a vehcile for the MondrianProperties
- ClassResolver switched to use the local Classloader of Mondrian as OSGI will provide access to needed classes.
- Build updated to inlcude a BND step, using the mondrian.bnd file as a template for the OSGI manifest entries.
