### PR TITLE
[MONDRIAN-1776] PhysStatistic.getRelationCardinality() was using an inva...

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -182,6 +182,7 @@ mondrian/rolap/RolapCubeUsages.java"/>
       <include name="olap4j-xmla.jar"/>
       <include name="xmlunit.jar"/>
       <include name="junit.jar"/>
+      <include name="mockito-all.jar"/>
     </fileset>
     <!-- this picks up the default log4j.properties -->
     <pathelement path="${basedir}"/>

--- a/ivy.xml
+++ b/ivy.xml
@@ -110,6 +110,7 @@
 
         <!-- Test Jars -->
         <dependency org="junit" name="junit" rev="3.8.1" conf="test->default"/>
+        <dependency org="org.mockito" name="mockito-all" rev="1.8.5" conf="test->default"/>
         <dependency org="xmlunit" name="xmlunit" rev="1.3" conf="test->default"/>
         <dependency org="monetdb" name="monetdb-jdbc" rev="2.8-SNAPSHOT" conf="test->default"/>
         <dependency org="pentaho" name="mondrian-data-adventureworks" rev="0.1-SNAPSHOT" conf="test->default"/>

--- a/src/main/mondrian/rolap/RolapSchema.java
+++ b/src/main/mondrian/rolap/RolapSchema.java
@@ -5,7 +5,7 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2001-2005 Julian Hyde
-// Copyright (C) 2005-2013 Pentaho and others
+// Copyright (C) 2005-2014 Pentaho and others
 // All Rights Reserved.
 */
 package mondrian.rolap;
@@ -2826,10 +2826,11 @@ public class RolapSchema extends OlapElementBase implements Schema {
             if (approxRowCount >= 0) {
                 return approxRowCount;
             }
-            if (relation instanceof MondrianDef.Table) {
-                final MondrianDef.Table table = (MondrianDef.Table) relation;
+            if (false && relation instanceof RolapSchema.PhysTable) {
+                final RolapSchema.PhysTable table =
+                    (RolapSchema.PhysTable) relation;
                 return getTableCardinality(
-                    null, table.schema, table.name);
+                    null, table.getSchemaName(), table.name);
             } else {
                 final SqlQuery sqlQuery = new SqlQuery(dialect);
                 sqlQuery.addSelect("1", null);

--- a/testsrc/main/mondrian/rolap/RolapSchemaTest.java
+++ b/testsrc/main/mondrian/rolap/RolapSchemaTest.java
@@ -1,0 +1,99 @@
+/*
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (C) 2003-2005 Julian Hyde
+// Copyright (C) 2005-2014 Pentaho
+// All Rights Reserved.
+*/
+package mondrian.rolap;
+
+import mondrian.server.Execution;
+import mondrian.server.Statement;
+import mondrian.server.StatementImpl;
+import mondrian.spi.Dialect;
+import mondrian.spi.StatisticsProvider;
+import mondrian.spi.impl.JdbcDialectImpl;
+
+import junit.framework.TestCase;
+
+import javax.sql.DataSource;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.Mockito.*;
+
+public class RolapSchemaTest extends TestCase {
+
+    public static final int QUERY_CARD_VAL = 1010;
+    public static final int TABLE_CARD_VAL = 2010;
+    public static final int APPROX_CARD    = 3010;
+
+    public void testGetRelationCardinalityWithTable() {
+        StatisticsProvider statsProv = mock(StatisticsProvider.class);
+        RolapSchema.PhysTable table = mock(RolapSchema.PhysTable.class);
+        RolapSchema.PhysStatistic physStatistic = buildTestPhysStatistic(
+            statsProv);
+        assertEquals(
+            TABLE_CARD_VAL,
+            physStatistic.getRelationCardinality(table, "alias", -1));
+        assertEquals(
+            APPROX_CARD,
+            physStatistic.getRelationCardinality(table, "alias", APPROX_CARD));
+        verify(statsProv).getTableCardinality(
+            any(Dialect.class), any(DataSource.class),
+            anyString(), anyString(), anyString(), any(Execution.class));
+    }
+
+    public void testGetRelationCardinalityWithQuery() {
+        RolapSchema.PhysRelation[] relations = new RolapSchema.PhysRelation[] {
+            spy(new RolapSchema.PhysInlineTable(null, "alias")),
+            spy(new RolapSchema.PhysView(null, "alias", "sql")) };
+
+        StatisticsProvider statsProv = mock(StatisticsProvider.class);
+        RolapSchema.PhysStatistic physStatistic = buildTestPhysStatistic(
+            statsProv);
+        for (RolapSchema.PhysRelation relation : relations) {
+            assertEquals(
+                QUERY_CARD_VAL,
+                physStatistic.getRelationCardinality(relation, "alias", -1));
+            assertEquals(
+                APPROX_CARD,
+                physStatistic.getRelationCardinality(
+                    relation, "alias", APPROX_CARD));
+        }
+        verify(statsProv, times(relations.length))
+            .getQueryCardinality(
+                any(Dialect.class), any(DataSource.class),
+                anyString(), any(Execution.class));
+    }
+
+    private RolapSchema.PhysStatistic buildTestPhysStatistic(
+        StatisticsProvider statsProv)
+    {
+        when(
+            statsProv.getTableCardinality(
+                any(Dialect.class),
+                any(DataSource.class),
+                anyString(), anyString(), anyString(), any(Execution.class)))
+            .thenReturn(TABLE_CARD_VAL);
+        Dialect spyDialect = spy(new JdbcDialectImpl());
+        when(statsProv.getQueryCardinality(
+            any(Dialect.class), any(DataSource.class),
+            anyString(), any(Execution.class))).thenReturn(QUERY_CARD_VAL);
+        when(spyDialect.getDatabaseProduct()).thenReturn(
+            Dialect.DatabaseProduct.MYSQL);
+        List<StatisticsProvider> statsProvs =
+            new ArrayList<StatisticsProvider>();
+        statsProvs.add(statsProv);
+        when(spyDialect.getStatisticsProviders()).thenReturn(statsProvs);
+        RolapConnection conn = mock(RolapConnection.class);
+        Statement statement = mock(StatementImpl.class);
+        when(conn.getInternalStatement()).thenReturn(statement);
+        return new RolapSchema.PhysStatistic(spyDialect, conn);
+    }
+}
+// End RolapSchemaTest.java


### PR DESCRIPTION
...lid instanceof comparison, checking whether the PhysRelation was of type MondrianDef.Table,
when RolapSchema.PhysTable was intended.  Because of this all cardinality checks would use the stats provider's .getQueryCardinality() method for making the determination, which should be accurate but may be more costly.

This was also causing issues with mongolap since the Mongo stats provider does not implement support for .getQueryCardinality().
