### PR TITLE
[TEST] Fixes two more tests in SteelWheelsSchemaTest in lagunitas.  O...

### DIFF
--- a/src/main/mondrian/rolap/RolapAggregator.java
+++ b/src/main/mondrian/rolap/RolapAggregator.java
@@ -56,6 +56,9 @@ public abstract class RolapAggregator
                             if (sumInt == Integer.MIN_VALUE) {
                                 sumInt = 0;
                             }
+                            if (data instanceof Double) {
+                                data = ((Double) data).intValue();
+                            }
                             sumInt += (Integer) data;
                         }
                     }

--- a/src/main/mondrian/rolap/RolapSchemaLoader.java
+++ b/src/main/mondrian/rolap/RolapSchemaLoader.java
@@ -4154,7 +4154,7 @@ public class RolapSchemaLoader {
         case Date:
         case Time:
         case Timestamp:
-            return Property.Datatype.TYPE_OTHER;
+            return Property.Datatype.TYPE_TIMESTAMP;
         case Integer:
         case Numeric:
             return Property.Datatype.TYPE_NUMERIC;

--- a/testsrc/main/mondrian/test/SteelWheelsSchemaTest.java
+++ b/testsrc/main/mondrian/test/SteelWheelsSchemaTest.java
@@ -563,7 +563,7 @@ public class SteelWheelsSchemaTest extends SteelWheelsTestCase {
             + "Axis #1:\n"
             + "{[Measures].[Date]}\n"
             + "Axis #2:\n"
-            + "{[Orders].[10421]}\n"
+            + "{[Orders].[Orders].[10421]}\n"
             + "Row #0: 2005-05-29\n");
     }
 


### PR DESCRIPTION
...ne was failing due to a missing type check that's present in 3.x.  The other was failing because properties with type Timestamp were being mapped to TYPE_OTHER rather than TYPE_TIMESTAMP.
