### PR TITLE
[MONDRIAN-1687] Addressing bad rollups formed as a result of mishandling columns with nullAxisFlag.

### DIFF
--- a/src/main/mondrian/rolap/agg/AbstractSegmentBody.java
+++ b/src/main/mondrian/rolap/agg/AbstractSegmentBody.java
@@ -117,7 +117,11 @@ abstract class AbstractSegmentBody implements SegmentBody {
                 }
                 int k = ordinals.length - 1;
                 while (k >= 0) {
-                    if (ordinals[k] < axisValueSets[k].size() - 1) {
+                    int j = 1;
+                    if (nullAxisFlags[k]) {
+                        j = 0;
+                    }
+                    if (ordinals[k] < axisValueSets[k].size() - j) {
                         ++ordinals[k];
                         break;
                     } else {

--- a/src/main/mondrian/rolap/agg/SegmentBuilder.java
+++ b/src/main/mondrian/rolap/agg/SegmentBuilder.java
@@ -522,7 +522,9 @@ public class SegmentBuilder {
         int multiplier = 1;
         for (int i = axes.size() - 1; i >= 0; --i) {
             axisMultipliers[i] = multiplier;
-            multiplier *= axes.get(i).left.size();
+            // if the nullAxisFlag is set we need to offset by 1.
+            int nullAxisAdjustment = axes.get(i).right ? 1 : 0;
+            multiplier *= (axes.get(i).left.size() + nullAxisAdjustment);
         }
         return axisMultipliers;
     }

--- a/testsrc/main/mondrian/rolap/agg/SegmentBuilderTest.java
+++ b/testsrc/main/mondrian/rolap/agg/SegmentBuilderTest.java
@@ -5,7 +5,7 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2002-2005 Julian Hyde
-// Copyright (C) 2005-2013 Pentaho and others
+// Copyright (C) 2005-2014 Pentaho and others
 // All Rights Reserved.
 */
 package mondrian.rolap.agg;
@@ -13,19 +13,20 @@ package mondrian.rolap.agg;
 import mondrian.olap.*;
 import mondrian.rolap.*;
 import mondrian.spi.*;
-import mondrian.test.PerformanceTest;
-import mondrian.test.TestContext;
+import mondrian.test.*;
 import mondrian.util.ByteString;
 import mondrian.util.Pair;
 
 import java.util.*;
 
 /**
- * <p>Test for <code>SegmenBuilder</code></p>
+ * <p>Test for <code>SegmentBuilder</code>.</p>
  *
  * @author mcampbell
  */
 public class SegmentBuilderTest extends BatchTestCase {
+
+    public static final double MOCK_CELL_VALUE = 123.123;
 
     protected void setUp() throws Exception {
         super.setUp();
@@ -37,6 +38,287 @@ public class SegmentBuilderTest extends BatchTestCase {
             MondrianProperties.instance().SparseSegmentDensityThreshold, .5);
         propSaver.set(
             MondrianProperties.instance().SparseSegmentCountThreshold, 1000);
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        super.tearDown();
+        propSaver.reset();
+    }
+
+    public void testRollupWithNullAxisVals() {
+        // Perform two rollups.  One with two columns each containing 3 values.
+        // The second with two columns containing 2 values + null.
+        // The rolled up values should be equal in the two cases.
+        Pair<SegmentHeader, SegmentBody> rollupNoNulls = SegmentBuilder.rollup(
+            makeSegmentMap(
+                new String[] {"col1", "col2"}, null, 3, 9, true,
+                new boolean[] {false, false}),// each axis sets null axis flag=F
+            new HashSet<String>(Arrays.asList("col2")),
+            null, RolapAggregator.Sum, Dialect.Datatype.Numeric);
+        Pair<SegmentHeader, SegmentBody> rollupWithNullMembers =
+            SegmentBuilder.rollup(
+                makeSegmentMap(
+                    new String[] {"col1", "col2"}, null, 2, 9, true,
+                    // each axis sets null axis flag=T
+                    new boolean[] {true, true}),
+                new HashSet<String>(Arrays.asList("col2")),
+                null, RolapAggregator.Sum, Dialect.Datatype.Numeric);
+        assertArraysAreEqual(
+            (double[]) rollupNoNulls.getValue().getValueArray(),
+            (double[]) rollupWithNullMembers.getValue().getValueArray());
+        assertTrue(
+            "Rolled up column should have nullAxisFlag set.",
+            rollupWithNullMembers.getValue().getNullAxisFlags().length == 1
+                && rollupWithNullMembers.getValue().getNullAxisFlags()[0]);
+        assertEquals(
+            "col2",
+            rollupWithNullMembers.getKey().getConstrainedColumns()
+                .get(0).columnExpression);
+    }
+
+    public void testRollupWithMixOfNullAxisValues() {
+        // constructed segment has 3 columns:
+        //    2 values in the first
+        //    2 values + null in the second and third
+        //  = 18 values
+        Pair<SegmentHeader, SegmentBody> rollup = SegmentBuilder.rollup(
+            makeSegmentMap(
+                new String[] {"col1", "col2", "col3"}, null, 2, 18, true,
+                // col2 & col3 have nullAxisFlag=T
+                new boolean[] {false, true, true}),
+            new HashSet<String>(Arrays.asList("col2")),
+            null, RolapAggregator.Sum, Dialect.Datatype.Numeric);
+
+        // expected value is 6 * MOCK_CELL_VALUE for each of 3 column values,
+        // since each of the 18 cells are being rolled up to 3 buckets
+        double expectedVal = 6 * MOCK_CELL_VALUE;
+        assertArraysAreEqual(
+            new double[] { expectedVal, expectedVal, expectedVal },
+            (double[]) rollup.getValue().getValueArray());
+        assertTrue(
+            "Rolled up column should have nullAxisFlag set.",
+            rollup.getValue().getNullAxisFlags().length == 1
+                && rollup.getValue().getNullAxisFlags()[0]);
+        assertEquals(
+            "col2",
+            rollup.getKey().getConstrainedColumns()
+                .get(0).columnExpression);
+    }
+
+    public void testRollup2ColumnsWithMixOfNullAxisValues() {
+        // constructed segment has 3 columns:
+        //    2 values in the first
+        //    2 values + null in the second and third
+        //  = 18 values
+        Pair<SegmentHeader, SegmentBody> rollup = SegmentBuilder.rollup(
+            makeSegmentMap(
+                new String[] {"col1", "col2", "col3"}, null, 2, 12, true,
+                // col2 & col3 have nullAxisFlag=T
+                new boolean[] {false, true, false}),
+            new HashSet<String>(Arrays.asList("col1", "col2")),
+            null, RolapAggregator.Sum, Dialect.Datatype.Numeric);
+
+        // expected value is 2 * MOCK_CELL_VALUE for each of 3 column values,
+        // since each of the 12 cells are being rolled up to 3 * 2 buckets
+        double expectedVal = 2 * MOCK_CELL_VALUE;
+        assertArraysAreEqual(
+            new double[] {expectedVal, expectedVal, expectedVal,
+                expectedVal, expectedVal, expectedVal},
+            (double[]) rollup.getValue().getValueArray());
+        assertTrue(
+            "Rolled up column should have nullAxisFlag set to false for "
+            + "the first column, true for second column.",
+            rollup.getValue().getNullAxisFlags().length == 2
+                && !rollup.getValue().getNullAxisFlags()[0]
+                && rollup.getValue().getNullAxisFlags()[1]);
+        assertEquals(
+            "col1",
+            rollup.getKey().getConstrainedColumns()
+                .get(0).columnExpression);
+        assertEquals(
+            "col2",
+            rollup.getKey().getConstrainedColumns()
+                .get(1).columnExpression);
+    }
+
+    public void testMultiSegRollupWithMixOfNullAxisValues() {
+        // rolls up 2 segments.
+        // Segment 1 has 3 columns:
+        //    2 values in the first
+        //    1 values + null in the second
+        //    2 vals + null in the third
+        //  = 12 values
+        //  Segment 2 has the same 3 columns, difft values for 3rd column.
+        //
+        //  none of the columns are wildcarded.
+        final Map<SegmentHeader, SegmentBody> map = makeSegmentMap(
+            new String[]{"col1", "col2", "col3"},
+            new String[][]{{"col1A", "col1B"}, {"col2A"}, {"col3A", "col3B"}},
+            -1, 12, false,
+            // col2 & col3 have nullAxisFlag=T
+            new boolean[]{false, true, true});
+        map.putAll(
+            makeSegmentMap(
+                new String[]{"col1", "col2", "col3"},
+                new String[][]{{"col1A", "col1B"}, {"col2A"}, {"col3C",
+                    "col3D"}},
+                -1, 8, false,
+                // col3 has nullAxisFlag=T
+                new boolean[]{false, true, false}));
+        Pair<SegmentHeader, SegmentBody> rollup = SegmentBuilder.rollup(
+            map,
+            new HashSet<String>(Arrays.asList("col2")),
+            null, RolapAggregator.Sum, Dialect.Datatype.Numeric);
+        // expected value is 10 * MOCK_CELL_VALUE for each of 2 column values,
+        // since the 20 cells across 2 segments are being rolled up to 2 buckets
+        double expectedVal = 10 * MOCK_CELL_VALUE;
+        assertArraysAreEqual(
+            new double[]{ expectedVal, expectedVal},
+            (double[]) rollup.getValue().getValueArray());
+        assertTrue(
+            "Rolled up column should have nullAxisFlag set to true for "
+            + "a single column.",
+            rollup.getValue().getNullAxisFlags().length == 1
+                && rollup.getValue().getNullAxisFlags()[0]);
+        assertEquals(
+            "col2",
+            rollup.getKey().getConstrainedColumns()
+                .get(0).columnExpression);
+    }
+
+    private void assertArraysAreEqual(double[] expected, double[] actual) {
+        assertTrue(
+            "Expected double array:  "
+            + Arrays.toString(expected)
+            + ", but got "
+            + Arrays.toString(actual),
+            doubleArraysEqual(actual, expected));
+    }
+
+    private boolean doubleArraysEqual(
+        double[] valueArray, double[] expectedVal)
+    {
+        if (valueArray.length != expectedVal.length) {
+            return false;
+        }
+        double within = 0.00000001;
+        for (int i = 0; i < valueArray.length; i++) {
+            if (Math.abs(valueArray[i] - expectedVal[i]) > within) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public void testNullMemberOffset() {
+        // verifies that presence of a null member does not cause
+        // offsets to be incorrect for a Segment rollup.
+        // First query loads the cache with a segment that can fulfill the
+        // second query.
+        executeQuery(
+            "select [Store Size in SQFT].[Store Sqft].members * "
+            + "gender.gender.members  on 0 from sales");
+        assertQueryReturns(
+            "select non empty [Store Size in SQFT].[Store Sqft].members on 0"
+            + "from sales",
+            "Axis #0:\n"
+            + "{}\n"
+            + "Axis #1:\n"
+            + "{[Store].[Store Size in SQFT].[#null]}\n"
+            + "{[Store].[Store Size in SQFT].[20319]}\n"
+            + "{[Store].[Store Size in SQFT].[21215]}\n"
+            + "{[Store].[Store Size in SQFT].[22478]}\n"
+            + "{[Store].[Store Size in SQFT].[23598]}\n"
+            + "{[Store].[Store Size in SQFT].[23688]}\n"
+            + "{[Store].[Store Size in SQFT].[27694]}\n"
+            + "{[Store].[Store Size in SQFT].[28206]}\n"
+            + "{[Store].[Store Size in SQFT].[30268]}\n"
+            + "{[Store].[Store Size in SQFT].[33858]}\n"
+            + "{[Store].[Store Size in SQFT].[39696]}\n"
+            + "Row #0: 39,329\n"
+            + "Row #0: 26,079\n"
+            + "Row #0: 25,011\n"
+            + "Row #0: 2,117\n"
+            + "Row #0: 25,663\n"
+            + "Row #0: 21,333\n"
+            + "Row #0: 41,580\n"
+            + "Row #0: 2,237\n"
+            + "Row #0: 23,591\n"
+            + "Row #0: 35,257\n"
+            + "Row #0: 24,576\n");
+    }
+
+    public void testNullMemberOffset2ColRollup() {
+        // verifies that presence of a null member does not cause
+        // offsets to be incorrect for a Segment rollup involving 2
+        // columns.  This tests a case where
+        // SegmentBuilder.computeAxisMultipliers needs to factor in
+        // the null axis flag.
+        executeQuery(
+            "select [Store Size in SQFT].[Store Sqft].members * "
+            + "[store].[store state].members * time.[quarter].members on 0"
+            + " from sales where [Product].[Food].[Produce].[Vegetables].[Fresh Vegetables]");
+        assertQueryReturns(
+            "select non empty [Store Size in SQFT].[Store Sqft].members "
+            + " * [store].[store state].members  on 0"
+            + "from sales where [Product].[Food].[Produce].[Vegetables].[Fresh Vegetables]",
+            "Axis #0:\n"
+            + "{[Product].[Products].[Food].[Produce].[Vegetables].[Fresh Vegetables]}\n"
+            + "Axis #1:\n"
+            + "{[Store].[Store Size in SQFT].[#null], [Store].[Stores].[USA].[CA]}\n"
+            + "{[Store].[Store Size in SQFT].[#null], [Store].[Stores].[USA].[WA]}\n"
+            + "{[Store].[Store Size in SQFT].[20319], [Store].[Stores].[USA].[OR]}\n"
+            + "{[Store].[Store Size in SQFT].[21215], [Store].[Stores].[USA].[WA]}\n"
+            + "{[Store].[Store Size in SQFT].[22478], [Store].[Stores].[USA].[CA]}\n"
+            + "{[Store].[Store Size in SQFT].[23598], [Store].[Stores].[USA].[CA]}\n"
+            + "{[Store].[Store Size in SQFT].[23688], [Store].[Stores].[USA].[CA]}\n"
+            + "{[Store].[Store Size in SQFT].[27694], [Store].[Stores].[USA].[OR]}\n"
+            + "{[Store].[Store Size in SQFT].[28206], [Store].[Stores].[USA].[WA]}\n"
+            + "{[Store].[Store Size in SQFT].[30268], [Store].[Stores].[USA].[WA]}\n"
+            + "{[Store].[Store Size in SQFT].[33858], [Store].[Stores].[USA].[WA]}\n"
+            + "{[Store].[Store Size in SQFT].[39696], [Store].[Stores].[USA].[WA]}\n"
+            + "Row #0: 1,967\n"
+            + "Row #0: 947\n"
+            + "Row #0: 2,065\n"
+            + "Row #0: 1,827\n"
+            + "Row #0: 165\n"
+            + "Row #0: 2,109\n"
+            + "Row #0: 1,665\n"
+            + "Row #0: 3,382\n"
+            + "Row #0: 162\n"
+            + "Row #0: 1,875\n"
+            + "Row #0: 2,668\n"
+            + "Row #0: 1,907\n");
+    }
+
+    public void testSegmentBodyIterator() {
+        // checks that cell key coordinates are generated correctly
+        // when a null member is present.
+        List<Pair<SortedSet<Comparable>, Boolean>> axes =
+            new ArrayList<Pair<SortedSet<Comparable>, Boolean>>();
+        axes.add(new Pair<SortedSet<Comparable>, Boolean>(
+            new TreeSet<Comparable>(
+                Arrays.asList(
+                    new String[] { "foo1", "bar1"})), true)); // nullAxisFlag=T
+        axes.add(new Pair<SortedSet<Comparable>, Boolean>(
+            new TreeSet<Comparable>(
+                Arrays.asList(new String[] { "foo2", "bar2", "baz3"})), false));
+        SegmentBody testBody = new DenseIntSegmentBody(
+            new BitSet(), new int[]{1, 2, 3, 4, 5, 6, 7, 8, 9},
+            axes);
+        Map<CellKey, Object> valueMap = testBody.getValueMap();
+        assertEquals(
+            "{(0, 0)=1, "
+            + "(0, 1)=2, "
+            + "(0, 2)=3, "
+            + "(1, 0)=4, "
+            + "(1, 1)=5, "
+            + "(1, 2)=6, "
+            + "(2, 0)=7, "
+            + "(2, 1)=8, "
+            + "(2, 2)=9}",
+            valueMap.toString());
     }
 
     public void testSparseRollup() {
@@ -80,10 +362,11 @@ public class SegmentBuilderTest extends BatchTestCase {
         Pair<SegmentHeader, SegmentBody> rollup =
             SegmentBuilder.rollup(
                 makeSegmentMap(
-                    new String[] {"col1", "col2", "col3"}, 47000, 4),
+                    new String[] {"col1", "col2", "col3"},
+                    null, 47000, 4, false, null),
                 new HashSet<String>(Arrays.asList("col1", "col2")),
                 null, RolapAggregator.Sum, Dialect.Datatype.Numeric);
-        assertTrue(rollup.right instanceof  SparseSegmentBody);
+        assertTrue(rollup.right instanceof SparseSegmentBody);
     }
 
     public void testRollupWithOOMPossibility() {
@@ -96,10 +379,11 @@ public class SegmentBuilderTest extends BatchTestCase {
         Pair<SegmentHeader, SegmentBody> rollup =
             SegmentBuilder.rollup(
                 makeSegmentMap(
-                    new String[] {"col1", "col2", "col3"}, 44000, 4),
+                    new String[] {"col1", "col2", "col3"},
+                    null, 44000, 4, false, null),
                 new HashSet<String>(Arrays.asList("col1", "col2")),
                 null, RolapAggregator.Sum, Dialect.Datatype.Numeric);
-        assertTrue(rollup.right instanceof  SparseSegmentBody);
+        assertTrue(rollup.right instanceof SparseSegmentBody);
     }
 
     public void testRollupShouldBeDense() {
@@ -107,7 +391,8 @@ public class SegmentBuilderTest extends BatchTestCase {
         Pair<SegmentHeader, SegmentBody> rollup =
             SegmentBuilder.rollup(
                 makeSegmentMap(
-                    new String[] {"col1", "col2", "col3"}, 10, 15),
+                    new String[] {"col1", "col2", "col3"},
+                    null, 10, 15, false, null),
                 new HashSet<String>(Arrays.asList("col1", "col2")),
                 null, RolapAggregator.Sum, Dialect.Datatype.Numeric);
         assertTrue(rollup.right instanceof DenseDoubleSegmentBody);
@@ -117,10 +402,38 @@ public class SegmentBuilderTest extends BatchTestCase {
             SegmentBuilder.rollup(
                 makeSegmentMap(
                     new String[] {"col1", "col2", "col3", "col4"},
-                    11, 10000),   // 1331 possible intersections (11*3)
+                    null, 11, 10000, false, null),
+                    // 1331 possible intersections (11*3)
                 new HashSet<String>(Arrays.asList("col1", "col2", "col3")),
                 null, RolapAggregator.Sum, Dialect.Datatype.Numeric);
         assertTrue(rollup.right instanceof DenseDoubleSegmentBody);
+    }
+
+    public void testBadRollupCausesGreaterThan12Iterations() {
+        // http://jira.pentaho.com/browse/MONDRIAN-1729
+        // The first two queries populate the cache with segments
+        // capable of being rolled up to fulfill the 3rd query.
+        // MONDRIAN-1729 involved the rollup being invalid, causing
+        // an infinite loop.
+        getTestContext().flushSchemaCache();
+        TestContext context = getTestContext().withFreshConnection();
+
+        context.executeQuery(
+            "select "
+            + "{[Time].[1998].[Q1].[2],[Time].[1998].[Q1].[3],"
+            + "[Time].[1998].[Q2].[4],[Time].[1998].[Q2].[5],"
+            + "[Time].[1998].[Q2].[5],[Time].[1998].[Q2].[6],"
+            + "[Time].[1998].[Q3].[7]} on 0 from sales");
+
+        context.executeQuery(
+            "select "
+            + "{[Time].[1997].[Q1].[1], [Time].[1997].[Q3].[8], [Time].[1997].[Q3].[9], "
+            + "[Time].[1997].[Q4].[10], [Time].[1997].[Q4].[11], [Time].[1997].[Q4].[12],"
+            + "[Time].[1998].[Q1].[1], [Time].[1998].[Q3].[8], [Time].[1998].[Q3].[9], "
+            + "[Time].[1998].[Q4].[10], [Time].[1998].[Q4].[11], [Time].[1998].[Q4].[12]}"
+            + "on 0 from sales");
+
+        context.executeQuery("select [Time].[1998].[Q1] on 0 from sales");
     }
 
     public void testSameRollupRegardlessOfSegmentOrderWithEmptySegmentBody() {
@@ -149,7 +462,15 @@ public class SegmentBuilderTest extends BatchTestCase {
                 + "on 0 from sales"},
             new String[] {
                 "6806cee8561ece016f1acee39e2481c933aae4de7d4bd8bf28aee0b15dc894ce",
+                    // ^^^
+                    //    {time_by_day.the_year=('1998')}
+                    //    {time_by_day.quarter=('Q1','Q2','Q3')}
+                    //    {time_by_day.month_of_year=('2','3','4','5','6','7')}]
                 "ce2f10efe351f9c3b01fe54665bde120b5e7df7474b2363f3f7f3b3a3a93a733"
+                    // ^^^
+                    // {time_by_day.the_year=(*)}
+                    // {time_by_day.quarter=('Q1','Q3','Q4')}
+                    // {time_by_day.month_of_year=('1','8','9','10','11','12')}]
             },
             new String[]{
                 // rollup columns
@@ -184,7 +505,16 @@ public class SegmentBuilderTest extends BatchTestCase {
                 + "on 0 from sales"},
             new String[] {
               "8f8f28faa78d9688b5f2bf0419302b858039544690ed71fd270e2f1c2697fb0a",
+                // ^^^
+                //    {time_by_day.the_year=('1997')}
+                //    {product_class.product_family=(*)}
+                //    {product_class.product_department=('Alcoholic Beverages',
+                //     'Baked Goods','Beverages','Periodicals')}]
               "e0800d8f9d3fff381152fa2b5d2b5499d5a3a9993cc3aec0ab28995debefbeca"
+                // ^^^
+                //    {time_by_day.the_year=('1997')}
+                //    {product_class.product_family=('Drink')}
+                //    {product_class.product_department=('Dairy')}]
             },
             new String[]{
                 "`product_class`.`product_family`"
@@ -216,7 +546,16 @@ public class SegmentBuilderTest extends BatchTestCase {
                 + "on 0 from sales"},
             new String[] {
                 "b9cd57a8b7b3db1021a72c540da1f64382cce469742095b04d023a0d3c8f0096",
+                    // ^^^
+                    //    {time_by_day.the_year=('1997')}
+                    // {product_class.product_family=('Drink','Non-Consumable')}
+                    // {product_class.product_department=('Alcoholic Beverages',
+                    //  'Beverages','Periodicals')}]
                 "8f8f28faa78d9688b5f2bf0419302b858039544690ed71fd270e2f1c2697fb0a"
+                    // ^^^
+                    //    {time_by_day.the_year=('1997')}
+                    //    {product_class.product_family=('Drink')}
+                    //    {product_class.product_department=('Dairy')}]
             },
             new String[]{
                 "`product_class`.`product_family`"
@@ -249,8 +588,22 @@ public class SegmentBuilderTest extends BatchTestCase {
                 + "{[Product].[Drink].[Beverages]} on 0 from sales"},
             new String[] {
                 "4472479a34c350cd2c208d369fae0968f860f61e8a893575f310144b87c7ceb5",
+                    // ^^^
+                    //    {time_by_day.the_year=('1997')}
+                    //    {product_class.product_family=('Drink')}
+                    //    {product_class.product_department=('Dairy')}]
                 "b19558359f411085f94692daefb46806e8bd0c3f95ff491eac0f8274bc655198",
+                    // ^^^
+                    //    {time_by_day.the_year=('1997')}
+                    //    {product_class.product_family=('Drink')}
+                    //    {product_class.product_department=('Beverages')}]
                 "8f8f28faa78d9688b5f2bf0419302b858039544690ed71fd270e2f1c2697fb0a"
+                    // ^^^
+                    //    {time_by_day.the_year=('1997')}
+                    //    {product_class.product_family=
+                    //                              ('Drink','Non-Consumable')}
+                    //    {product_class.product_department=
+                    //                  ('Alcoholic Beverages','Periodicals')}]
             },
             new String[]{
                 "`product_class`.`product_family`"
@@ -405,8 +758,12 @@ public class SegmentBuilderTest extends BatchTestCase {
                 }
             }
         }
+        assertFalse(String.format(
+            "SegmentMap is empty. No segmentIds matched test parameters. "
+            + "Full segment cache: %s", headers), testMap.isEmpty());
         return testMap;
     }
+
 
     /**
      * Creates a rough segment map for testing purposes, containing
@@ -416,20 +773,28 @@ public class SegmentBuilderTest extends BatchTestCase {
      * values array.
      */
     private Map<SegmentHeader, SegmentBody> makeSegmentMap(
-        String[] colNames, int numValsPerCol, int numPopulatedCells)
+        String[] colNames, String[][] colVals,
+        int numValsPerCol, int numPopulatedCells,
+        boolean wildcardCols, boolean[] nullAxisFlags)
     {
+        if (colVals == null) {
+            colVals = dummyColumnValues(colNames.length, numValsPerCol);
+        }
+
         Pair<SegmentHeader, SegmentBody> headerBody = makeDummyHeaderBodyPair(
             colNames,
-            dummyColumnValues(colNames.length, numValsPerCol),
-            numPopulatedCells);
+            colVals,
+            numPopulatedCells, wildcardCols, nullAxisFlags);
         Map<SegmentHeader, SegmentBody> map =
             new HashMap<SegmentHeader, SegmentBody>();
         map.put(headerBody.left, headerBody.right);
 
         return map;
     }
+
     private Pair<SegmentHeader, SegmentBody> makeDummyHeaderBodyPair(
-        String[] colExps, String[][] colVals, int numCellVals)
+        String[] colExps, String[][] colVals, int numCellVals,
+        boolean wildcardCols, boolean[] nullAxisFlags)
     {
         final List<SegmentColumn> constrainedColumns =
             new ArrayList<SegmentColumn>();
@@ -438,19 +803,24 @@ public class SegmentBuilderTest extends BatchTestCase {
             new ArrayList<Pair<SortedSet<Comparable>, Boolean>>();
         for (int i = 0; i < colVals.length; i++) {
             String colExp = colExps[i];
+            SortedSet<Comparable> headerVals = null;
             SortedSet<Comparable> vals =
                 new TreeSet<Comparable>(Arrays.<Comparable>asList(colVals[i]));
+            if (!wildcardCols) {
+                headerVals = vals;
+            }
+            boolean nullAxisFlag = nullAxisFlags != null && nullAxisFlags[i];
             constrainedColumns.add(
                 new SegmentColumn(
                     colExp,
                     colVals[i].length,
-                    vals));
-            axes.add(Pair.of(vals, Boolean.FALSE));
+                    headerVals));
+            axes.add(Pair.of(vals, nullAxisFlag));
         }
 
         Object [] cells = new Object[numCellVals];
         for (int i = 0; i < numCellVals; i++) {
-            cells[i] = 123.123; // assign a non-null val
+            cells[i] = MOCK_CELL_VALUE; // assign a non-null val
         }
         return Pair.<SegmentHeader, SegmentBody>of(
             new SegmentHeader(
@@ -477,6 +847,9 @@ public class SegmentBuilderTest extends BatchTestCase {
         }
         return dummyColVals;
     }
+
+
+
 }
 
 // End SegmentBuilderTest.java


### PR DESCRIPTION
There were 3 places where we were failing to account for nullAxis correctly, resulting in bad CellKey coordinates and incorrect offsets.
(cherry picked from commit 7b095a2)
