### PR TITLE
[MONDRIAN-1949] Add generic method to identify a database product.

### DIFF
--- a/bin/loadFoodMart.sh
+++ b/bin/loadFoodMart.sh
@@ -101,6 +101,17 @@ mysql() {
         -outputJdbcURL="jdbc:mysql://localhost/${datasetLower}?user=foodmart&password=foodmart"
 }
 
+nuodb() {
+    java -cp "${CP}${PS}/opt/nuodb/jar/nuodbjdbc.jar" \
+         mondrian.test.loader.MondrianFoodMartLoader \
+         -verbose -aggregates -tables -data -indexes \
+         -jdbcDrivers=com.nuodb.jdbc.Driver \
+         -inputFile=demo/FoodMartCreateData.sql \
+         -outputJdbcURL="jdbc:com.nuodb://localhost/foodmart?schema=mondrian" \
+         -outputJdbcUser=foodmart \
+         -outputJdbcPassword=foodmart
+}
+
 infobright() {
     # As mysql, but '-indexes' option removed because infobright doesn't support them.
     java -cp "${CP}${PS}/usr/local/mysql-connector-java-3.1.12/mysql-connector-java-3.1.12-bin.jar" \
@@ -365,6 +376,7 @@ luciddb \
 monetdb \
 mongodb \
 mysql \
+nuodb \
 oracle \
 oracleTrickle \
 phoenix \
@@ -419,6 +431,7 @@ case "$db" in
 (monetdb) monetdb;;
 (mongodb) mongodb;;
 (mysql) mysql;;
+(nuodb) nuodb;;
 (oracle) oracle;;
 (oracleTrickle) oracleTrickle;;
 (phoenix) phoenix;;

--- a/build.xml
+++ b/build.xml
@@ -693,6 +693,7 @@ in {mondrian.foodmart.jdbcURL}."
         fork="yes"
         maxmemory="2g">
       <arg value="${test.args}"/>
+      <!--<jvmarg line="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8787" />-->
       <jvmarg line="${junit.jvmargs}"/>
       <sysproperty key="log4j.configuration"
           value="${log4j.configuration}"/>
@@ -997,6 +998,7 @@ doc/deployDoc.sh" />
     <java classname="mondrian.test.loader.MondrianFoodMartLoader"
             classpathref="project.test.classpath"
             fork="yes">
+        <!--<jvmarg line="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8787" />-->
         <arg value="-tables"/>
         <arg value="-data"/>
         <arg value="-indexes"/>

--- a/doc/install.html
+++ b/doc/install.html
@@ -513,6 +513,7 @@ for the Java VM.</p>
   <li>Microsoft SQL Server</li>
   <li>MySQL</li>
   <li>Netezza</li>
+  <li>NuoDB</li>
   <li>Oracle</li>
   <li>PostgreSQL (also known as Postgres)</li>
   <li>Sybase</li>

--- a/doc/install_es.html
+++ b/doc/install_es.html
@@ -485,6 +485,7 @@ Rex</a> o Jrubik trabajan con múltiples fuentes de datos.</p>
   <li>Microsoft Access </li>
   <li>Microsoft SQL Server </li>
   <li>MySQL </li>
+  <li>NuoDB </li>
   <li>Oracle </li>
   <li>PostgreSQL </li>
   <li>Sybase </li>

--- a/doc/install_fr.html
+++ b/doc/install_fr.html
@@ -821,6 +821,8 @@ suivantes:</p>
 
   <li>MySQL</li>
 
+  <li>NuoDB</li>
+
   <li>Oracle</li>
 
   <li>PostgreSQL</li>

--- a/src/main/META-INF/services/mondrian.spi.Dialect
+++ b/src/main/META-INF/services/mondrian.spi.Dialect
@@ -14,6 +14,7 @@ mondrian.spi.impl.MicrosoftSqlServerDialect
 mondrian.spi.impl.MySqlDialect
 mondrian.spi.impl.MonetDbDialect
 mondrian.spi.impl.NeoviewDialect
+mondrian.spi.impl.NuoDbDialect
 mondrian.spi.impl.NetezzaDialect
 mondrian.spi.impl.OracleDialect
 mondrian.spi.impl.PhoenixDialect

--- a/src/main/mondrian/olap/MondrianProperties.xml
+++ b/src/main/mondrian/olap/MondrianProperties.xml
@@ -193,6 +193,15 @@ mondrian.foodmart.jdbcPassword=foodmart<br/>
 mondrian.jdbcDrivers=com.mysql.jdbc.Driver<br/>
 driver.classpath=D:/mysql-connector-3.1.12</code></blockquote>
 
+<h3> NuoDB</h3>
+<blockquote><code>
+mondrian.foodmart.jdbcURL=jdbc:com.nuodb://localhost/foodmart?schema=mondrian<br/>
+mondrian.foodmart.jdbcUser=foodmart<br/>
+mondrian.foodmart.jdbcPassword=foodmart<br/>
+mondrian.jdbcDrivers=com.nuodb.jdbc.Driver<br/>
+mondrian.foodmart.jdbcSchema=mondrian<br/>
+driver.classpath=/opt/nuodb/jar/nuodbjdbc.jar</code></blockquote>
+
 <h3>Infobright</h3>
 <p>As MySQL. (Infobright uses a MySQL driver, version 5.1 and later.)</p>
 

--- a/src/main/mondrian/spi/Dialect.java
+++ b/src/main/mondrian/spi/Dialect.java
@@ -956,6 +956,7 @@ public interface Dialect {
         MONETDB,
         NETEZZA,
         NEOVIEW,
+        NUODB,
         ORACLE,
         PHOENIX,
         POSTGRESQL,
@@ -985,6 +986,15 @@ public interface Dialect {
             default:
                 return this;
             }
+        }
+
+        public static DatabaseProduct getDatabaseProduct(String name) {
+            for (DatabaseProduct databaseProduct : values()) {
+                if (databaseProduct.name().equalsIgnoreCase(name)) {
+                    return databaseProduct;
+                }
+            }
+            return UNKNOWN;
         }
     }
 

