### PR TITLE
[MONDRIAN-1448] Expose monitoring metrics via JMX MBeans

### DIFF
--- a/src/main/mondrian/server/MonitorImpl.java
+++ b/src/main/mondrian/server/MonitorImpl.java
@@ -4,7 +4,7 @@
 // http://www.eclipse.org/legal/epl-v10.html.
 // You must accept the terms of that agreement to use this software.
 //
-// Copyright (C) 2011-2013 Pentaho
+// Copyright (C) 2011-2014 Pentaho
 // All Rights Reserved.
 */
 package mondrian.server;
@@ -13,6 +13,7 @@ import mondrian.olap.MondrianProperties;
 import mondrian.olap.Util;
 import mondrian.rolap.RolapUtil;
 import mondrian.server.monitor.*;
+import mondrian.server.monitor.MonitorMXBean;
 import mondrian.util.*;
 
 import org.apache.log4j.Logger;
@@ -59,7 +60,7 @@ import java.util.concurrent.BlockingQueue;
  * </ul>
  */
 class MonitorImpl
-    implements Monitor
+    implements Monitor, MonitorMXBean
 {
     private static final Logger LOGGER = Logger.getLogger(MonitorImpl.class);
     private final Handler handler = new Handler();

--- a/src/main/mondrian/server/monitor/ConnectionInfo.java
+++ b/src/main/mondrian/server/monitor/ConnectionInfo.java
@@ -4,7 +4,7 @@
 // http://www.eclipse.org/legal/epl-v10.html.
 // You must accept the terms of that agreement to use this software.
 //
-// Copyright (C) 2011-2013 Pentaho
+// Copyright (C) 2011-2014 Pentaho
 // All Rights Reserved.
 */
 package mondrian.server.monitor;
@@ -42,6 +42,38 @@ public class ConnectionInfo extends Info {
         this.statementEndCount = statementEndCount;
         this.executeStartCount = executeStartCount;
         this.executeEndCount = executeEndCount;
+    }
+
+    public int getStatementStartCount() {
+        return statementStartCount;
+    }
+
+    public int getCellCacheHitCount() {
+        return cellCacheHitCount;
+    }
+
+    public int getCellCacheRequestCount() {
+        return cellCacheRequestCount;
+    }
+
+    public int getCellCacheMissCount() {
+        return cellCacheMissCount;
+    }
+
+    public int getCellCachePendingCount() {
+        return cellCachePendingCount;
+    }
+
+    public int getStatementEndCount() {
+        return statementEndCount;
+    }
+
+    public int getExecuteStartCount() {
+        return executeStartCount;
+    }
+
+    public int getExecuteEndCount() {
+        return executeEndCount;
     }
 }
 

--- a/src/main/mondrian/server/monitor/MonitorMXBean.java
+++ b/src/main/mondrian/server/monitor/MonitorMXBean.java
@@ -1,0 +1,30 @@
+/*
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (C) 2005-2014 Pentaho and others
+// All Rights Reserved.
+*/
+package mondrian.server.monitor;
+
+import java.util.List;
+
+/**
+ * Defines the MXBean interface required to register
+ * MonitorImpl with a JMX agent.  This simply lists
+ * the attributes we want exposed to a JMX client.
+ */
+public interface MonitorMXBean {
+
+    ServerInfo getServer();
+
+    List<ConnectionInfo> getConnections();
+
+    List<StatementInfo> getStatements();
+
+    List<SqlStatementInfo> getSqlStatements();
+}
+
+// End MonitorMXBean.java

--- a/src/main/mondrian/server/monitor/ServerInfo.java
+++ b/src/main/mondrian/server/monitor/ServerInfo.java
@@ -4,7 +4,7 @@
 // http://www.eclipse.org/legal/epl-v10.html.
 // You must accept the terms of that agreement to use this software.
 //
-// Copyright (C) 2011-2013 Pentaho
+// Copyright (C) 2011-2014 Pentaho
 // All Rights Reserved.
 */
 package mondrian.server.monitor;
@@ -162,36 +162,139 @@ public class ServerInfo extends Info {
         this.cellCoordinateCount = cellCoordinateCount;
     }
 
