### PR TITLE
[MONDRIAN-1519]  Median from set of one member is returned as 50% from measure value.

### DIFF
--- a/src/main/mondrian/olap/fun/FunUtil.java
+++ b/src/main/mondrian/olap/fun/FunUtil.java
@@ -1197,7 +1197,7 @@ public class FunUtil extends Util {
         } else if (p >= 1.0) {
             return asArray[length - 1];
         } else if (length == 1) {
-            return asArray[0] * p;
+            return asArray[0];
         } else if (p == 0.5) {
             // Special case for median.
             if ((length & 1) == 1) {

--- a/testsrc/main/mondrian/olap/fun/FunctionTest.java
+++ b/testsrc/main/mondrian/olap/fun/FunctionTest.java
@@ -3292,6 +3292,10 @@ public class FunctionTest extends FoodMartTestCase {
             "MEDIAN({[Store].[All Stores].[USA].children},"
             + "[Measures].[Store Sales])",
             "159,167.84");
+        // single value
+        assertExprReturns(
+            "MEDIAN({[Store].[All Stores].[USA]}, [Measures].[Store Sales])",
+            "565,238.13");
     }
 
     public void testMedian2() {
@@ -3403,13 +3407,13 @@ public class FunctionTest extends FoodMartTestCase {
     public void testPercentileBugMondrian1045() {
         assertExprReturns(
             "Percentile({[Store].[All Stores].[USA]}, [Measures].[Store Sales], 50)",
-            "282,619.07");
+            "565,238.13");
         assertExprReturns(
             "Percentile({[Store].[All Stores].[USA]}, [Measures].[Store Sales], 40)",
-            "226,095.25");
+            "565,238.13");
         assertExprReturns(
             "Percentile({[Store].[All Stores].[USA]}, [Measures].[Store Sales], 95)",
-            "536,976.22");
+            "565,238.13");
     }
 
     public void testMin() {


### PR DESCRIPTION
In the case of single value arrays, the percentile function was returning p*value, which is inconsistent with most other implementations of Percentile (e.g. Excel's).
    (cherry picked from commit c3956f2)
