### PR TITLE
[MONDRIAN-1910] NPE in XmlaHandler with empty axis

### DIFF
--- a/src/main/mondrian/olap/type/TypeUtil.java
+++ b/src/main/mondrian/olap/type/TypeUtil.java
@@ -5,10 +5,9 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2005-2005 Julian Hyde
-// Copyright (C) 2005-2013 Pentaho
+// Copyright (C) 2005-2014 Pentaho
 // All Rights Reserved.
 */
-
 package mondrian.olap.type;
 
 import mondrian.mdx.UnresolvedFunCall;
@@ -513,7 +512,10 @@ public class TypeUtil {
             }
             return hierarchyList;
         } else {
-            return Collections.singletonList(type.getHierarchy());
+            Hierarchy hierarchy = type.getHierarchy();
+            return hierarchy == null
+                ? Collections.<Hierarchy>emptyList()
+                : Collections.singletonList(hierarchy);
         }
     }
 

--- a/testsrc/main/mondrian/xmla/XmlaBasicTest.java
+++ b/testsrc/main/mondrian/xmla/XmlaBasicTest.java
@@ -23,6 +23,7 @@ import org.olap4j.metadata.XmlaConstants;
 
 import org.w3c.dom.Document;
 
+import java.sql.SQLException;
 import java.util.*;
 
 /**
@@ -981,6 +982,15 @@ public class XmlaBasicTest extends XmlaBaseTestCase {
         props.setProperty(DATA_SOURCE_INFO_PROP, DATA_SOURCE_INFO);
 
         doTest(requestType, props, testContext);
+    }
+
+    /**
+     * Testcase for <a href="http://jira.pentaho.com/browse/MONDRIAN-1910">
+     * MONDRIAN-1910: "Axes with empty sets cause NPE in XmlaHandler."</a>.
+     */
+    public void testEmptySet() throws SQLException {
+        getTestContext().executeOlap4jXmlaQuery(
+            "select {} on 0, gender.gender.members on 1 from sales");
     }
 
     private void doTestExecuteContent(


### PR DESCRIPTION
http://jira.pentaho.com/browse/MONDRIAN-1910
Axes with empty sets cause NPE in XmlaHandler.
