### PR TITLE
[MONDRIAN-1949] Add generic method to identify a database product.

### DIFF
--- a/src/main/mondrian/spi/Dialect.java
+++ b/src/main/mondrian/spi/Dialect.java
@@ -859,6 +859,15 @@ public interface Dialect {
                 return this;
             }
         }
+
+        public static DatabaseProduct getDatabaseProduct(String name) {
+            for (DatabaseProduct databaseProduct : values()) {
+                if (databaseProduct.name().equalsIgnoreCase(name)) {
+                    return databaseProduct;
+                }
+            }
+            return UNKNOWN;
+        }
     }
 
     /**

--- a/src/main/mondrian/spi/impl/JdbcDialectImpl.java
+++ b/src/main/mondrian/spi/impl/JdbcDialectImpl.java
@@ -1106,7 +1106,7 @@ public class JdbcDialectImpl implements Dialect {
         } else if (upperProductName.indexOf("VECTORWISE") >= 0) {
             return DatabaseProduct.VECTORWISE;
         } else {
-            return DatabaseProduct.UNKNOWN;
+            return DatabaseProduct.getDatabaseProduct(upperProductName);
         }
     }
 


### PR DESCRIPTION
A hard-coded if-then-else block exists in JdbcDialectImpl.getProduct method. Observation shows that most of these branches involve a simple toUpper mapping of the database product name which otherwise directly maps to the enumeration names in "src/main/mondrian/spi/Dialect.java". This diff adds a static method to the enum that performs a comparison to enum names to find a match, which would effectively reduce the amount of if-then-else code at the call site in JdbcDialectImpl.getProduct from 82 LOC to 29 LOC, making the overall registration and integration procedure for new database dialects more straightforward.
