### PR TITLE
[MONDRIAN-1432]  ArrayIndexOutOfBoundsException in DenseObjectSegmentDataset.getObject

### DIFF
--- a/src/main/mondrian/olap/Util.java
+++ b/src/main/mondrian/olap/Util.java
@@ -2475,6 +2475,28 @@ public class Util extends XOMUtil {
         return list.subList(from, list.size());
     }
 
+    /**
+     * Creates a bitset with bits from {@code fromIndex} (inclusive) to
+     * specified {@code toIndex} (exclusive) set to {@code true}.
+     *
+     * <p>For example, {@code bitSetBetween(0, 3)} returns a bit set with bits
+     * {0, 1, 2} set.
+     *
+     * @param fromIndex Index of the first bit to be set.
+     * @param toIndex   Index after the last bit to be set.
+     * @return Bit set
+     */
+    public static BitSet bitSetBetween(int fromIndex, int toIndex) {
+        final BitSet bitSet = new BitSet();
+        if (toIndex > fromIndex) {
+            // Avoid http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=6222207
+            // "BitSet internal invariants may be violated"
+            bitSet.set(fromIndex, toIndex);
+        }
+        return bitSet;
+    }
+
+
     public static class ErrorCellValue {
         public String toString() {
             return "#ERR";

--- a/src/main/mondrian/rolap/agg/AbstractSegmentBody.java
+++ b/src/main/mondrian/rolap/agg/AbstractSegmentBody.java
@@ -4,7 +4,7 @@
 // http://www.eclipse.org/legal/epl-v10.html.
 // You must accept the terms of that agreement to use this software.
 //
-// Copyright (C) 2011-2012 Pentaho and others
+// Copyright (C) 2011-2014 Pentaho and others
 // All Rights Reserved.
 */
 package mondrian.rolap.agg;
@@ -69,7 +69,7 @@ abstract class AbstractSegmentBody implements SegmentBody {
             "This method is only supported for dense segments");
     }
 
-    public BitSet getIndicators() {
+    public BitSet getNullValueIndicators() {
         throw new UnsupportedOperationException(
             "This method is only supported for dense segments "
             + "of native values");

--- a/src/main/mondrian/rolap/agg/DenseDoubleSegmentBody.java
+++ b/src/main/mondrian/rolap/agg/DenseDoubleSegmentBody.java
@@ -4,7 +4,7 @@
 // http://www.eclipse.org/legal/epl-v10.html.
 // You must accept the terms of that agreement to use this software.
 //
-// Copyright (C) 2010-2012 Pentaho and others
+// Copyright (C) 2010-2014 Pentaho and others
 // All Rights Reserved.
 */
 package mondrian.rolap.agg;
@@ -23,7 +23,7 @@ class DenseDoubleSegmentBody extends AbstractSegmentBody {
     private static final long serialVersionUID = 5775717165497921144L;
 
     private final double[] values;
-    private final BitSet nullIndicators;
+    private final BitSet nullValues;
 
     /**
      * Creates a DenseDoubleSegmentBody.
@@ -31,18 +31,21 @@ class DenseDoubleSegmentBody extends AbstractSegmentBody {
      * <p>Stores the given array of cell values and null indicators; caller must
      * not modify them afterwards.</p>
      *
-     * @param nullIndicators Null indicators
+     * @param nullValues A bit-set indicating whether values are null. Each
+     *                   position in the bit-set corresponds to an offset in the
+     *                   value array. If position is null, the corresponding
+     *                   entry in the value array will also be 0.
      * @param values Cell values
      * @param axes Axes
      */
     DenseDoubleSegmentBody(
-        BitSet nullIndicators,
+        BitSet nullValues,
         double[] values,
         List<Pair<SortedSet<Comparable>, Boolean>> axes)
     {
         super(axes);
         this.values = values;
-        this.nullIndicators = nullIndicators;
+        this.nullValues = nullValues;
     }
 
     @Override
@@ -51,19 +54,19 @@ class DenseDoubleSegmentBody extends AbstractSegmentBody {
     }
 
     @Override
-    public BitSet getIndicators() {
-        return nullIndicators;
+    public BitSet getNullValueIndicators() {
+        return nullValues;
     }
 
     @Override
     protected int getSize() {
-        return values.length - nullIndicators.cardinality();
+        return values.length;
     }
 
     @Override
     protected Object getObject(int i) {
         double value = values[i];
-        if (value == 0d && nullIndicators.get(i)) {
+        if (value == 0d && nullValues.get(i)) {
             return null;
         }
         return value;
@@ -76,7 +79,7 @@ class DenseDoubleSegmentBody extends AbstractSegmentBody {
         sb.append(values.length);
         sb.append(", data=");
         sb.append(Arrays.toString(values));
-        sb.append(", nullIndicators=").append(nullIndicators);
+        sb.append(", nullValues=").append(nullValues);
         sb.append(", axisValueSets=");
         sb.append(Arrays.toString(getAxisValueSets()));
         sb.append(", nullAxisFlags=");

--- a/src/main/mondrian/rolap/agg/DenseDoubleSegmentDataset.java
+++ b/src/main/mondrian/rolap/agg/DenseDoubleSegmentDataset.java
@@ -4,11 +4,13 @@
 // http://www.eclipse.org/legal/epl-v10.html.
 // You must accept the terms of that agreement to use this software.
 //
-// Copyright (C) 2010-2012 Pentaho and others
+// Copyright (C) 2010-2014 Pentaho and others
 // All Rights Reserved.
 */
 package mondrian.rolap.agg;
 
+
+import mondrian.olap.Util;
 import mondrian.rolap.CellKey;
 import mondrian.rolap.SqlStatement;
 import mondrian.spi.SegmentBody;
@@ -32,7 +34,7 @@ class DenseDoubleSegmentDataset extends DenseNativeSegmentDataset {
      * @param size Number of coordinates
      */
     DenseDoubleSegmentDataset(SegmentAxis[] axes, int size) {
-        this(axes, new double[size], new BitSet(size));
+        this(axes, new double[size], Util.bitSetBetween(0, size));
     }
 
     /**
@@ -55,12 +57,6 @@ class DenseDoubleSegmentDataset extends DenseNativeSegmentDataset {
     }
 
     public Object getObject(CellKey pos) {
-        if (values.length == 0) {
-            // No values means they are all null.
-            // We can't call isNull because we risk going into a SOE. Besides,
-            // this is a tight loop and we can skip over one VFC.
-            return null;
-        }
         int offset = pos.getOffset(axisMultipliers);
         return getObject(offset);
     }
@@ -79,19 +75,19 @@ class DenseDoubleSegmentDataset extends DenseNativeSegmentDataset {
 
     public void populateFrom(int[] pos, SegmentDataset data, CellKey key) {
         final int offset = getOffset(pos);
-        double value = values[offset] = data.getDouble(key);
-        if (value == 0) {
-            nullIndicators.set(offset, !data.isNull(key));
+        final double value = values[offset] = data.getDouble(key);
+        if (value != 0d || !data.isNull(key)) {
+            nullValues.clear(offset);
         }
     }
 
     public void populateFrom(
         int[] pos, SegmentLoader.RowList rowList, int column)
     {
-        int offset = getOffset(pos);
-        double d = values[offset] = rowList.getDouble(column);
-        if (d == 0) {
-            nullIndicators.set(offset, !rowList.isNull(column));
+        final int offset = getOffset(pos);
+        final double value = values[offset] = rowList.getDouble(column);
+        if (value != 0d || !rowList.isNull(column)) {
+            nullValues.clear(offset);
         }
     }
 
@@ -111,7 +107,7 @@ class DenseDoubleSegmentDataset extends DenseNativeSegmentDataset {
         List<Pair<SortedSet<Comparable>, Boolean>> axes)
     {
         return new DenseDoubleSegmentBody(
-            nullIndicators,
+            nullValues,
             values,
             axes);
     }

--- a/src/main/mondrian/rolap/agg/DenseIntSegmentBody.java
+++ b/src/main/mondrian/rolap/agg/DenseIntSegmentBody.java
@@ -4,7 +4,7 @@
 // http://www.eclipse.org/legal/epl-v10.html.
 // You must accept the terms of that agreement to use this software.
 //
-// Copyright (C) 2011-2012 Pentaho and others
+// Copyright (C) 2011-2014 Pentaho and others
 // All Rights Reserved.
 */
 package mondrian.rolap.agg;
@@ -23,7 +23,7 @@ class DenseIntSegmentBody extends AbstractSegmentBody {
     private static final long serialVersionUID = 5391233622968115488L;
 
     private final int[] values;
-    private final BitSet nullIndicators;
+    private final BitSet nullValues;
 
     /**
      * Creates a DenseIntSegmentBody.
@@ -31,18 +31,21 @@ class DenseIntSegmentBody extends AbstractSegmentBody {
      * <p>Stores the given array of cell values and null indicators; caller must
      * not modify them afterwards.</p>
      *
-     * @param nullIndicators Null indicators
+     * @param nullValues A bit-set indicating whether values are null. Each
+     *                   position in the bit-set corresponds to an offset in the
+     *                   value array. If position is null, the corresponding
+     *                   entry in the value array will also be 0.
      * @param values Cell values
      * @param axes Axes
      */
     DenseIntSegmentBody(
-        BitSet nullIndicators,
+        BitSet nullValues,
         int[] values,
         List<Pair<SortedSet<Comparable>, Boolean>> axes)
     {
         super(axes);
         this.values = values;
-        this.nullIndicators = nullIndicators;
+        this.nullValues = nullValues;
     }
 
     @Override
@@ -51,17 +54,17 @@ class DenseIntSegmentBody extends AbstractSegmentBody {
     }
 
     @Override
-    public BitSet getIndicators() {
-        return nullIndicators;
+    public BitSet getNullValueIndicators() {
+        return nullValues;
     }
 
     protected int getSize() {
-        return values.length - nullIndicators.cardinality();
+        return values.length;
     }
 
     protected Object getObject(int i) {
         int value = values[i];
-        if (value == 0 && nullIndicators.get(i)) {
+        if (value == 0 && nullValues.get(i)) {
             return null;
         }
         return value;

--- a/src/main/mondrian/rolap/agg/DenseNativeSegmentDataset.java
+++ b/src/main/mondrian/rolap/agg/DenseNativeSegmentDataset.java
@@ -5,7 +5,7 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2002-2005 Julian Hyde
-// Copyright (C) 2005-2011 Pentaho and others
+// Copyright (C) 2005-2014 Pentaho and others
 // All Rights Reserved.
 //
 // jhyde, 21 March, 2002
@@ -23,20 +23,23 @@ import java.util.BitSet;
  * @author jhyde
  */
 abstract class DenseNativeSegmentDataset extends DenseSegmentDataset {
-    protected final BitSet nullIndicators;
+    protected final BitSet nullValues;
 
     /**
      * Creates a DenseNativeSegmentDataset.
      *
      * @param axes Segment axes, containing actual column values
-     * @param nullIndicators Null indicators
+     * @param nullValues A bit-set indicating whether values are null. Each
+     *                   position in the bit-set corresponds to an offset in the
+     *                   value array. If position is null, the corresponding
+     *                   entry in the value array will also be 0.
      */
     DenseNativeSegmentDataset(
         SegmentAxis[] axes,
-        BitSet nullIndicators)
+        BitSet nullValues)
     {
         super(axes);
-        this.nullIndicators = nullIndicators;
+        this.nullValues = nullValues;
     }
 
     public boolean isNull(CellKey key) {
@@ -54,7 +57,7 @@ abstract class DenseNativeSegmentDataset extends DenseSegmentDataset {
      * @return Whether the cell at this offset is null
      */
     protected final boolean isNull(int offset) {
-        return !nullIndicators.get(offset);
+        return nullValues.get(offset);
     }
 }
 

--- a/src/main/mondrian/rolap/agg/DenseSegmentDataset.java
+++ b/src/main/mondrian/rolap/agg/DenseSegmentDataset.java
@@ -5,7 +5,7 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2002-2005 Julian Hyde
-// Copyright (C) 2005-2011 Pentaho and others
+// Copyright (C) 2005-2014 Pentaho and others
 // All Rights Reserved.
 //
 // jhyde, 21 March, 2002
@@ -114,6 +114,7 @@ outer:
         Iterator<Map.Entry<CellKey, Object>>,
         Map.Entry<CellKey, Object>
     {
+        private final int last = getSize() - 1;
         private int i = -1;
         private final int[] ordinals;
 
@@ -123,7 +124,7 @@ outer:
         }
 
         public boolean hasNext() {
-            return i < getSize() - 1;
+            return i < last;
         }
 
         public Map.Entry<CellKey, Object> next() {

--- a/src/main/mondrian/spi/SegmentBody.java
+++ b/src/main/mondrian/spi/SegmentBody.java
@@ -4,7 +4,7 @@
 // http://www.eclipse.org/legal/epl-v10.html.
 // You must accept the terms of that agreement to use this software.
 //
-// Copyright (C) 2011-2012 Pentaho and others
+// Copyright (C) 2011-2014 Pentaho and others
 // All Rights Reserved.
 */
 package mondrian.spi;
@@ -33,19 +33,24 @@ public interface SegmentBody extends Serializable {
     Map<CellKey, Object> getValueMap();
 
     /**
-     * Returns an array of values. Use only for dense segments.
+     * Returns an array of values.
+     *
+     * <p>Use only for dense segments.</p>
      *
      * @return An array of values
      */
     Object getValueArray();
 
     /**
-     * Returns a bitset indicating whether values are null.
-     * Use only for dense segments.
+     * Returns a bit-set indicating whether values are null. The ordinals in
+     * the bit-set correspond to the indexes in the array returned from
+     * {@link #getValueArray()}.
+     *
+     * <p>Use only for dense segments of native values.</p>
      *
      * @return Indicators
      */
-    BitSet getIndicators();
+    BitSet getNullValueIndicators();
 
     /**
      * Returns the cached axis value sets to be used as an

--- a/testsrc/main/mondrian/test/BasicQueryTest.java
+++ b/testsrc/main/mondrian/test/BasicQueryTest.java
@@ -7749,6 +7749,66 @@ public class BasicQueryTest extends FoodMartTestCase {
             + "{[Time].[Time].[1997]}\n"
             + "Row #0: \n");
     }
+
+    public void testMondrian1432()
+    {
+        TestContext testContext = getTestContext()
+            .insertCalculatedColumnDef(
+                "sales_fact_1997",
+                "<CalculatedColumnDef name='zero' type='Numeric'>\n"
+                + "    <ExpressionView>\n"
+                + "        <SQL dialect='generic'>0</SQL>\n"
+                + "    </ExpressionView>\n"
+                + "</CalculatedColumnDef>\n")
+            .insertCube(
+                "<Cube name='FooBar'>\n"
+                + "  <Dimensions>"
+                + "    <Dimension name='Gender' table='customer' key='Name' >\n"
+                + "  <Attributes>    "
+                + " <Attribute name='Gender' keyColumn='gender'/>"
+                + "<Attribute name='Name' keyColumn='customer_id' nameColumn='full_name' orderByColumn='full_name' hasHierarchy='false'/>"
+                + " </Attributes>    "
+                + "    </Dimension>\n"
+                + "  </Dimensions>"
+                + "  <MeasureGroups>"
+                + "    <MeasureGroup table='sales_fact_1997'>"
+                + "      <Measures>"
+                + "        <Measure name='zero' aggregator='sum' column='zero'>\n"
+                + "        </Measure>\n"
+                + "      </Measures>"
+                + "      <DimensionLinks>\n"
+                + "        <ForeignKeyLink dimension='Gender' foreignKeyColumn='customer_id'/>\n"
+                + "      </DimensionLinks>\n"
+                + "    </MeasureGroup>"
+                + "  </MeasureGroups>"
+                + "</Cube>");
+
+
+        testContext.assertQueryReturns(
+            "select "
+            + "Crossjoin([Gender].[Gender].[Gender].Members, [Measures].[zero]) ON COLUMNS\n"
+            + "from [FooBar] "
+            + "  \n",
+            "Axis #0:\n"
+            + "{}\n"
+            + "Axis #1:\n"
+            + "{[Gender].[Gender].[F], [Measures].[zero]}\n"
+            + "{[Gender].[Gender].[M], [Measures].[zero]}\n"
+            + "Row #0: 0\n"
+            + "Row #0: 0\n");
+        testContext.assertQueryReturns(
+            "select [Measures].[zero] ON COLUMNS,\n"
+            + "  {[Gender].[All Gender]}  ON ROWS\n"
+            + "from [FooBar] "
+            + " ",
+            "Axis #0:\n"
+            + "{}\n"
+            + "Axis #1:\n"
+            + "{[Measures].[zero]}\n"
+            + "Axis #2:\n"
+            + "{[Gender].[Gender].[All Gender]}\n"
+            + "Row #0: 0\n");
+    }
 }
 
 // End BasicQueryTest.java


### PR DESCRIPTION
'0' and NULL values in segments were being mishandled in some cases.
    This is a merge of Julian's changes from master branch.
    (cherry picked from commit 30889d5)
