### PR TITLE
[MONDRIAN-1961] - Multi-byte characters in mondrian.xml files aren't read back in properly

### DIFF
--- a/src/main/mondrian/olap/Util.java
+++ b/src/main/mondrian/olap/Util.java
@@ -3377,11 +3377,7 @@ public class Util extends XOMUtil {
         InputStream in = readVirtualFile(catalogUrl);
         try {
             final byte[] bytes = Util.readFully(in, 1024);
-            final char[] chars = new char[bytes.length];
-            for (int i = 0; i < chars.length; i++) {
-                chars[i] = (char) bytes[i];
-            }
-            return new String(chars);
+            return new String(bytes);
         } finally {
             if (in != null) {
                 in.close();


### PR DESCRIPTION
[MONDRIAN-1961] - Multi-byte characters in mondrian.xml files aren't read back in properly

One question i have... should we specify the encoding as UTF-8 here rather than just taking the default encoding from the OS?
