### PR TITLE
[MONDRIAN-1844]  Correcting a NPE issue when .getPropertyFormattedValue(...

### DIFF
--- a/src/main/mondrian/olap4j/MondrianOlap4jMember.java
+++ b/src/main/mondrian/olap4j/MondrianOlap4jMember.java
@@ -205,7 +205,9 @@ class MondrianOlap4jMember
     }
 
     public String getPropertyFormattedValue(Property property) {
-        return member.getPropertyFormattedValue(asd(property));
+        mondrian.olap.Property prop = asd(property);
+        return prop == null ? null
+            : member.getPropertyFormattedValue(prop);
     }
 
     public void setProperty(Property property, Object value)


### PR DESCRIPTION
...) is passed  a property object which is either not found in one of the maps, or is of an unknown type.
