### PR TITLE
[TEST]  ParentChildHierarchyTest.testParentChildOrdinal was failing due ...

### DIFF
--- a/src/main/mondrian/rolap/RolapSchemaUpgrader.java
+++ b/src/main/mondrian/rolap/RolapSchemaUpgrader.java
@@ -3223,6 +3223,15 @@ public class RolapSchemaUpgrader {
                         Collections.singletonList(
                             physClosureTable.getColumn(
                                 xmlLegacyLevel.closure.childColumn, true)));
+                // add link between closure and dim relation
+                physSchemaConverter.physSchema.addLink(
+                    relation.lookupKey(
+                        Collections.singletonList(
+                            relation.getColumn(keyColumn.name, false)), false),
+                    physClosureTable,
+                    Collections.singletonList(
+                        physClosureTable.getColumn(
+                            xmlLegacyLevel.closure.childColumn, true)), false);
                 if (links != null) {
                     for (Link link : links) {
                         physSchemaConverter.physSchema.addLink(

--- a/testsrc/main/mondrian/test/ParentChildHierarchyTest.java
+++ b/testsrc/main/mondrian/test/ParentChildHierarchyTest.java
@@ -5,7 +5,7 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2003-2005 Julian Hyde
-// Copyright (C) 2005-2013 Pentaho
+// Copyright (C) 2005-2014 Pentaho
 // All Rights Reserved.
 //
 // jhyde, Mar 6, 2003
@@ -1010,18 +1010,18 @@ public class ParentChildHierarchyTest extends FoodMartTestCase {
             "Axis #0:\n"
             + "{}\n"
             + "Axis #1:\n"
-            + "{[Employees].[Employees].[Sheri Nowmer].[Derrick Whelply].[Beverly Baker].[Shauna Wyro].[Bunny McCown].[Nancy Miller]}\n"
-            + "{[Employees].[Employees].[Sheri Nowmer].[Derrick Whelply].[Beverly Baker].[Shauna Wyro].[Bunny McCown].[Wanda Hollar]}\n"
-            + "{[Employees].[Employees].[Sheri Nowmer].[Derrick Whelply].[Beverly Baker].[Jacqueline Wyllie].[Ralph Mccoy].[Anne Tuck].[Corinne Zugschwert]}\n"
-            + "{[Employees].[Employees].[Sheri Nowmer].[Derrick Whelply].[Beverly Baker].[Jacqueline Wyllie].[Ralph Mccoy].[Anne Tuck].[Michelle Adams]}\n"
-            + "{[Employees].[Employees].[Sheri Nowmer].[Derrick Whelply].[Beverly Baker].[Jacqueline Wyllie].[Ralph Mccoy].[Anne Tuck].[Donahue Steen]}\n"
-            + "{[Employees].[Employees].[Sheri Nowmer].[Derrick Whelply].[Beverly Baker].[Jacqueline Wyllie].[Ralph Mccoy].[Anne Tuck].[John Baker]}\n"
-            + "Row #0: $148.20\n"
-            + "Row #0: $80.36\n"
-            + "Row #0: $159.60\n"
-            + "Row #0: $155.04\n"
+            + "{[Employees].[Employees].[Sheri Nowmer].[Donna Arnold].[Howard Bechard]}\n"
+            + "{[Employees].[Employees].[Sheri Nowmer].[Donna Arnold].[Doris Carter]}\n"
+            + "{[Employees].[Employees].[Sheri Nowmer].[Roberta Damstra].[Phyllis Burchett]}\n"
+            + "{[Employees].[Employees].[Sheri Nowmer].[Roberta Damstra].[Jennifer Cooper]}\n"
+            + "{[Employees].[Employees].[Sheri Nowmer].[Roberta Damstra].[Jessica Olguin]}\n"
+            + "{[Employees].[Employees].[Sheri Nowmer].[Roberta Damstra].[Peggy Petty]}\n"
+            + "Row #0: $193.80\n"
+            + "Row #0: $60.00\n"
+            + "Row #0: $120.00\n"
             + "Row #0: $152.76\n"
-            + "Row #0: $186.96\n");
+            + "Row #0: $120.00\n"
+            + "Row #0: $182.40\n");
     }
 
     public void testLevelMembers() {


### PR DESCRIPTION
...to a missing link in the upgraded legacy schema.  The link between closure and fact table was present, but not between closure and dim table.  Also corrected the expected results for the query-- formerly the set of [Employees] was not in correct order.  Results now match the ordering from the Mondrian 3 test.
