### PR TITLE
[CLEANUP] - these are all changes to support the change in FunUtil.compa...

### DIFF
--- a/src/main/mondrian/olap/Util.java
+++ b/src/main/mondrian/olap/Util.java
@@ -1098,7 +1098,7 @@ public class Util extends XOMUtil {
             if (matchType.isExact() || hierarchy.hasAll()) {
                 rc = rootMember.getName().compareToIgnoreCase(memberName.name);
             } else {
-                rc = FunUtil.compareSiblingMembers(
+                rc = FunUtil.compareSiblingMembersByName(
                     rootMember,
                     searchMember);
             }
@@ -1109,7 +1109,7 @@ public class Util extends XOMUtil {
                 if (matchType == MatchType.BEFORE) {
                     if (rc < 0
                         && (bestMatch == -1
-                            || FunUtil.compareSiblingMembers(
+                            || FunUtil.compareSiblingMembersByName(
                                 rootMember,
                                 rootMembers.get(bestMatch)) > 0))
                     {
@@ -1118,7 +1118,7 @@ public class Util extends XOMUtil {
                 } else if (matchType == MatchType.AFTER) {
                     if (rc > 0
                         && (bestMatch == -1
-                            || FunUtil.compareSiblingMembers(
+                            || FunUtil.compareSiblingMembersByName(
                                 rootMember,
                                 rootMembers.get(bestMatch)) < 0))
                     {

--- a/src/main/mondrian/olap/fun/FunUtil.java
+++ b/src/main/mondrian/olap/fun/FunUtil.java
@@ -1872,16 +1872,8 @@ public class FunUtil extends Util {
     }
 
     /**
-     * Compares two members which are known to have the same parent.
-     *
-     * First, compare by ordinal.
-     * This is only valid now we know they're siblings, because
-     * ordinals are only unique within a parent.
-     * If the dimension does not use ordinals, both ordinals
-     * will be -1.
-     *
-     * <p>If the ordinals do not differ, compare using regular member
-     * comparison.
+     * Compares two members which are known to have the same parent using their
+     * order keys.
      *
      * @param m1 First member
      * @param m2 Second member
@@ -1904,28 +1896,34 @@ public class FunUtil extends Util {
         }
         final Comparable k1 = m1.getOrderKey();
         final Comparable k2 = m2.getOrderKey();
-        if (notNull(k1) && notNull(k2)) {
-            //noinspection unchecked
-            return k1.compareTo(k2);
-        }
-
-        Util.deprecated("ordinal to be replaced with order key", false);
-        int m1Ordinal = m1.getOrdinal();
-        int m2Ordinal = m2.getOrdinal();
-
-        if (m1Ordinal >= 0 && m2Ordinal >= 0) {
-            int c = Util.compare(m1Ordinal, m2Ordinal);
-            if (c != 0) {
-                return c;
-            }
-        }
-        //noinspection unchecked
-        return m1.compareTo(m2);
+        return Util.compare(k1, k2);
     }
 
-  private static boolean notNull(Comparable k) {
-    return k != null && k != RolapUtil.sqlNullValue;
-  }
+    /**
+     * Compares two members which are known to have the same parent by their
+     * names.
+     *
+     * @param m1 First member
+     * @param m2 Second member
+     * @return -1 if m1 collates less than m2,
+     *   1 if m1 collates after m2,
+     *   0 if m1 == m2.
+     */
+    public static int compareSiblingMembersByName(Member m1, Member m2) {
+        // calculated members collate after non-calculated
+        final boolean calculated1 = m1.isCalculatedInQuery();
+        final boolean calculated2 = m2.isCalculatedInQuery();
+        if (calculated1) {
+            if (!calculated2) {
+                return 1;
+            }
+        } else {
+            if (calculated2) {
+                return -1;
+            }
+        }
+        return m1.getName().compareTo(m2.getName());
+    }
 
   /**
      * Returns whether one of the members in a tuple is null.
@@ -3601,11 +3599,7 @@ public class FunUtil extends Util {
             }
             final Comparable thisKey = this.member.getOrderKey();
             final Comparable otherKey = otherMember.getOrderKey();
-            if (notNull(thisKey) && notNull(otherKey)) {
-                return thisKey.compareTo(otherKey);
-            } else {
-                return this.member.compareTo(otherMember);
-            }
+            return Util.compare(thisKey, otherKey);
         }
     }
 

--- a/src/main/mondrian/rolap/RolapCubeHierarchy.java
+++ b/src/main/mondrian/rolap/RolapCubeHierarchy.java
@@ -5,7 +5,7 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2001-2005 Julian Hyde
-// Copyright (C) 2005-2013 Pentaho and others
+// Copyright (C) 2005-2014 Pentaho and others
 // All Rights Reserved.
 */
 package mondrian.rolap;
@@ -199,14 +199,26 @@ public class RolapCubeHierarchy extends RolapHierarchy {
         String name,
         Formula formula)
     {
+        return createMember(_parent, _level, name, formula, name);
+    }
+
+    public RolapMember createMember(
+        Member _parent,
+        Level _level,
+        String name,
+        Formula formula,
+        Comparable orderKey)
+    {
         final RolapCubeLevel level = (RolapCubeLevel) _level;
         final RolapMember parent = (RolapMember) _parent;
         if (formula == null) {
-            return new RolapMemberBase(
+            RolapMemberBase rolapMemberBase = new RolapMemberBase(
                 parent, level, name, MemberType.REGULAR,
                 RolapMemberBase.deriveUniqueName(
                     parent, level, name, false),
                 Larders.ofName(name));
+            rolapMemberBase.setOrderKey(orderKey);
+            return rolapMemberBase;
         } else if (level.isMeasure()) {
             return new RolapCalculatedMeasure(
                 parent, level, name, formula);

--- a/src/main/mondrian/rolap/RolapMemberBase.java
+++ b/src/main/mondrian/rolap/RolapMemberBase.java
@@ -5,7 +5,7 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2001-2005 Julian Hyde
-// Copyright (C) 2005-2013 Pentaho and others
+// Copyright (C) 2005-2014 Pentaho and others
 // All Rights Reserved.
 */
 package mondrian.rolap;
@@ -555,6 +555,9 @@ public class RolapMemberBase
             }
             final double d = Double.parseDouble(ordinal);
             setOrdinal((int) d);
+            if (isMeasure()) {
+                setOrderKey((int) d);
+            }
         }
 
         larder = Larders.set(larder, property, value);
@@ -756,7 +759,11 @@ public class RolapMemberBase
     }
 
     public void setOrderKey(Comparable orderKey) {
-        assert arity(orderKey) == level.getOrderByKeyArity();
+        if (!level.isMeasure()) {
+            assert arity(orderKey) == level.getOrderByKeyArity();
+        } else {
+            assert arity(orderKey) == 1;
+        }
         this.orderKey = orderKey;
     }
 

--- a/src/main/mondrian/rolap/RolapSchemaLoader.java
+++ b/src/main/mondrian/rolap/RolapSchemaLoader.java
@@ -1677,6 +1677,7 @@ public class RolapSchemaLoader {
                 }
                 if (measure.getOrdinal() == -1) {
                     measure.setOrdinal(nonSystemMeasures().size());
+                    measure.setOrderKey(nonSystemMeasures().size());
                 }
                 if (measure.getAggregator() == RolapAggregator.Count) {
                     measureGroup.factCountMeasure = measure;
@@ -2390,9 +2391,10 @@ public class RolapSchemaLoader {
                     && expr.endsWith("\""))
                 {
                     try {
-                        measure.setOrdinal(
-                            Integer.valueOf(
-                                expr.substring(1, expr.length() - 1)));
+                        Integer ordinal = Integer.valueOf(
+                            expr.substring(1, expr.length() - 1));
+                        measure.setOrdinal(ordinal);
+                        measure.setOrderKey(ordinal);
                     } catch (NumberFormatException e) {
                         Util.discard(e);
                     }

--- a/src/main/mondrian/rolap/RolapUtil.java
+++ b/src/main/mondrian/rolap/RolapUtil.java
@@ -5,7 +5,7 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2001-2005 Julian Hyde
-// Copyright (C) 2005-2013 Pentaho and others
+// Copyright (C) 2005-2014 Pentaho and others
 // All Rights Reserved.
 //
 // jhyde, 22 December, 2001
@@ -30,6 +30,8 @@ import java.sql.SQLException;
 import java.util.*;
 
 import javax.sql.DataSource;
+
+import static mondrian.olap.fun.FunUtil.*;
 
 /**
  * Utility methods for classes in the <code>mondrian.rolap</code> package.
@@ -479,7 +481,7 @@ public class RolapUtil {
                             parent, level, nameSegment.name, null);
                 }
                 rc =
-                    FunUtil.compareSiblingMembers(
+                    compareSiblingMembersByName(
                         member,
                         searchMember);
             }
@@ -489,7 +491,7 @@ public class RolapUtil {
             if (matchType == MatchType.BEFORE) {
                 if (rc < 0
                     && (bestMatch == null
-                        || FunUtil.compareSiblingMembers(member, bestMatch)
+                        || compareSiblingMembersByName(member, bestMatch)
                         > 0))
                 {
                     bestMatch = member;
@@ -497,7 +499,7 @@ public class RolapUtil {
             } else if (matchType == MatchType.AFTER) {
                 if (rc > 0
                     && (bestMatch == null
-                        || FunUtil.compareSiblingMembers(member, bestMatch)
+                        || compareSiblingMembersByName(member, bestMatch)
                         < 0))
                 {
                     bestMatch = member;

--- a/src/main/mondrian/rolap/SqlMemberSource.java
+++ b/src/main/mondrian/rolap/SqlMemberSource.java
@@ -1235,6 +1235,7 @@ public class SqlMemberSource
         assert parentMember == null
             || parentMember.getLevel().getDepth() == childLevel.getDepth() - 1
             || childLevel.isParentChild();
+        setOrderKey(orderKey, layout, member);
         if (parentChild) {
             // Create a 'public' and a 'data' member. The public member is
             // calculated, and its value is the aggregation of the data member
@@ -1247,17 +1248,10 @@ public class SqlMemberSource
                         parentMember, childLevel, key, member)
                     : new RolapParentChildMemberNoClosure(
                         parentMember, childLevel, key, member);
+            setOrderKey(orderKey, layout, member);
         }
         final Map<Object, SqlStatement.Accessor> accessors =
             stmt.getAccessors();
-        if (layout.getOrderBySource() != NONE) {
-            if (Util.deprecated(true, false)) {
-                // Setting ordinals is wrong unless we're sure we're reading
-                // the whole hierarchy.
-                member.setOrdinal(lastOrdinal++);
-            }
-            member.setOrderKey(orderKey);
-        }
         if (layout.getNameKey()
             != layout.getKeys().get(layout.getKeys().size() - 1)
             && false)
@@ -1280,6 +1274,19 @@ public class SqlMemberSource
         }
         cache.putMember(member.getLevel(), key, member);
         return member;
+    }
+
+    private void setOrderKey(
+        Comparable orderKey, LevelColumnLayout layout, RolapMemberBase member)
+    {
+        if (layout.getOrderBySource() != NONE) {
+            if (Util.deprecated(true, false)) {
+                // Setting ordinals is wrong unless we're sure we're reading
+                // the whole hierarchy.
+                member.setOrdinal(lastOrdinal++);
+            }
+            member.setOrderKey(orderKey);
+        }
     }
 
     static Comparable getCompositeKey(

--- a/testsrc/main/mondrian/rolap/MemberCacheControlTest.java
+++ b/testsrc/main/mondrian/rolap/MemberCacheControlTest.java
@@ -4,7 +4,7 @@
 // http://www.eclipse.org/legal/epl-v10.html.
 // You must accept the terms of that agreement to use this software.
 //
-// Copyright (C) 2006-2013 Pentaho and others
+// Copyright (C) 2006-2014 Pentaho and others
 // All Rights Reserved.
 */
 package mondrian.rolap;


### PR DESCRIPTION
...reSiblingMembers so that comparing members always uses orderKey instead of falling back to ordinals.  Fixes two failing unit tests, SegmentCacheTest.testMemberWithNullKey and BasicQueryTest.testMemberWithNullKey
