### PR TITLE
Mondrian 1869 lag

### DIFF
--- a/src/main/mondrian/olap/fun/AggregateFunDef.java
+++ b/src/main/mondrian/olap/fun/AggregateFunDef.java
@@ -4,7 +4,7 @@
 // http://www.eclipse.org/legal/epl-v10.html.
 // You must accept the terms of that agreement to use this software.
 //
-// Copyright (C) 2005-2013 Pentaho
+// Copyright (C) 2005-2014 Pentaho
 // All Rights Reserved.
 */
 package mondrian.olap.fun;
@@ -105,7 +105,9 @@ public class AggregateFunDef extends AbstractAggregateFunDef {
                     null,
                     "Don't know how to rollup aggregator '" + aggregator + "'");
             }
-            if (aggregator != RolapAggregator.DistinctCount) {
+            if (aggregator != RolapAggregator.DistinctCount
+                && aggregator != RolapAggregator.Avg)
+            {
                 final int savepoint = evaluator.savepoint();
                 try {
                     evaluator.setNonEmpty(false);

--- a/testsrc/main/mondrian/rolap/sql/SqlQueryTest.java
+++ b/testsrc/main/mondrian/rolap/sql/SqlQueryTest.java
@@ -733,6 +733,47 @@ public class SqlQueryTest extends BatchTestCase {
         context.executeQuery(mdx);
         assertQuerySqlOrNot(context, mdx, patterns, true, false, false);
     }
+
+    /**
+     * This is a test for
+     * <a href="http://jira.pentaho.com/browse/MONDRIAN-1869">MONDRIAN-1869</a>
+     *
+     * <p>Avg Aggregates need to be computed in SQL to get correct values.
+     */
+    public void testAvgAggregator() {
+        propSaver.set(propSaver.props.GenerateFormattedSql, true);
+        TestContext context = getTestContext().createSubstitutingCube(
+            "Sales",
+            null,
+            " <Measure name=\"Avg Sales\" column=\"unit_sales\" aggregator=\"avg\"\n"
+            + " formatString=\"#.###\"/>",
+            null,
+            null);
+        String mdx = "select measures.[avg sales] on 0 from sales"
+                       + " where { time.[1997].q1, time.[1997].q2.[4] }";
+        context.assertQueryReturns(
+            mdx,
+            "Axis #0:\n"
+            + "{[Time].[Time].[1997].[Q1]}\n"
+            + "{[Time].[Time].[1997].[Q2].[4]}\n"
+            + "Axis #1:\n"
+            + "{[Measures].[Avg Sales]}\n"
+            + "Row #0: 3.069\n");
+        String sql =
+            "select\n"
+            + "    avg(`sales_fact_1997`.`unit_sales`) as `m0`\n"
+            + "from\n"
+            + "    `sales_fact_1997` as `sales_fact_1997`,\n"
+            + "    `time_by_day` as `time_by_day`\n"
+            + "where\n"
+            + "    ((`time_by_day`.`the_year` = 1997 and `time_by_day`.`quarter` = 'Q1') "
+            + "or (`time_by_day`.`the_year` = 1997 and `time_by_day`.`month_of_year` = 4))\n"
+            + "and\n"
+            + "    `sales_fact_1997`.`time_id` = `time_by_day`.`time_id`";
+        SqlPattern mySqlPattern =
+            new SqlPattern(Dialect.DatabaseProduct.MYSQL, sql, sql.length());
+        assertQuerySql(context, mdx, new SqlPattern[]{mySqlPattern});
+    }
 }
 
 // End SqlQueryTest.java

--- a/testsrc/main/mondrian/test/CompoundSlicerTest.java
+++ b/testsrc/main/mondrian/test/CompoundSlicerTest.java
@@ -4,7 +4,7 @@
 // http://www.eclipse.org/legal/epl-v10.html.
 // You must accept the terms of that agreement to use this software.
 //
-// Copyright (C) 2009-2013 Pentaho and others
+// Copyright (C) 2009-2014 Pentaho and others
 // All Rights Reserved.
 */
 package mondrian.test;
@@ -793,7 +793,7 @@ public class CompoundSlicerTest extends FoodMartTestCase {
             + "where ([Measures].[Avg Unit Sales], [Customers].[OR and CA])",
             "Axis #0:\n"
             + "{[Measures].[Avg Unit Sales], [Customers].[Customers].[OR and CA]}\n"
-            + "3.094");
+            + "3.092");
     }
 
     /**


### PR DESCRIPTION
[MONDRIAN-1869] - avg measures need to be aggregated in SQL similar to distinct-count. You cannot aggregate avg from separate queries because the count for the denominator is lost by then. cherry-pick from f1d5991