--- a/src/main/mondrian/spi/impl/JdbcDialectImpl.java
+++ b/src/main/mondrian/spi/impl/JdbcDialectImpl.java
@@ -1106,7 +1106,7 @@ public class JdbcDialectImpl implements Dialect {
         } else if (upperProductName.indexOf("VECTORWISE") >= 0) {
             return DatabaseProduct.VECTORWISE;
         } else {
-            return DatabaseProduct.UNKNOWN;
+            return DatabaseProduct.getDatabaseProduct(upperProductName);
         }
     }
 

--- a/src/main/mondrian/spi/impl/NuoDbDialect.java
+++ b/src/main/mondrian/spi/impl/NuoDbDialect.java
@@ -1,0 +1,97 @@
+/*
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (c) 2002-2014 Pentaho Corporation..  All rights reserved.
+*/
+package mondrian.spi.impl;
+
+import mondrian.olap.Util;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.Date;
+import java.sql.SQLException;
+import java.util.List;
+
+/**
+ * Implementation of {@link mondrian.spi.Dialect} for the NuoDB database.
+ * In order to use NuoDB with Pentaho Mondrian users can only use NuoDB
+ * version 2.0.4 or newer.
+ *
+ * @author rbuck
+ * @since Mar 20, 2014
+ */
+public class NuoDbDialect extends JdbcDialectImpl {
+
+    public static final JdbcDialectFactory FACTORY =
+            new JdbcDialectFactory(
+                    NuoDbDialect.class,
+                    DatabaseProduct.NUODB);
+
+    /**
+     * Creates a NuoDbDialect.
+     *
+     * @param connection Connection
+     */
+    public NuoDbDialect(Connection connection) throws SQLException {
+        super(connection);
+    }
+
+    /**
+     * In order to generate a SQL statement to represent an inline dataset
+     * NuoDB requires that you use FROM DUAL.
+     *
+     * @param columnNames the list of column names
+     * @param columnTypes the list of column types
+     * @param valueList   the value list
+     * @return the generated SQL statement for an inline dataset
+     */
+    @Override
+    public String generateInline(List<String> columnNames, List<String> columnTypes, List<String[]> valueList) {
+        return generateInlineGeneric(
+                columnNames, columnTypes, valueList,
+                " FROM DUAL", false);
+    }
+
+    /**
+     * NuoDB does not yet support ANSI SQL:2003 for DATE literals so we have
+     * to cast dates using a function.
+     *
+     * @param buf   Buffer to append to
+     * @param value Value as string
+     * @param date  Value as date
+     */
+    @Override
+    protected void quoteDateLiteral(StringBuilder buf, String value, Date date) {
+        buf.append("DATE(");
+        Util.singleQuoteString(value, buf);
+        buf.append(")");
+    }
+
+    /**
+     * The NuoDB JDBC driver lists " " as the string to use for quoting, but we
+     * know better. Ideally the quotation character ought to have been "`" but
+     * if that is used and a generated query uses non quoted object names, not-
+     * found exceptions will occur for the object. So we here fall back to using
+     * the double quote character. We ought to investigate why back-tick won't
+     * work. But for now this makes all the tests work with Nuo (besides the
+     * tweaks above).
+     *
+     * @param databaseMetaData the database metadata from the connection
+     * @return the quotation character
+     */
+    @Override
+    protected String deduceIdentifierQuoteString(DatabaseMetaData databaseMetaData) {
+        String identifierQuoteString = super.deduceIdentifierQuoteString(databaseMetaData);
+        if (" ".equals(identifierQuoteString)) {
+            identifierQuoteString = "\"";
+        }
+        return identifierQuoteString;
+    }
+}
+
+// End NuoDbDialect.java
+

