### PR TITLE
[MONDRIAN-2107]  Incorrect segment rollup with overlapping segments.

### DIFF
--- a/src/main/mondrian/rolap/RolapUtil.java
+++ b/src/main/mondrian/rolap/RolapUtil.java
@@ -5,7 +5,7 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2001-2005 Julian Hyde
-// Copyright (C) 2005-2013 Pentaho and others
+// Copyright (C) 2005-2014 Pentaho and others
 // All Rights Reserved.
 //
 // jhyde, 22 December, 2001
@@ -636,7 +636,7 @@ public class RolapUtil {
         return result.getRootEvaluator();
     }
 
-    static interface ExecuteQueryHook {
+    public static interface ExecuteQueryHook {
         void onExecuteQuery(String sql);
     }
 


### PR DESCRIPTION
There was the possiblity of creating invalid segments if rolled up segments overlapped and/or were unconstrained for one or more columns.
This commit adds checks for cases where more than one segment has an unconstrained column (i.e. requestedValues=null) and merges the value sets.  This avoids "losing" values.  Also added verification that cells being added to a rollup haven't already been added (if there's an overlap).
