### PR TITLE
[MONDRIAN-1785][MONDRIAN-1867] HiveDialect returns ' ` ' (backtick) as t...

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -182,6 +182,7 @@ mondrian/rolap/RolapCubeUsages.java"/>
       <include name="olap4j-xmla.jar"/>
       <include name="xmlunit.jar"/>
       <include name="junit.jar"/>
+      <include name="mockito-all.jar"/>
     </fileset>
     <!-- this picks up the default log4j.properties -->
     <pathelement path="${basedir}"/>

--- a/ivy.xml
+++ b/ivy.xml
@@ -110,6 +110,7 @@
 
         <!-- Test Jars -->
         <dependency org="junit" name="junit" rev="3.8.1" conf="test->default"/>
+        <dependency org="org.mockito" name="mockito-all" rev="1.8.5" conf="test->default"/>
         <dependency org="xmlunit" name="xmlunit" rev="1.3" conf="test->default"/>
         <dependency org="monetdb" name="monetdb-jdbc" rev="2.8-SNAPSHOT" conf="test->default"/>
         <dependency org="pentaho" name="mondrian-data-adventureworks" rev="0.1-SNAPSHOT" conf="test->default"/>

--- a/src/main/mondrian/rolap/RolapNativeTopCount.java
+++ b/src/main/mondrian/rolap/RolapNativeTopCount.java
@@ -6,7 +6,7 @@
 //
 // Copyright (C) 2004-2005 TONBELLER AG
 // Copyright (C) 2005-2005 Julian Hyde
-// Copyright (C) 2005-2013 Pentaho and others
+// Copyright (C) 2005-2014 Pentaho and others
 // All Rights Reserved.
 */
 package mondrian.rolap;
@@ -84,17 +84,19 @@ public class RolapNativeTopCount extends RolapNativeSet {
                     new RolapNativeSql(
                         sqlQuery, starSet.getAggStar(),
                         getEvaluator(), null);
-                String orderBySql = sql.generateTopCountOrderBy(orderByExpr);
-                Dialect dialect = queryBuilder.getDialect();
-                boolean nullable = deduceNullability(orderByExpr);
-                if (dialect.requiresOrderByAlias()) {
-                    String alias = sqlQuery.nextColumnAlias();
-                    alias = dialect.quoteIdentifier(alias);
-                    sqlQuery.addSelect(orderBySql, null, alias);
-                    sqlQuery.addOrderBy(alias, ascending, true, nullable);
-                } else {
-                    sqlQuery.addOrderBy(orderBySql, ascending, true, nullable);
-                }
+                final String orderBySql =
+                    sql.generateTopCountOrderBy(orderByExpr);
+                boolean nullable =
+                    deduceNullability(orderByExpr);
+                final String orderByAlias =
+                    sqlQuery.addSelect(orderBySql, null);
+                sqlQuery.addOrderBy(
+                    orderBySql,
+                    orderByAlias,
+                    ascending,
+                    true,
+                    nullable,
+                    true);
             }
             super.addConstraint(queryBuilder, starSet);
         }

--- a/src/main/mondrian/rolap/SqlMemberSource.java
+++ b/src/main/mondrian/rolap/SqlMemberSource.java
@@ -5,7 +5,7 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2001-2005 Julian Hyde
-// Copyright (C) 2005-2013 Pentaho and others
+// Copyright (C) 2005-2014 Pentaho and others
 // All Rights Reserved.
 */
 package mondrian.rolap;
