### PR TITLE
[MONDRIAN-1867] Syntax error using aliases in the order by clause with M...

### DIFF
--- a/bin/checkFile.awk
+++ b/bin/checkFile.awk
@@ -330,7 +330,7 @@ FNR < headerCount {
 /^\/\/ Copyright .* Pentaho/ && strict > 1 {
     # We assume that '--strict' is only invoked on files currently being
     # edited. Therefore we would expect the copyright to be current.
-    if ($0 !~ /-2013/) {
+    if ($0 !~ /-2014/) {
         error(fname, FNR, "copyright is not current");
     }
 }

--- a/build.xml
+++ b/build.xml
@@ -196,6 +196,7 @@ demo/access/MondrianFoodMart.mdb"/>
       <include name="derby.jar"/>
       <include name="xmlunit.jar"/>
       <include name="junit.jar"/>
+      <include name="mockito-all.jar"/>
     </fileset>
     <!-- this picks up the default log4j.properties -->
     <pathelement path="${basedir}"/>

--- a/ivy.xml
+++ b/ivy.xml
@@ -108,6 +108,7 @@
         <dependency org="junit" name="junit" rev="3.8.1" conf="test->default"/>
         <dependency org="xmlunit" name="xmlunit" rev="1.1" conf="test->default"/>
         <dependency org="monetdb" name="monetdb-jdbc" rev="2.6" conf="test->default"/>
+        <dependency org="org.mockito" name="mockito-all" rev="1.8.5" conf="test->default"/>
 
         <!-- Exclusions -->
         <exclude org="avalon-framework" module="avalon-framework"/>

--- a/src/main/mondrian/spi/impl/Db2Dialect.java
+++ b/src/main/mondrian/spi/impl/Db2Dialect.java
@@ -4,8 +4,7 @@
 // http://www.eclipse.org/legal/epl-v10.html.
 // You must accept the terms of that agreement to use this software.
 //
-// Copyright (C) 2008-2009 Pentaho
-// All Rights Reserved.
+// Copyright (c) 2002-2014 Pentaho Corporation..  All rights reserved.
 */
 package mondrian.spi.impl;
 
@@ -41,10 +40,6 @@ public class Db2Dialect extends JdbcDialectImpl {
     }
 
     public boolean supportsGroupingSets() {
-        return true;
-    }
-
-    public boolean requiresOrderByAlias() {
         return true;
     }
 }

--- a/testsrc/main/mondrian/rolap/sql/SqlQueryTest.java
+++ b/testsrc/main/mondrian/rolap/sql/SqlQueryTest.java
@@ -5,7 +5,7 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2004-2005 Julian Hyde
-// Copyright (C) 2005-2011 Pentaho and others
+// Copyright (C) 2005-2014 Pentaho and others
 // All Rights Reserved.
 */
 package mondrian.rolap.sql;
@@ -13,10 +13,15 @@ package mondrian.rolap.sql;
 import mondrian.olap.MondrianProperties;
 import mondrian.rolap.BatchTestCase;
 import mondrian.spi.Dialect;
+import mondrian.spi.impl.*;
 import mondrian.test.SqlPattern;
 import mondrian.test.TestContext;
 
+import java.sql.SQLException;
 import java.util.*;
+
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 /**
  * Test for <code>SqlQuery</code>.
@@ -97,6 +102,50 @@ public class SqlQueryTest extends BatchTestCase {
         }
     }
 
+
+    public void testOrderBy() throws SQLException {
+        // Test with requireAlias = true
+        assertEquals(
+            "\norder by\n"
+            + "    CASE WHEN alias IS NULL THEN 1 ELSE 0 END, alias ASC",
+            makeTestSqlQuery("expr", "alias", true, true, true, true)
+            .toString());
+        // requireAlias = false
+        assertEquals(
+            "\norder by\n"
+            + "    CASE WHEN expr IS NULL THEN 1 ELSE 0 END, expr ASC",
+            makeTestSqlQuery("expr", "alias", true, true, true, false)
+                .toString());
+        //  nullable = false
+        assertEquals(
+            "\norder by\n"
+            + "    expr ASC",
+            makeTestSqlQuery("expr", "alias", true, false, true, false)
+                .toString());
+        //  ascending=false, collateNullsLast=false
+        assertEquals(
+            "\norder by\n"
+            + "    CASE WHEN alias IS NULL THEN 0 ELSE 1 END, alias DESC",
+            makeTestSqlQuery("expr", "alias", false, true, false, true)
+                .toString());
+    }
+
+    /**
+     * Builds a SqlQuery with flags set according to params.
+     * Uses a Mockito spy to construct a dialect which will give the desired
+     * boolean value for reqOrderByAlias.
+     */
+    private SqlQuery makeTestSqlQuery(
+        String expr, String alias, boolean ascending,
+        boolean nullable, boolean collateNullsLast, boolean reqOrderByAlias)
+    {
+        JdbcDialectImpl dialect = spy(new JdbcDialectImpl());
+        when(dialect.requiresOrderByAlias()).thenReturn(reqOrderByAlias);
+        SqlQuery query = new SqlQuery(dialect, true);
+        query.addOrderBy(
+            expr, alias, ascending, true, nullable, collateNullsLast);
+        return query;
+    }
 
     public void testToStringForForcedIndexHint() {
         Map<String, String> hints = new HashMap<String, String>();


### PR DESCRIPTION
...ondrian SQL generated against DB2

Change a3012a4 corrected an issue where the alias was not used in the ORDER BY even if requiresOrderByAlias was true for a dialect.
Once that was fixed DB2, ORDER BY queries started failing.  From tests against DB2 10.2 it appears aliases are permitted in the ORDER BY clause only if they are
_unquoted_ in the SELECT list.  But expressions are also permitted, so requiresOrderByAlias can be set to false.
(cherry picked from commit b42fecc)
