### PR TITLE
[BISERVER-11357] Makes the dialect factory for Impala work on the 5.0 JD...

### DIFF
--- a/src/main/mondrian/spi/impl/ImpalaDialect.java
+++ b/src/main/mondrian/spi/impl/ImpalaDialect.java
@@ -42,11 +42,10 @@ public class ImpalaDialect extends HiveDialect {
     public static final JdbcDialectFactory FACTORY =
         new JdbcDialectFactory(
             ImpalaDialect.class,
-            DatabaseProduct.HIVE)
+            DatabaseProduct.IMPALA)
         {
             protected boolean acceptsConnection(Connection connection) {
-                return super.acceptsConnection(connection)
-                    && isDatabase(DatabaseProduct.IMPALA, connection);
+                return isDatabase(DatabaseProduct.IMPALA, connection);
             }
         };
 


### PR DESCRIPTION
...BC jars. The call to getDatabaseProduct doesn't return 'Hive' anymore.