@@ -249,8 +249,8 @@ public class SqlMemberSource
             if (mustCount[0]) {
                 for (String colDef : columnList) {
                     final String exp = dialect.generateCountExpression(colDef);
-                    sqlQuery.addSelect(exp, null);
-                    sqlQuery.addOrderBy(exp, true, false, true);
+                    String alias = sqlQuery.addSelect(exp, null);
+                    sqlQuery.addOrderBy(exp, alias, true, false, true, true);
                 }
             } else {
                 List<String> list = new ArrayList<String>();

--- a/src/main/mondrian/rolap/sql/SqlQuery.java
+++ b/src/main/mondrian/rolap/sql/SqlQuery.java
@@ -5,7 +5,7 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2002-2005 Julian Hyde
-// Copyright (C) 2005-2013 Pentaho and others
+// Copyright (C) 2005-2014 Pentaho and others
 // All Rights Reserved.
 //
 // jhyde, Mar 21, 2002
@@ -528,7 +528,7 @@ public class SqlQuery {
         boolean prepend,
         boolean nullable)
     {
-        this.addOrderBy(expr, ascending, prepend, nullable, true);
+        this.addOrderBy(expr, expr, ascending, prepend, nullable, true);
     }
 
     /**
@@ -542,6 +542,7 @@ public class SqlQuery {
      */
     public void addOrderBy(
         String expr,
+        String alias,
         boolean ascending,
         boolean prepend,
         boolean nullable,
@@ -549,7 +550,9 @@ public class SqlQuery {
     {
         String orderExpr =
             dialect.generateOrderItem(
-                expr,
+                dialect.requiresOrderByAlias()
+                    ? alias
+                    : expr,
                 nullable,
                 ascending,
                 collateNullsLast);

--- a/src/main/mondrian/rolap/sql/SqlQueryBuilder.java
+++ b/src/main/mondrian/rolap/sql/SqlQueryBuilder.java
@@ -4,7 +4,7 @@
 // http://www.eclipse.org/legal/epl-v10.html.
 // You must accept the terms of that agreement to use this software.
 //
-// Copyright (C) 2013-2013 Pentaho
+// Copyright (C) 2013-2014 Pentaho
 // All Rights Reserved.
 */
 package mondrian.rolap.sql;
@@ -285,12 +285,10 @@ public class SqlQueryBuilder {
             sqlQuery.addGroupBy(expString, alias);
             break;
         case SELECT_ORDER:
-            sqlQuery.addOrderBy(expString, true, false, true);
             alias = sqlQuery.addSelect(
                 expString, column.physColumn.getInternalType(), alias0);
             break;
         case SELECT_GROUP_ORDER:
-            sqlQuery.addOrderBy(expString, true, false, true);
             alias = sqlQuery.addSelect(
                 expString, column.physColumn.getInternalType(), alias0);
             sqlQuery.addGroupBy(expString, alias);
@@ -304,7 +302,7 @@ public class SqlQueryBuilder {
         switch (clause) {
         case SELECT_GROUP_ORDER:
         case SELECT_ORDER:
-            sqlQuery.addOrderBy(expString, true, false, true);
+            sqlQuery.addOrderBy(expString, alias, true, false, true, true);
             orderBitSet.set(ordinal);
         }
         return ordinal;

--- a/src/main/mondrian/spi/Dialect.java
+++ b/src/main/mondrian/spi/Dialect.java
@@ -4,7 +4,7 @@
 // http://www.eclipse.org/legal/epl-v10.html.
 // You must accept the terms of that agreement to use this software.
 //
-// Copyright (C) 2008-2013 Pentaho
+// Copyright (C) 2008-2014 Pentaho
 // All Rights Reserved.
 */
 package mondrian.spi;
@@ -532,7 +532,7 @@ public interface Dialect {
      *
      * would be legal.</p>
      *
-     * <p>MySQL, DB2 and Ingres are examples of such dialects.</p>
+     * <p>Ingres and Hive are examples of such dialects.</p>
      *
      * @return Whether this Dialect can include expressions in the ORDER BY
      *   clause only by adding an expression to the SELECT clause and using

--- a/src/main/mondrian/spi/impl/Db2Dialect.java
+++ b/src/main/mondrian/spi/impl/Db2Dialect.java
@@ -4,7 +4,7 @@
 // http://www.eclipse.org/legal/epl-v10.html.
 // You must accept the terms of that agreement to use this software.
 //
-// Copyright (C) 2008-2009 Pentaho
+// Copyright (C) 2008-2014 Pentaho
 // All Rights Reserved.
 */
 package mondrian.spi.impl;
@@ -41,10 +41,6 @@ public class Db2Dialect extends JdbcDialectImpl {
     }
 
     public boolean supportsGroupingSets() {
-        return true;
-    }
-
-    public boolean requiresOrderByAlias() {
         return true;
     }
 }

--- a/src/main/mondrian/spi/impl/HiveDialect.java
+++ b/src/main/mondrian/spi/impl/HiveDialect.java
@@ -4,7 +4,7 @@
 // http://www.eclipse.org/legal/epl-v10.html.
 // You must accept the terms of that agreement to use this software.
 //
-// Copyright (C) 2011-2013 Pentaho and others
+// Copyright (C) 2011-2014 Pentaho and others
 // All Rights Reserved.
 */
 package mondrian.spi.impl;
@@ -49,18 +49,7 @@ public class HiveDialect extends JdbcDialectImpl {
     protected String deduceIdentifierQuoteString(
         DatabaseMetaData databaseMetaData)
     {
-        try {
-            final String quoteIdentifierString =
-                databaseMetaData.getIdentifierQuoteString();
-            return "".equals(quoteIdentifierString)
-                // quoting not supported
-                ? null
-                : quoteIdentifierString;
-        } catch (SQLException e) {
-            // Not supported by HiveDatabaseMetaData; do nothing if catch an
-            // Exception
-            return "`";
-        }
+        return null;
     }
 
     protected Set<List<Integer>> deduceSupportedResultSetStyles(
@@ -99,7 +88,15 @@ public class HiveDialect extends JdbcDialectImpl {
         return true;
     }
 
+    public boolean requiresGroupByAlias() {
+        return false;
+    }
+
     public boolean requiresUnionOrderByExprToBeInSelectClause() {
+        return false;
+    }
+
+    public boolean requiresUnionOrderByOrdinal() {
         return false;
     }
 

--- a/src/main/mondrian/spi/impl/MonetDbDialect.java
+++ b/src/main/mondrian/spi/impl/MonetDbDialect.java
@@ -4,7 +4,7 @@
 // http://www.eclipse.org/legal/epl-v10.html.
 // You must accept the terms of that agreement to use this software.
 //
-// Copyright (C) 2012-2013 Pentaho
+// Copyright (C) 2012-2014 Pentaho
 // All Rights Reserved.
 */
 package mondrian.spi.impl;
@@ -53,6 +53,11 @@ public class MonetDbDialect extends JdbcDialectImpl {
 
     @Override
     public boolean requiresAliasForFromQuery() {
+        return true;
+    }
+
+    @Override
+    public boolean requiresGroupByAlias() {
         return true;
     }
 

--- a/src/main/mondrian/spi/impl/MySqlDialect.java
+++ b/src/main/mondrian/spi/impl/MySqlDialect.java
@@ -4,7 +4,7 @@
 // http://www.eclipse.org/legal/epl-v10.html.
 // You must accept the terms of that agreement to use this software.
 //
-// Copyright (C) 2008-2012 Pentaho
+// Copyright (C) 2008-2014 Pentaho
 // All Rights Reserved.
 */
 package mondrian.spi.impl;
@@ -247,10 +247,6 @@ public class MySqlDialect extends JdbcDialectImpl {
                 return "ISNULL(" + expr + ") DESC, " + expr + " DESC";
             }
         }
-    }
-
-    public boolean requiresOrderByAlias() {
-        return true;
     }
 
     public boolean requiresHavingAlias() {

--- a/testsrc/main/mondrian/rolap/SqlTupleReaderTest.java
+++ b/testsrc/main/mondrian/rolap/SqlTupleReaderTest.java
@@ -1,0 +1,337 @@
+/*
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (C) 2005-2014 Pentaho and others
+// All Rights Reserved.
+*/
+package mondrian.rolap;
+
+import mondrian.olap.*;
+import mondrian.rolap.sql.SqlQueryBuilder;
+import mondrian.rolap.sql.TupleConstraint;
+import mondrian.spi.Dialect;
+import mondrian.spi.impl.JdbcDialectImpl;
+import mondrian.test.FoodMartTestCase;
+
+import static org.mockito.Mockito.*;
+
+public class SqlTupleReaderTest extends FoodMartTestCase {
+
+    private final RolapMeasureGroup salesMeasureGroup = getCube("Sales")
+        .getMeasureGroups().get(0);
+    private SqlTupleReader.ColumnLayoutBuilder layoutBuilder;
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        propSaver.set(MondrianProperties.instance().GenerateFormattedSql, true);
+        layoutBuilder = new SqlTupleReader.ColumnLayoutBuilder();
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        propSaver.reset();
+    }
+
+    public void testAddLevelMembersSqlOrderByAliasCalcExpr() {
+        RolapStarSet starSet = new RolapStarSet(
+            salesMeasureGroup.getStar(), salesMeasureGroup, null);
+        SqlTupleReader sqlTupleReader = new SqlTupleReader(
+            DefaultTupleConstraint.instance());
+        Dialect spyDialect = spy(new JdbcDialectImpl());
+        when(spyDialect.requiresOrderByAlias()).thenReturn(true);
+        when(spyDialect.getDatabaseProduct()).thenReturn(
+            Dialect.DatabaseProduct.MYSQL);
+
+        final SqlQueryBuilder queryBuilder =
+            new SqlQueryBuilder(spyDialect, "", layoutBuilder);
+        sqlTupleReader.addLevelMemberSql(
+            queryBuilder,
+            getLevel(getCube("Sales"), "Customer", "Customers", "Name"),
+            starSet, 0, 1);
+
+        getTestContext().assertSqlEquals(
+            "select\n"
+            + "    customer.country as c0,\n"
+            + "    customer.state_province as c1,\n"
+            + "    customer.city as c2,\n"
+            + "    CONCAT(customer.fname, ' ', customer.lname) as c3,\n"
+            + "    customer.customer_id as c4\n"
+            + "from\n"
+            + "    customer as customer\n"
+            + "group by\n"
+            + "    customer.country,\n"
+            + "    customer.state_province,\n"
+            + "    customer.city,\n"
+            + "    CONCAT(customer.fname, ' ', customer.lname),\n"
+            + "    customer.customer_id\n"
+            + "order by\n"
+            + "    CASE WHEN c0 IS NULL THEN 1 ELSE 0 END, c0 ASC,\n"
+            + "    CASE WHEN c1 IS NULL THEN 1 ELSE 0 END, c1 ASC,\n"
+            + "    CASE WHEN c2 IS NULL THEN 1 ELSE 0 END, c2 ASC,\n"
+            + "    CASE WHEN c3 IS NULL THEN 1 ELSE 0 END, c3 ASC,\n"
+            + "    CASE WHEN c4 IS NULL THEN 1 ELSE 0 END, c4 ASC",
+            queryBuilder.toSqlAndTypes().getKey(), -1);
+    }
+
+    public void testAddLevelMembersSqlWithOneLevel() {
+        RolapStarSet starSet = new RolapStarSet(
+            salesMeasureGroup.getStar(), salesMeasureGroup, null);
+        SqlTupleReader sqlTupleReader = new SqlTupleReader(
+            DefaultTupleConstraint.instance());
+        Dialect spyDialect = spy(new JdbcDialectImpl());
+        when(spyDialect.requiresOrderByAlias()).thenReturn(false);
+        when(spyDialect.getDatabaseProduct()).thenReturn(
+            Dialect.DatabaseProduct.MYSQL);
+
+        final SqlQueryBuilder queryBuilder =
+            new SqlQueryBuilder(spyDialect, "", layoutBuilder);
+        sqlTupleReader.addLevelMemberSql(
+            queryBuilder,
+            getLevel(getCube("Sales"), "Time", "Time", "Quarter"),
+            starSet, 0, 1);
+
+        getTestContext().assertSqlEquals(
+            "select\n"
+            + "    time_by_day.the_year as c0,\n"
+            + "    time_by_day.quarter as c1\n"
+            + "from\n"
+            + "    time_by_day as time_by_day\n"
+            + "group by\n"
+            + "    time_by_day.the_year,\n"
+            + "    time_by_day.quarter\n"
+            + "order by\n"
+            + "    CASE WHEN time_by_day.the_year IS NULL THEN 1 ELSE 0 END, time_by_day.the_year ASC,\n"
+            + "    CASE WHEN time_by_day.quarter IS NULL THEN 1 ELSE 0 END, time_by_day.quarter ASC",
+            queryBuilder.toSqlAndTypes().getKey(), -1);
+    }
+
+    public void testAddLevelMembersSqlWithTwoLevels() {
+        RolapStarSet starSet = new RolapStarSet(
+            salesMeasureGroup.getStar(), salesMeasureGroup, null);
+        SqlTupleReader sqlTupleReader = new SqlTupleReader(
+            DefaultTupleConstraint.instance());
+        Dialect spyDialect = spy(new JdbcDialectImpl());
+        when(spyDialect.requiresOrderByAlias()).thenReturn(false);
+        when(spyDialect.getDatabaseProduct()).thenReturn(
+            Dialect.DatabaseProduct.MYSQL);
+
+        final SqlQueryBuilder queryBuilder =
+            new SqlQueryBuilder(spyDialect, "", layoutBuilder);
+        sqlTupleReader.addLevelMemberSql(
+            queryBuilder,
+            getLevel(getCube("Sales"), "Time", "Time", "Quarter"),
+            starSet, 0, 1);
+        sqlTupleReader.addLevelMemberSql(
+            queryBuilder,
+            getLevel(getCube("Sales"), "Store", "Stores", "Store Name"),
+            starSet, 0, 1);
+
+        getTestContext().assertSqlEquals(
+            "select\n"
+            + "    time_by_day.the_year as c0,\n"
+            + "    time_by_day.quarter as c1,\n"
+            + "    store.store_country as c2,\n"
+            + "    store.store_state as c3,\n"
+            + "    store.store_city as c4,\n"
+            + "    store.store_name as c5,\n"
+            + "    store.store_type as c6,\n"
+            + "    store.store_manager as c7,\n"
+            + "    store.store_sqft as c8,\n"
+            + "    store.grocery_sqft as c9,\n"
+            + "    store.frozen_sqft as c10,\n"
+            + "    store.meat_sqft as c11,\n"
+            + "    store.coffee_bar as c12,\n"
+            + "    store.store_street_address as c13\n"
+            + "from\n"
+            + "    time_by_day as time_by_day,\n"
+            + "    store as store\n"
+            + "group by\n"
+            + "    time_by_day.the_year,\n"
+            + "    time_by_day.quarter,\n"
+            + "    store.store_country,\n"
+            + "    store.store_state,\n"
+            + "    store.store_city,\n"
+            + "    store.store_name\n"
+            + "order by\n"
+            + "    CASE WHEN time_by_day.the_year IS NULL THEN 1 ELSE 0 END, time_by_day.the_year ASC,\n"
+            + "    CASE WHEN time_by_day.quarter IS NULL THEN 1 ELSE 0 END, time_by_day.quarter ASC,\n"
+            + "    CASE WHEN store.store_country IS NULL THEN 1 ELSE 0 END, store.store_country ASC,\n"
+            + "    CASE WHEN store.store_state IS NULL THEN 1 ELSE 0 END, store.store_state ASC,\n"
+            + "    CASE WHEN store.store_city IS NULL THEN 1 ELSE 0 END, store.store_city ASC,\n"
+            + "    CASE WHEN store.store_name IS NULL THEN 1 ELSE 0 END, store.store_name ASC",
+            queryBuilder.toSqlAndTypes().getKey(), -1);
+    }
+
+    public void testAddLevelMembersSqlWithOneLevelReqOrderAlias() {
+        RolapStarSet starSet = new RolapStarSet(
+            salesMeasureGroup.getStar(), salesMeasureGroup, null);
+        SqlTupleReader sqlTupleReader = new SqlTupleReader(
+            DefaultTupleConstraint.instance());
+        Dialect spyDialect = spy(new JdbcDialectImpl());
+        when(spyDialect.requiresOrderByAlias()).thenReturn(true);
+        when(spyDialect.getDatabaseProduct()).thenReturn(
+            Dialect.DatabaseProduct.HIVE);
+
+        SqlQueryBuilder queryBuilder =
+            new SqlQueryBuilder(spyDialect, "", layoutBuilder);
+        sqlTupleReader.addLevelMemberSql(
+            queryBuilder,
+            getLevel(getCube("Sales"), "Time", "Time", "Quarter"),
+            starSet, 0, 1);
+        getTestContext().assertSqlEquals(
+            "select\n"
+            + "    time_by_day.the_year as c0,\n"
+            + "    time_by_day.quarter as c1\n"
+            + "from\n"
+            + "    time_by_day as time_by_day\n"
+            + "group by\n"
+            + "    time_by_day.the_year,\n"
+            + "    time_by_day.quarter\n"
+            + "order by\n"
+            + "    CASE WHEN c0 IS NULL THEN 1 ELSE 0 END, c0 ASC,\n"
+            + "    CASE WHEN c1 IS NULL THEN 1 ELSE 0 END, c1 ASC",
+            queryBuilder.toSqlAndTypes().getKey(), -1);
+    }
+
+    public void testAddLevelMembersSqlWithTwoLevelsReqOrderAlias() {
+        RolapStarSet starSet = new RolapStarSet(
+            salesMeasureGroup.getStar(), salesMeasureGroup, null);
+        SqlTupleReader sqlTupleReader = new SqlTupleReader(
+            DefaultTupleConstraint.instance());
+        Dialect spyDialect = spy(new JdbcDialectImpl());
+        when(spyDialect.requiresOrderByAlias()).thenReturn(true);
+        when(spyDialect.getDatabaseProduct()).thenReturn(
+            Dialect.DatabaseProduct.HIVE);
+        final SqlQueryBuilder queryBuilder =
+            new SqlQueryBuilder(spyDialect, "", layoutBuilder);
+        sqlTupleReader.addLevelMemberSql(
+            queryBuilder,
+            getLevel(getCube("Sales"), "Time", "Time", "Quarter"),
+            starSet, 0, 1);
+        sqlTupleReader.addLevelMemberSql(
+            queryBuilder,
+            getLevel(getCube("Sales"), "Store", "Stores", "Store Name"),
+            starSet, 0, 1);
+
+        getTestContext().assertSqlEquals(
+            "select\n"
+            + "    time_by_day.the_year as c0,\n"
+            + "    time_by_day.quarter as c1,\n"
+            + "    store.store_country as c2,\n"
+            + "    store.store_state as c3,\n"
+            + "    store.store_city as c4,\n"
+            + "    store.store_name as c5,\n"
+            + "    store.store_type as c6,\n"
+            + "    store.store_manager as c7,\n"
+            + "    store.store_sqft as c8,\n"
+            + "    store.grocery_sqft as c9,\n"
+            + "    store.frozen_sqft as c10,\n"
+            + "    store.meat_sqft as c11,\n"
+            + "    store.coffee_bar as c12,\n"
+            + "    store.store_street_address as c13\n"
+            + "from\n"
+            + "    time_by_day as time_by_day,\n"
+            + "    store as store\n"
+            + "group by\n"
+            + "    time_by_day.the_year,\n"
+            + "    time_by_day.quarter,\n"
+            + "    store.store_country,\n"
+            + "    store.store_state,\n"
+            + "    store.store_city,\n"
+            + "    store.store_name\n"
+            + "order by\n"
+            + "    CASE WHEN c0 IS NULL THEN 1 ELSE 0 END, c0 ASC,\n"
+            + "    CASE WHEN c1 IS NULL THEN 1 ELSE 0 END, c1 ASC,\n"
+            + "    CASE WHEN c2 IS NULL THEN 1 ELSE 0 END, c2 ASC,\n"
+            + "    CASE WHEN c3 IS NULL THEN 1 ELSE 0 END, c3 ASC,\n"
+            + "    CASE WHEN c4 IS NULL THEN 1 ELSE 0 END, c4 ASC,\n"
+            + "    CASE WHEN c5 IS NULL THEN 1 ELSE 0 END, c5 ASC",
+            queryBuilder.toSqlAndTypes().getKey(), -1);
+    }
+
+
+    public void testMakeLevelMembersSqlMultipleMeasureGroups() {
+        TupleConstraint mockConstraint = mock(TupleConstraint.class);
+        RolapCube warehouseSales = getCube("Warehouse and Sales");
+        when(mockConstraint.getMeasureGroupList()).thenReturn(
+            warehouseSales.getMeasureGroups());
+        when(mockConstraint.isJoinRequired()).thenReturn(true);
+        SqlTupleReader sqlTupleReader = new SqlTupleReader(mockConstraint);
+        Dialect spyDialect = spy(new JdbcDialectImpl());
+        // verify requireOrderByAlias in dialect doesn't screw up the
+        // ORDER BY when ordinal should be used.
+        when(spyDialect.requiresOrderByAlias()).thenReturn(true);
+        when(spyDialect.getDatabaseProduct()).thenReturn(
+            Dialect.DatabaseProduct.MYSQL);
+        RolapCubeLevel level = getLevel(
+            warehouseSales, "Time", "Time", "Quarter");
+        MemberReader memberReader = RolapSchemaLoader.createMemberReader(
+            level.getHierarchy(), getTestContext().getConnection().getRole());
+        sqlTupleReader.addLevelMembers(
+            level, memberReader.getMemberBuilder(), null);
+
+        getTestContext().assertSqlEquals(
+            "select\n"
+            + "    time_by_day.the_year as c0,\n"
+            + "    time_by_day.quarter as c1\n"
+            + "from\n"
+            + "    sales_fact_1997 as sales_fact_1997,\n"
+            + "    time_by_day as time_by_day\n"
+            + "where\n"
+            + "    sales_fact_1997.time_id = time_by_day.time_id\n"
+            + "group by\n"
+            + "    time_by_day.the_year,\n"
+            + "    time_by_day.quarter\n"
+            + "union\n"
+            + "select\n"
+            + "    time_by_day.the_year as c0,\n"
+            + "    time_by_day.quarter as c1\n"
+            + "from\n"
+            + "    inventory_fact_1997 as inventory_fact_1997,\n"
+            + "    time_by_day as time_by_day\n"
+            + "where\n"
+            + "    inventory_fact_1997.time_id = time_by_day.time_id\n"
+            + "group by\n"
+            + "    time_by_day.the_year,\n"
+            + "    time_by_day.quarter\n"
+            + "order by\n"
+            + "    1 ASC,\n"
+            + "    2 ASC",
+            sqlTupleReader.makeLevelMembersSql(spyDialect).getKey(), -1);
+    }
+
+    private RolapCube getCube(String name) {
+        for (Cube cube
+            : getTestContext().getConnection().getSchema().getCubes())
+        {
+            if (cube.getName().equals(name)) {
+                return (RolapCube)cube;
+            }
+        }
+        return null;
+    }
+
+    private RolapCubeLevel getLevel(
+        RolapCube cube, String dimName, String hierName, String levelName)
+    {
+        for (Dimension dim : cube.getDimensionList()) {
+            if (dim.getName().equals(dimName)) {
+                for (Hierarchy hier : dim.getHierarchyList()) {
+                    if (hier.getName().equals(hierName)) {
+                        for (Level level : hier.getLevelList()) {
+                            if (level.getName().equals(levelName)) {
+                                return (RolapCubeLevel)level;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return null;
+    }
+}
+// End SqlTupleReaderTest.java

--- a/testsrc/main/mondrian/rolap/sql/SqlQueryTest.java
+++ b/testsrc/main/mondrian/rolap/sql/SqlQueryTest.java
@@ -5,7 +5,7 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2004-2005 Julian Hyde
-// Copyright (C) 2005-2013 Pentaho and others
+// Copyright (C) 2005-2014 Pentaho and others
 // All Rights Reserved.
 */
 package mondrian.rolap.sql;
@@ -13,10 +13,17 @@ package mondrian.rolap.sql;
 import mondrian.olap.MondrianProperties;
 import mondrian.rolap.BatchTestCase;
 import mondrian.spi.Dialect;
+import mondrian.spi.impl.JdbcDialectImpl;
 import mondrian.test.SqlPattern;
 import mondrian.test.TestContext;
 
-import java.util.*;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 /**
  * Test for <code>SqlQuery</code>.
@@ -91,6 +98,49 @@ public class SqlQueryTest extends BatchTestCase {
         }
     }
 
+    public void testOrderBy() throws SQLException {
+        // Test with requireAlias = true
+        assertEquals(
+            "\norder by\n"
+            + "    CASE WHEN alias IS NULL THEN 1 ELSE 0 END, alias ASC",
+            makeTestSqlQuery("expr", "alias", true, true, true, true)
+                .toString());
+        // requireAlias = false
+        assertEquals(
+            "\norder by\n"
+            + "    CASE WHEN expr IS NULL THEN 1 ELSE 0 END, expr ASC",
+            makeTestSqlQuery("expr", "alias", true, true, true, false)
+                .toString());
+        //  nullable = false
+        assertEquals(
+            "\norder by\n"
+            + "    expr ASC",
+            makeTestSqlQuery("expr", "alias", true, false, true, false)
+                .toString());
+        //  ascending=false, collateNullsLast=false
+        assertEquals(
+            "\norder by\n"
+            + "    CASE WHEN alias IS NULL THEN 0 ELSE 1 END, alias DESC",
+            makeTestSqlQuery("expr", "alias", false, true, false, true)
+                .toString());
+    }
+
+    /**
+     * Builds a SqlQuery with flags set according to params.
+     * Uses a Mockito spy to construct a dialect which will give the desired
+     * boolean value for reqOrderByAlias.
+     */
+    private SqlQuery makeTestSqlQuery(
+        String expr, String alias, boolean ascending,
+        boolean nullable, boolean collateNullsLast, boolean reqOrderByAlias)
+    {
+        JdbcDialectImpl dialect = spy(new JdbcDialectImpl());
+        when(dialect.requiresOrderByAlias()).thenReturn(reqOrderByAlias);
+        SqlQuery query = new SqlQuery(dialect, true);
+        query.addOrderBy(
+            expr, alias, ascending, true, nullable, collateNullsLast);
+        return query;
+    }
 
     public void testToStringForForcedIndexHint() {
         Map<String, String> hints = new HashMap<String, String>();

--- a/testsrc/main/mondrian/test/TestContext.java
+++ b/testsrc/main/mondrian/test/TestContext.java
@@ -5,7 +5,7 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2002-2005 Julian Hyde
-// Copyright (C) 2005-2013 Pentaho and others
+// Copyright (C) 2005-2014 Pentaho and others
 // All Rights Reserved.
 */
 package mondrian.test;
@@ -1950,7 +1950,9 @@ public class TestContext {
 
         Assert.assertEquals(transformedExpectedSql, transformedActualSql);
 
-        checkSqlAgainstDatasource(actualSql, expectedRows);
+        if (expectedRows >= 0) {
+            checkSqlAgainstDatasource(actualSql, expectedRows);
+        }
     }
 
     /**


### PR DESCRIPTION
...he character to use to quote field names.

Merge of Luc's changes 00e3d, a3012,75bc49 from master.  This change includes fixes for the Dialect.requireOrderByAlias property, which was formerly not being honored.
This commit also addresses MONDRIAN-1867, which is a DB2 bug that was introduced on master once the requireOrderByAlias property started being used.
DB2 (at least version 10.2+) does not require order by alias.
