### PR TITLE
[MONDRIAN-2072]  When a virtual cube uses a compound slicer with unrelated dimensions, invalid results occur

### DIFF
--- a/src/main/mondrian/rolap/RolapResult.java
+++ b/src/main/mondrian/rolap/RolapResult.java
@@ -5,7 +5,7 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2001-2005 Julian Hyde
-// Copyright (C) 2005-2013 Pentaho and others
+// Copyright (C) 2005-2014 Pentaho and others
 // All Rights Reserved.
 */
 package mondrian.rolap;
@@ -363,8 +363,12 @@ public class RolapResult extends ResultBase {
                             new DummyExp(query.slicerCalc.getType()))
                         {
                             public Object evaluate(Evaluator evaluator) {
+                                TupleList list =
+                                    AbstractAggregateFunDef
+                                        .processUnrelatedDimensions(
+                                            tupleList1, evaluator);
                                 return AggregateFunDef.AggregateCalc.aggregate(
-                                    valueCalc, evaluator, tupleList1);
+                                    valueCalc, evaluator, list);
                             }
                         };
                     final List<RolapCubeHierarchy> hierarchyList =


### PR DESCRIPTION
This change is a merge of Will's commit (https://github.com/wgorman/mondrian/commit/953037d879bba35a31f330d8e71d6fbab5b3ae50),
plus tests to verify functionality.  The commit also addresses the case where a measure is present in the slicer, which was not covered by Will's original commit.
(cherry picked from 2301e014d)
