### PR TITLE
[MONDRIAN-1694]  Since a native filter can be used even when the context...

### DIFF
--- a/src/main/mondrian/rolap/RolapNativeFilter.java
+++ b/src/main/mondrian/rolap/RolapNativeFilter.java
@@ -9,7 +9,6 @@
 // Copyright (C) 2005-2013 Pentaho
 // All Rights Reserved.
 */
-
 package mondrian.rolap;
 
 import mondrian.mdx.MdxVisitorImpl;
@@ -105,6 +104,7 @@ public class RolapNativeFilter extends RolapNativeSet {
             if (filterExpr != null) {
                 key.add(filterExpr.toString());
             }
+            key.add(getEvaluator().isNonEmpty());
 
             if (this.getEvaluator() instanceof RolapEvaluator) {
                 key.add(

--- a/testsrc/main/mondrian/rolap/NativeFilterMatchingTest.java
+++ b/testsrc/main/mondrian/rolap/NativeFilterMatchingTest.java
@@ -295,6 +295,20 @@ public class NativeFilterMatchingTest extends BatchTestCase {
             getTestContext());
     }
 
+    public void testCachedNativeFilter() {
+        // http://jira.pentaho.com/browse/MONDRIAN-1694
+
+        // verify that the RolapNativeSet cached values from NON EMPTY context
+        // are not reused when not NON EMPTY.
+        verifySameNativeAndNot(
+            "select NON EMPTY Filter([Store].[Store Name].Members, Store.CurrentMember.Name matches \"Store.*\") "
+            + " on 0 from sales",
+            "Filter w/ regex.", getTestContext());
+        verifySameNativeAndNot(
+            "select Filter([Store].[Store Name].Members, Store.CurrentMember.Name matches \"Store.*\") "
+            + " on 0 from sales",
+            "Filter w/ regex.", getTestContext());
+    }
 
     public void testMatchesWithAccessControl() {
         String dimension =


### PR DESCRIPTION
... is not NON EMPTY, the cache key needs to include NON EMPTY state.  Otherwise the resulting tuple

list may not correctly reflect isNonEmpty.
