### PR TITLE
[CUST-169][MONDRIAN-2128][MONDRIAN-2016]  Addressing two issues with the...

### DIFF
--- a/src/main/mondrian/olap/fun/AggregateFunDef.java
+++ b/src/main/mondrian/olap/fun/AggregateFunDef.java
@@ -4,18 +4,20 @@
 // http://www.eclipse.org/legal/epl-v10.html.
 // You must accept the terms of that agreement to use this software.
 //
-// Copyright (C) 2005-2012 Pentaho
-// All Rights Reserved.
+// Copyright (c) 2002-2014 Pentaho Corporation..  All rights reserved.
 */
 package mondrian.olap.fun;
 
 import mondrian.calc.*;
 import mondrian.calc.impl.*;
+import mondrian.mdx.MemberExpr;
 import mondrian.mdx.ResolvedFunCall;
 import mondrian.olap.*;
 import mondrian.olap.Role.RollupPolicy;
 import mondrian.rolap.RolapAggregator;
 import mondrian.rolap.RolapEvaluator;
+
+import org.apache.log4j.Logger;
 
 import org.eigenbase.util.property.IntegerProperty;
 
@@ -31,7 +33,8 @@ public class AggregateFunDef extends AbstractAggregateFunDef {
 
     private static final String TIMING_NAME =
         AggregateFunDef.class.getSimpleName();
-
+    private static final Logger LOGGER =
+        Logger.getLogger(AggregateFunDef.class);
     static final ReflectiveMultiResolver resolver =
         new ReflectiveMultiResolver(
             "Aggregate", "Aggregate(<Set>[, <Numeric Expression>])",
@@ -48,31 +51,61 @@ public class AggregateFunDef extends AbstractAggregateFunDef {
         super(dummyFunDef);
     }
 
+    private Member getMember(Exp exp) {
+        if (exp instanceof MemberExpr) {
+            Member m = ((MemberExpr)exp).getMember();
+            if (m.isMeasure() && !m.isCalculated()) {
+                return m;
+            }
+        }
+        // Since the expression is not a base measure, we won't
+        // attempt to determine the aggregator and will simply sum.
+        LOGGER.warn(
+            "Unable to determine aggregator for non-base measures "
+            + "in 2nd parameter of Aggregate(), summing: " + exp.toString());
+        return null;
+    }
+
     public Calc compileCall(ResolvedFunCall call, ExpCompiler compiler) {
         final ListCalc listCalc = compiler.compileList(call.getArg(0));
         final Calc calc =
             call.getArgCount() > 1
-            ? compiler.compileScalar(call.getArg(1), true)
-            : new ValueCalc(call);
-        return new AggregateCalc(call, listCalc, calc);
+                ? compiler.compileScalar(call.getArg(1), true)
+                : new ValueCalc(call);
+        final Member member =
+            call.getArgCount() > 1 ? getMember(call.getArg(1)) : null;
+        return new AggregateCalc(call, listCalc, calc, member);
     }
 
     public static class AggregateCalc extends GenericCalc {
         private final ListCalc listCalc;
         private final Calc calc;
+        private final Member member;
 
-        public AggregateCalc(Exp exp, ListCalc listCalc, Calc calc) {
+        public AggregateCalc(
+            Exp exp, ListCalc listCalc, Calc calc, Member member)
+        {
             super(exp, new Calc[]{listCalc, calc});
             this.listCalc = listCalc;
             this.calc = calc;
+            this.member = member;
+        }
+
+        public AggregateCalc(Exp exp, ListCalc listCalc, Calc calc) {
+            this(exp, listCalc, calc, null);
         }
 
         public Object evaluate(Evaluator evaluator) {
             evaluator.getTiming().markStart(TIMING_NAME);
+            final int savepoint = evaluator.savepoint();
             try {
                 TupleList list = evaluateCurrentList(listCalc, evaluator);
+                if (member != null) {
+                    evaluator.setContext(member);
+                }
                 return aggregate(calc, evaluator, list);
             } finally {
+                evaluator.restore(savepoint);
                 evaluator.getTiming().markEnd(TIMING_NAME);
             }
         }

--- a/testsrc/main/mondrian/rolap/FastBatchingCellReaderTest.java
+++ b/testsrc/main/mondrian/rolap/FastBatchingCellReaderTest.java
@@ -4,8 +4,7 @@
 // http://www.eclipse.org/legal/epl-v10.html.
 // You must accept the terms of that agreement to use this software.
 //
-// Copyright (C) 2007-2012 Pentaho and others
-// All Rights Reserved.
+// Copyright (c) 2002-2014 Pentaho Corporation..  All rights reserved.
 */
 package mondrian.rolap;
 
@@ -1971,6 +1970,171 @@ public class FastBatchingCellReaderTest extends BatchTestCase {
             new SqlPattern(Dialect.DatabaseProduct.MYSQL, mysqlSql, mysqlSql)};
 
         assertQuerySql(query, patterns);
+    }
+
+    public void testAggregateDistinctCount2ndParameter() {
+        // simple case of count distinct measure as second argument to
+        // Aggregate().  Should apply distinct-count aggregator (MONDRIAN-2016)
+        assertQueryReturns(
+            "with\n"
+            + "  set periods as [Time].[1997].[Q1].[1] : [Time].[1997].[Q4].[10]\n"
+            + "  member [Time].[agg] as Aggregate(periods, [Measures].[Customer Count])\n"
+            + "select\n"
+            + "  [Time].[agg]  ON COLUMNS,\n"
+            + "  [Gender].[M] on ROWS\n"
+            + "FROM [Sales]",
+            "Axis #0:\n"
+            + "{}\n"
+            + "Axis #1:\n"
+            + "{[Time].[agg]}\n"
+            + "Axis #2:\n"
+            + "{[Gender].[M]}\n"
+            + "Row #0: 2,651\n");
+        assertQueryReturns(
+            "WITH MEMBER [Measures].[My Distinct Count] AS \n"
+            + "'AGGREGATE([1997].Children, [Measures].[Customer Count])' \n"
+            + "SELECT {[Measures].[My Distinct Count], [Measures].[Customer Count]} ON COLUMNS,\n"
+            + "{[1997].Children} ON ROWS\n"
+            + "FROM Sales",
+            "Axis #0:\n"
+            + "{}\n"
+            + "Axis #1:\n"
+            + "{[Measures].[My Distinct Count]}\n"
+            + "{[Measures].[Customer Count]}\n"
+            + "Axis #2:\n"
+            + "{[Time].[1997].[Q1]}\n"
+            + "{[Time].[1997].[Q2]}\n"
+            + "{[Time].[1997].[Q3]}\n"
+            + "{[Time].[1997].[Q4]}\n"
+            + "Row #0: 5,581\n"
+            + "Row #0: 2,981\n"
+            + "Row #1: 5,581\n"
+            + "Row #1: 2,973\n"
+            + "Row #2: 5,581\n"
+            + "Row #2: 3,026\n"
+            + "Row #3: 5,581\n"
+            + "Row #3: 3,261\n");
+    }
+
+    public void testCountDistinctAggWithOtherCountDistinctInContext() {
+        // tests that Aggregate( <set>, <count-distinct measure>) aggregates
+        // the correct measure when a *different* count-distinct measure is
+        // in context (MONDRIAN-2128)
+        TestContext testContext = TestContext.instance().create(
+            null,
+            "<Cube name=\"2CountDistincts\" defaultMeasure=\"Store Count\">\n"
+            + "  <Table name=\"sales_fact_1997\"/>\n"
+            + "    <DimensionUsage name=\"Time\" source=\"Time\" "
+            + "foreignKey=\"time_id\"/>"
+            + "  <DimensionUsage name=\"Store\" source=\"Store\" "
+            + "foreignKey=\"store_id\"/>\n"
+            + "    <DimensionUsage name=\"Product\" source=\"Product\" "
+            + "  foreignKey=\"product_id\"/>"
+            + "  <Measure name=\"Store Count\" column=\"store_id\" "
+            + "aggregator=\"distinct-count\"/>\n"
+            + "  <Measure name=\"Customer Count\" column=\"customer_id\" "
+            + "aggregator=\"distinct-count\"/>\n"
+            + "  <Measure name=\"Unit Sales\" column=\"unit_sales\" "
+            + "aggregator=\"sum\"/>\n"
+            + "</Cube>",
+            null,
+            null,
+            null,
+            null);
+        // We should get the same answer whether the default [Store Count]
+        // measure is in context or [Unit Sales].  The measure specified in the
+        // second param of Aggregate() should be used.
+        final String queryStoreCountInContext =
+            "with member Store.agg as "
+            + "'aggregate({[Store].[USA].[CA],[Store].[USA].[OR]}, "
+            + "           measures.[Customer Count])'"
+            + " select Store.agg on 0 from [2CountDistincts] ";
+        final String queryUnitSalesInContext =
+            "with member Store.agg as "
+            + "'aggregate({[Store].[USA].[CA],[Store].[USA].[OR]}, "
+            + "           measures.[Customer Count])'"
+            + " select Store.agg on 0 from [2CountDistincts] where "
+            + "measures.[Unit Sales] ";
+        assertQueriesReturnSimilarResults(
+            queryStoreCountInContext, queryUnitSalesInContext, testContext);
+
+        final String queryCAORRollup =
+            "with member measures.agg as "
+            + "'aggregate({[Store].[USA].[CA],[Store].[USA].[OR]}, "
+            + "           measures.[Customer Count])'"
+            + " select {measures.agg, measures.[Customer Count]} on 0,  "
+            + " [Product].[All Products].children on 1 "
+            + "from [2CountDistincts] ";
+        testContext.assertQueryReturns(
+            queryCAORRollup,
+            "Axis #0:\n"
+            + "{}\n"
+            + "Axis #1:\n"
+            + "{[Measures].[agg]}\n"
+            + "{[Measures].[Customer Count]}\n"
+            + "Axis #2:\n"
+            + "{[Product].[Drink]}\n"
+            + "{[Product].[Food]}\n"
+            + "{[Product].[Non-Consumable]}\n"
+            + "Row #0: 2,243\n"
+            + "Row #0: 3,485\n"
+            + "Row #1: 3,711\n"
+            + "Row #1: 5,525\n"
+            + "Row #2: 2,957\n"
+            + "Row #2: 4,468\n");
+
+        // [Customer Count] should override context
+        testContext.assertQueryReturns(
+            "with member Store.agg as "
+            + "'aggregate({[Store].[USA].[CA],[Store].[USA].[OR]}, "
+            + "           measures.[Customer Count])'"
+            + " select {measures.[Store Count], measures.[Customer Count]} on 0,  "
+            + " [Store].agg on 1 "
+            + "from [2CountDistincts] ",
+            "Axis #0:\n"
+            + "{}\n"
+            + "Axis #1:\n"
+            + "{[Measures].[Store Count]}\n"
+            + "{[Measures].[Customer Count]}\n"
+            + "Axis #2:\n"
+            + "{[Store].[agg]}\n"
+            + "Row #0: 3,753\n"
+            + "Row #0: 3,753\n");
+        // aggregate should pick up measure in context
+        testContext.assertQueryReturns(
+            "with member Store.agg as "
+            + "'aggregate({[Store].[USA].[CA],[Store].[USA].[OR]})'"
+            + " select {measures.[Store Count], measures.[Customer Count]} on 0,  "
+            + " [Store].agg on 1 "
+            + "from [2CountDistincts] ",
+            "Axis #0:\n"
+            + "{}\n"
+            + "Axis #1:\n"
+            + "{[Measures].[Store Count]}\n"
+            + "{[Measures].[Customer Count]}\n"
+            + "Axis #2:\n"
+            + "{[Store].[agg]}\n"
+            + "Row #0: 6\n"
+            + "Row #0: 3,753\n");
+    }
+
+    public void testContextSetCorrectlyWith2ParamAggregate() {
+        // Aggregate with a second parameter may change context.  Verify
+        // the evaluator is restored.   The query below would return
+        // the [Unit Sales] value instead of [Store Sales] if context was
+        // not restored.
+        assertQueryReturns(
+            "with \n"
+            + "member Store.cond as 'iif( \n"
+            + "aggregate({[Store].[All Stores].[USA]}, measures.[unit sales])\n"
+            + " > 70000, (Store.[All Stores], measures.currentMember), 0)'\n"
+            + "select Store.cond on 0 from sales\n"
+            + "where measures.[store sales]\n",
+            "Axis #0:\n"
+            + "{[Measures].[Store Sales]}\n"
+            + "Axis #1:\n"
+            + "{[Store].[cond]}\n"
+            + "Row #0: 565,238.13\n");
     }
 
     public void testAggregateDistinctCountInDimensionFilter() {


### PR DESCRIPTION
... Aggregate function when a second parameter is specified.  Aggregate() would formerly sum up the value of the second parameter, even if a different aggregator was appropriate (e.g. if a count distinct measure was specified).  If the second parameter is not a base measure we fall back to summing (consistent with SSAS when Aggregate is applied on a non-measures calculated member).

This commit also fixes a related issue involving non-additive measures in context when the 2 argument form of Aggregate is evaluated.  Formerly this would cause the second argument to be ignored (this was the issue with MONDRIAN-2128)
These changes were merged from Will Gorman's branch:  https://github.com/wgorman/mondrian/commit/e19cda6a2e1b03e2482dca502ffef258e41baa7a
(cherry picked from commit 5ab0031)