-    public int cellCacheMissCount() {
+    public int getCellCacheMissCount() {
         return cellCacheRequestCount - cellCacheHitCount;
     }
 
     /**
      * @return number of SQL statements currently executing
      */
-    public int sqlStatementCurrentlyOpenCount() {
+    public int getSqlStatementCurrentlyOpenCount() {
         return sqlStatementStartCount - sqlStatementEndCount;
     }
 
     /**
      * @return number of statements currently executing
      */
-    public int statementCurrentlyExecutingCount() {
+    public int getStatementCurrentlyExecutingCount() {
         return executeStartCount - executeEndCount;
     }
 
     /**
      * @return number of statements currently open
      */
-    public int statementCurrentlyOpenCount() {
+    public int getStatementCurrentlyOpenCount() {
         return statementStartCount - statementEndCount;
     }
 
     /**
-     * @return number of connections currently open
      */
-    public int connectionCurrentlyOpenCount() {
+    public int getConnectionCurrentlyOpenCount() {
         return connectionStartCount - connectionEndCount;
+    }
+
+    public int getConnectionStartCount() {
+        return connectionStartCount;
+    }
+
+    public int getConnectionEndCount() {
+        return connectionEndCount;
+    }
+
+    public int getStatementStartCount() {
+        return statementStartCount;
+    }
+
+    public int getStatementEndCount() {
+        return statementEndCount;
+    }
+
+    public int getSqlStatementStartCount() {
+        return sqlStatementStartCount;
+    }
+
+    public int getSqlStatementExecuteCount() {
+        return sqlStatementExecuteCount;
+    }
+
+    public int getSqlStatementEndCount() {
+        return sqlStatementEndCount;
+    }
+
+    public long getSqlStatementRowFetchCount() {
+        return sqlStatementRowFetchCount;
+    }
+
+    public long getSqlStatementExecuteNanos() {
+        return sqlStatementExecuteNanos;
+    }
+
+    public int getSqlStatementCellRequestCount() {
+        return sqlStatementCellRequestCount;
+    }
+
+    public int getCellCacheRequestCount() {
+        return cellCacheRequestCount;
+    }
+
+    public int getCellCacheHitCount() {
+        return cellCacheHitCount;
+    }
+
+    public int getCellCachePendingCount() {
+        return cellCachePendingCount;
+    }
+
+    public int getExecuteStartCount() {
+        return executeStartCount;
+    }
+
+    public int getExecuteEndCount() {
+        return executeEndCount;
+    }
+
+    public long getJvmHeapBytesUsed() {
+        return jvmHeapBytesUsed;
+    }
+
+    public long getJvmHeapBytesCommitted() {
+        return jvmHeapBytesCommitted;
+    }
+
+    public long getJvmHeapBytesMax() {
+        return jvmHeapBytesMax;
+    }
+
+    public int getSegmentCount() {
+        return segmentCount;
+    }
+
+    public int getSegmentCreateCount() {
+        return segmentCreateCount;
+    }
+
+    public int getSegmentCreateViaExternalCount() {
+        return segmentCreateViaExternalCount;
+    }
+
+    public int getSegmentDeleteViaExternalCount() {
+        return segmentDeleteViaExternalCount;
+    }
+
+    public int getSegmentCreateViaRollupCount() {
+        return segmentCreateViaRollupCount;
+    }
+
+    public int getSegmentCreateViaSqlCount() {
+        return segmentCreateViaSqlCount;
+    }
+
+    public int getCellCount() {
+        return cellCount;
+    }
+
+    public int getCellCoordinateCount() {
+        return cellCoordinateCount;
     }
 }
 

--- a/src/main/mondrian/server/monitor/SqlStatementInfo.java
+++ b/src/main/mondrian/server/monitor/SqlStatementInfo.java
@@ -4,7 +4,7 @@
 // http://www.eclipse.org/legal/epl-v10.html.
 // You must accept the terms of that agreement to use this software.
 //
-// Copyright (C) 2011-2013 Pentaho
+// Copyright (C) 2011-2014 Pentaho
 // All Rights Reserved.
 */
 package mondrian.server.monitor;
@@ -28,6 +28,15 @@ public class SqlStatementInfo extends Info {
         this.sqlStatementId = sqlStatementId;
         this.sql = sql;
     }
+
+    public long getSqlStatementId() {
+        return sqlStatementId;
+    }
+
+    public String getSql() {
+        return sql;
+    }
+
 }
 
 // End SqlStatementInfo.java

--- a/src/main/mondrian/server/monitor/StatementInfo.java
+++ b/src/main/mondrian/server/monitor/StatementInfo.java
@@ -4,7 +4,7 @@
 // http://www.eclipse.org/legal/epl-v10.html.
 // You must accept the terms of that agreement to use this software.
 //
-// Copyright (C) 2011-2013 Pentaho
+// Copyright (C) 2011-2014 Pentaho
 // All Rights Reserved.
 */
 package mondrian.server.monitor;
@@ -65,8 +65,64 @@ public class StatementInfo extends Info {
     /**
      * @return Whether the statement is currently executing.
      */
-    public boolean executing() {
+    public boolean getExecuting() {
         return executeStartCount > executeEndCount;
+    }
+
+    public long getStatementId() {
+        return statementId;
+    }
+
+    public int getExecuteStartCount() {
+        return executeStartCount;
+    }
+
+    public int getExecuteEndCount() {
+        return executeEndCount;
+    }
+
+    public int getPhaseCount() {
+        return phaseCount;
+    }
+
+    public long getCellCacheRequestCount() {
+        return cellCacheRequestCount;
+    }
+
+    public long getCellCacheHitCount() {
+        return cellCacheHitCount;
+    }
+
+    public long getCellCacheMissCount() {
+        return cellCacheMissCount;
+    }
+
+    public long getCellCachePendingCount() {
+        return cellCachePendingCount;
+    }
+
+    public int getSqlStatementStartCount() {
+        return sqlStatementStartCount;
+    }
+
+    public int getSqlStatementExecuteCount() {
+        return sqlStatementExecuteCount;
+    }
+
+    public int getSqlStatementEndCount() {
+        return sqlStatementEndCount;
+    }
+
+    public long getSqlStatementRowFetchCount() {
+        return sqlStatementRowFetchCount;
+    }
+
+    public long getSqlStatementExecuteNanos() {
+        return sqlStatementExecuteNanos;
+    }
+
+    public int getCellRequestCount() {
+        return cellRequestCount;
     }
 }
 

--- a/testsrc/main/mondrian/test/MonitorTest.java
+++ b/testsrc/main/mondrian/test/MonitorTest.java
@@ -4,7 +4,7 @@
 // http://www.eclipse.org/legal/epl-v10.html.
 // You must accept the terms of that agreement to use this software.
 //
-// Copyright (C) 2011-2013 Pentaho
+// Copyright (C) 2011-2014 Pentaho
 // All Rights Reserved.
 */
 package mondrian.test;
@@ -22,6 +22,7 @@ import java.sql.SQLException;
 import java.util.List;
 
 /**
+ *
  * Unit test for monitoring, including {@link mondrian.server.monitor.Monitor}.
  *
  * @author jhyde
@@ -66,17 +67,17 @@ public class MonitorTest extends FoodMartTestCase {
 
         println(
             "# stmts open: "
-            + server.statementCurrentlyOpenCount());
+            + server.getStatementCurrentlyOpenCount());
 
         println(
             "# connections open: "
-            + server.connectionCurrentlyOpenCount());
+            + server.getConnectionCurrentlyOpenCount());
 
         println("# rows fetched: " + server.sqlStatementRowFetchCount);
 
         println(
             "# sql stmts open: "
-            + server.sqlStatementCurrentlyOpenCount());
+            + server.getSqlStatementCurrentlyOpenCount());
 
         // # sql stmts by category (cell query, member query, other)
         //  -- if you want to do this, capture sql statement events
@@ -86,21 +87,22 @@ public class MonitorTest extends FoodMartTestCase {
         // cell cache hits
         final List<ConnectionInfo> connections = monitor.getConnections();
         ConnectionInfo lastConnection = connections.get(connections.size() - 1);
-        final List<StatementInfo> statements = monitor.getStatements();
-        StatementInfo lastStatement = statements.get(statements.size() - 1);
+
+        // Cannot reliably retrieve the last statement, since statements are
+        // removed from the map on completion.
+        //final List<StatementInfo> statements = monitor.getStatements();
+        //StatementInfo lastStatement = statements.get(statements.size() - 1);
+
         println(
             "# cell cache requests, misses, hits; "
             + "by server, connection, mdx statement: "
             + server.cellCacheRequestCount
-            + ", " + server.cellCacheMissCount()
+            + ", " + server.getCellCacheMissCount()
             + ", " + server.cellCacheHitCount
             + "; " + lastConnection.cellCacheRequestCount
             + ", " + (lastConnection.cellCacheRequestCount
                       - lastConnection.cellCacheHitCount)
-            + ", " + lastConnection.cellCacheHitCount
-            + "; " + lastStatement.cellCacheRequestCount
-            + ", " + lastStatement.cellCacheMissCount
-            + ", " + lastStatement.cellCacheHitCount);
+            + ", " + lastConnection.cellCacheHitCount);
 
         // cache misses in the last minute
         // cache hits in the last minute
@@ -109,10 +111,10 @@ public class MonitorTest extends FoodMartTestCase {
 
         println(
             "number of mdx statements currently open: "
-            + server.statementCurrentlyOpenCount());
+            + server.getStatementCurrentlyOpenCount());
         println(
             "number of mdx statements currently executing: "
-            + server.statementCurrentlyExecutingCount());
+            + server.getStatementCurrentlyExecutingCount());
 
         println(
             "jvm memory: " + server.jvmHeapBytesUsed
@@ -127,7 +129,6 @@ public class MonitorTest extends FoodMartTestCase {
             + ", average cell dimensionality: "
             + ((float) server.cellCoordinateCount / (float) server.cellCount));
 
-        println("Statement: " + lastStatement);
         println("Connection: " + lastConnection);
         println("Server: " + server);
 


### PR DESCRIPTION
Adds a MonitorMXBean interface which defines what will be exposed,
registers that bean in MondrianServerImpl, and adds getters for
the attributes in the various *Info classes (e.g. ServerInfo)