--- a/testsrc/main/mondrian/test/DialectTest.java
+++ b/testsrc/main/mondrian/test/DialectTest.java
@@ -149,6 +149,13 @@ public class DialectTest extends TestCase {
                 databaseMetaData.getDatabaseProductName()
                     .indexOf("Netezza") >= 0);
             break;
+        case NUODB:
+            // Dialect has identified that it is NUODB.
+            assertTrue(dialect instanceof NuoDbDialect);
+            assertTrue(
+                databaseMetaData.getDatabaseProductName()
+                    .contains("NuoDB"));
+            break;
         default:
             // Neither MySQL nor Infobright.
             assertFalse(dialect instanceof MySqlDialect);
@@ -194,7 +201,9 @@ public class DialectTest extends TestCase {
                 // monetdb
                 "syntax error, unexpected ',', expecting '\\)' in: \"select count\\(distinct \"customer_id\",\"",
                 // SQL server 2008
-                "Incorrect syntax near ','."
+                "Incorrect syntax near ','.",
+                // NuoDB
+                "(?s).*expected closing parenthesis got ,.*"
             };
             assertQueryFails(sql, errs);
         }
@@ -508,7 +517,9 @@ public class DialectTest extends TestCase {
                 // monetdb
                 "syntax error, unexpected IDENT, expecting SCOLON in: \"select \"customer_id\",",
                 // impala
-                "(?s).*Encountered: IDENTIFIER.*Expected: DIV, HAVING, LIMIT, ORDER, UNION, COMMA.*"
+                "(?s).*Encountered: IDENTIFIER.*Expected: DIV, HAVING, LIMIT, ORDER, UNION, COMMA.*",
+                // NuoDB
+                "(?s).*expected end of statement got SETS.*"
             };
             assertQueryFails(sql, errs);
         }
@@ -546,7 +557,9 @@ public class DialectTest extends TestCase {
                 // SQL server 2008
                 "An expression of non-boolean type specified in a context where a condition is expected, near ','.",
                 // impala
-                "(?s).*Encountered: COMMA.*Expected: BETWEEN, DIV, IS, IN, LIKE, NOT, REGEXP, RLIKE.*"
+                "(?s).*Encountered: COMMA.*Expected: BETWEEN, DIV, IS, IN, LIKE, NOT, REGEXP, RLIKE.*",
+                // NuoDB
+                "(?s).*Operator in list does not support multi-column operands.*"
             };
             assertQueryFails(sql, errs);
         }
@@ -1140,7 +1153,9 @@ public class DialectTest extends TestCase {
                 // SQL Server 2008
                 "Column 'time_by_day.the_month' is invalid in the select list because it is not contained in either an aggregate function or the GROUP BY clause.",
                 // impala
-                "(?s).*select list expression not produced by aggregation output.*missing from GROUP BY clause.*"
+                "(?s).*select list expression not produced by aggregation output.*missing from GROUP BY clause.*",
+                // NuoDB
+                "(?s).*scolumn mondrian.time_by_day.the_month must appear in the GROUP BY clause or be used in an aggregate function.*"
             };
             assertQueryFails(sql, errs);
         }


### PR DESCRIPTION
Use the new static method on the Dialect as the fallback means to
determine the database product. Take advantage of equalsIgnoreCase
as it does null checks, and it handles case properly, and optimizes
for ordinary equivalence. Add NuoDB Dialect support, and related
documentation.
