### PR TITLE
[MONDRIAN-1819]  Mondrian generates timestamp predicates for date fields

### DIFF
--- a/src/main/mondrian/rolap/RolapMember.java
+++ b/src/main/mondrian/rolap/RolapMember.java
@@ -12,6 +12,7 @@ package mondrian.rolap;
 
 import mondrian.olap.*;
 
+import java.sql.Timestamp;
 import java.util.*;
 
 /**
@@ -224,6 +225,8 @@ public interface RolapMember extends Member, RolapCalculation {
             if (key instanceof String
                 || key instanceof Number
                 || key instanceof Boolean
+                || key instanceof Timestamp
+                || key instanceof Date
                 || key == RolapUtil.sqlNullValue)
             {
                 return keyCount == 1

--- a/src/main/mondrian/rolap/RolapSchema.java
+++ b/src/main/mondrian/rolap/RolapSchema.java
@@ -725,7 +725,16 @@ public class RolapSchema extends OlapElementBase implements Schema {
         }
 
         synchronized RolapStar getStar(final String factTableName) {
-            return stars.get(factTableName);
+            for (RolapStar star : getStars()) {
+                final String starFactTable =
+                    star.getFactTable().getTableName();
+                if (starFactTable != null
+                    && starFactTable.equals(factTableName))
+                {
+                    return star;
+                }
+            }
+            return null;
         }
 
         synchronized Collection<RolapStar> getStars() {


### PR DESCRIPTION
1819 is a bug that applied to Mondrian 3.x.  Bringing over the test to lock in functionality in lagunitas as well.
This commit also fixes the RolapSchema.getStar() method, which formerly would always return null.
