### PR TITLE
[MONDRIAN-1867] Syntax error using aliases in the order by clause with M...

### DIFF
--- a/bin/checkFile.awk
+++ b/bin/checkFile.awk
@@ -330,7 +330,7 @@ FNR < headerCount {
 /^\/\/ Copyright .* Pentaho/ && strict > 1 {
     # We assume that '--strict' is only invoked on files currently being
     # edited. Therefore we would expect the copyright to be current.
-    if ($0 !~ /-2013/) {
+    if ($0 !~ /-2014/) {
         error(fname, FNR, "copyright is not current");
     }
 }

--- a/build.xml
+++ b/build.xml
@@ -197,6 +197,7 @@ demo/access/MondrianFoodMart.mdb"/>
       <include name="derby.jar"/>
       <include name="xmlunit.jar"/>
       <include name="junit.jar"/>
+      <include name="mockito-all.jar"/>
     </fileset>
     <!-- this picks up the default log4j.properties -->
     <pathelement path="${basedir}"/>

--- a/ivy.xml
+++ b/ivy.xml
@@ -108,6 +108,7 @@
         <dependency org="junit" name="junit" rev="3.8.1" conf="test->default"/>
         <dependency org="xmlunit" name="xmlunit" rev="1.1" conf="test->default"/>
         <dependency org="monetdb" name="monetdb-jdbc" rev="2.6" conf="test->default"/>
+        <dependency org="org.mockito" name="mockito-all" rev="1.8.5" conf="test->default"/>
 
         <!-- Exclusions -->
         <exclude org="avalon-framework" module="avalon-framework"/>

--- a/src/main/mondrian/spi/impl/Db2Dialect.java
+++ b/src/main/mondrian/spi/impl/Db2Dialect.java
@@ -1,12 +1,11 @@
 /*
-* This software is subject to the terms of the Eclipse Public License v1.0
-* Agreement, available at the following URL:
-* http://www.eclipse.org/legal/epl-v10.html.
-* You must accept the terms of that agreement to use this software.
-*
-* Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (c) 2002-2014 Pentaho Corporation..  All rights reserved.
 */
-
 package mondrian.spi.impl;
 
 import java.sql.Connection;
@@ -41,10 +40,6 @@ public class Db2Dialect extends JdbcDialectImpl {
     }
 
     public boolean supportsGroupingSets() {
-        return true;
-    }
-
-    public boolean requiresOrderByAlias() {
         return true;
     }
 }

--- a/testsrc/main/mondrian/test/NativeSetEvaluationTest.java
+++ b/testsrc/main/mondrian/test/NativeSetEvaluationTest.java
@@ -4,12 +4,8 @@
 // http://www.eclipse.org/legal/epl-v10.html.
 // You must accept the terms of that agreement to use this software.
 //
-<<<<<<< HEAD
-// Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
-=======
-// Copyright (C) 2012-2013 Pentaho and others
+// Copyright (c) 2002-2014 Pentaho Corporation
 // All Rights Reserved.
->>>>>>> [MONDRIAN-1785] Fixes issues with Hive. A lot of SQL related classes had to be fixed. The alias was not used consistently according to the dialect rules. Now all SQL generated uses the aliasses correctly.
 */
 package mondrian.test;
 
@@ -1234,7 +1230,7 @@ public class NativeSetEvaluationTest extends BatchTestCase {
         verifySameNativeAndNot(
             "select filter([Product].[Product Name].members, Measures.[Unit Sales] > 0) on 0 from sales",
             "Native native filter mismatch", ctx);
-       
+
         propSaver.reset();
     }
 }


### PR DESCRIPTION
...ondrian SQL generated against DB2

Change a3012a4 corrected an issue where the alias was not used in the ORDER BY even if requiresOrderByAlias was true for a dialect.
Once that was fixed DB2, ORDER BY queries started failing.  From tests against DB2 10.2 it appears aliases are permitted in the ORDER BY clause only if they are _unquoted_ in the SELECT list.  But expressions are also permitted, so requiresOrderByAlias can be set to false.
