### PR TITLE
[MONDRIAN-1694]  Since a native filter can be used even when the context...

### DIFF
--- a/src/main/mondrian/rolap/RolapNativeFilter.java
+++ b/src/main/mondrian/rolap/RolapNativeFilter.java
@@ -114,6 +114,7 @@ public class RolapNativeFilter extends RolapNativeSet {
             if (filterExpr != null) {
                 key.add(filterExpr.toString());
             }
+            key.add(getEvaluator().isNonEmpty());
 
             if (this.getEvaluator() instanceof RolapEvaluator) {
                 key.add(

--- a/testsrc/main/mondrian/rolap/NativeFilterMatchingTest.java
+++ b/testsrc/main/mondrian/rolap/NativeFilterMatchingTest.java
@@ -293,6 +293,20 @@ public class NativeFilterMatchingTest extends BatchTestCase {
             getTestContext());
     }
 
+    public void testCachedNativeFilter() {
+        // http://jira.pentaho.com/browse/MONDRIAN-1694
+
+        // verify that the RolapNativeSet cached values from NON EMPTY context
+        // are not reused when not NON EMPTY.
+        verifySameNativeAndNot(
+            "select NON EMPTY Filter([Store].Stores.[Store Name].Members, Store.Stores.CurrentMember.Name matches \"Store.*\") "
+            + " on 0 from sales",
+            "NON EMPTY Filter w/ regex.", getTestContext());
+        verifySameNativeAndNot(
+            "select Filter([Store].Stores.[Store Name].Members, Store.Stores.CurrentMember.Name matches \"Store.*\") "
+            + " on 0 from sales",
+            "Regex filter, not NON EMPTY.", getTestContext());
+    }
 
     public void testMatchesWithAccessControl() {
         // TODO:  Changes made with commit 51c1ac439 which allow pushdown of


### PR DESCRIPTION
... is not NON EMPTY, the cache key needs to include NON EMPTY state.  Otherwise the resulting tuple

list may not correctly reflect isNonEmpty.
(cherry picked from commit ab32ceb)
