### PR TITLE
[MONDRIAN-1978] Modifying childName to be default access in ChildByNameConstraint,

### DIFF
--- a/src/main/mondrian/rolap/ChildByNameConstraint.java
+++ b/src/main/mondrian/rolap/ChildByNameConstraint.java
@@ -5,7 +5,7 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2004-2005 TONBELLER AG
-// Copyright (C) 2006-2013 Pentaho
+// Copyright (C) 2006-2014 Pentaho
 // All Rights Reserved.
 */
 package mondrian.rolap;
@@ -24,7 +24,7 @@ import java.util.Arrays;
  * @author avix
  */
 class ChildByNameConstraint extends DefaultMemberChildrenConstraint {
-    private final String childName;
+    final String childName;
     private final Object cacheKey;
 
     /**

--- a/src/main/mondrian/rolap/SqlConstraintUtils.java
+++ b/src/main/mondrian/rolap/SqlConstraintUtils.java
@@ -855,7 +855,7 @@ public class SqlConstraintUtils {
      * @return true if the members comprise the cross product of all unique
      * member keys referenced at each level
      */
-    private static boolean membersAreCrossProduct(List<RolapMember> members)
+    public static boolean membersAreCrossProduct(List<RolapMember> members)
     {
         int crossProdSize = getNumUniqueMemberKeys(members);
         for (Collection<RolapMember> parents = getUniqueParentMembers(members);


### PR DESCRIPTION
also making the utility function .membersAreCrossProduct() public, for use when applying constraints in external data service providers.
