### PR TITLE
[MONDRIAN-1857] - hashCode only needs to use the member field as that is...

### DIFF
--- a/src/main/mondrian/rolap/RolapHierarchy.java
+++ b/src/main/mondrian/rolap/RolapHierarchy.java
@@ -1347,9 +1347,7 @@ public class RolapHierarchy extends HierarchyBase {
         }
 
         public int hashCode() {
-            int hash = member.hashCode();
-            hash = Util.hash(hash, exp);
-            return hash;
+            return member.hashCode();
         }
 
         public Exp getExpression() {


### PR DESCRIPTION
... also the only field used by equals.
