### PR TITLE
[MONDRIAN-2124]  Cell queries are not aggregated when ignored/un-matched...

### DIFF
--- a/src/main/mondrian/rolap/agg/AggregationManager.java
+++ b/src/main/mondrian/rolap/agg/AggregationManager.java
@@ -5,12 +5,11 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2001-2005 Julian Hyde
-// Copyright (C) 2005-2013 Pentaho and others
+// Copyright (C) 2005-2014 Pentaho and others
 // All Rights Reserved.
 //
 // jhyde, 30 August, 2001
 */
-
 package mondrian.rolap.agg;
 
 import mondrian.olap.CacheControl;
@@ -378,9 +377,19 @@ public class AggregationManager extends RolapAggregationManager {
                 // the agg stars levels, or if the agg star is not
                 // fully collapsed.
                 rollup[0] = !aggStar.isFullyCollapsed()
+                    || aggStar.hasIgnoredColumns()
                     || (levelBitKey.isEmpty()
                     || !aggStar.getLevelBitKey().equals(levelBitKey));
                 return aggStar;
+            } else if (aggStar.hasIgnoredColumns()) {
+                // we cannot safely pull a distinct count from an agg
+                // table if ignored columns are present since granularity
+                // may not be at the level of the dc measure
+                LOGGER.info(
+                    aggStar.getFactTable().getName()
+                    + " cannot be used for distinct-count measures since it has"
+                    + " unused or ignored columns.");
+                continue;
             }
 
             // If there are distinct measures, we can only rollup in limited

--- a/src/main/mondrian/rolap/aggmatcher/AggStar.java
+++ b/src/main/mondrian/rolap/aggmatcher/AggStar.java
@@ -5,10 +5,9 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2005-2005 Julian Hyde
-// Copyright (C) 2005-2013 Pentaho and others
+// Copyright (C) 2005-2014 Pentaho and others
 // All Rights Reserved.
 */
-
 package mondrian.rolap.aggmatcher;
 
 import mondrian.olap.*;
@@ -55,6 +54,7 @@ import javax.sql.DataSource;
  */
 public class AggStar {
     private static final Logger LOGGER = Logger.getLogger(AggStar.class);
+    private boolean hasIgnoredColumns;
 
     static Logger getLogger() {
         return LOGGER;
@@ -110,6 +110,8 @@ public class AggStar {
             JdbcSchema.Table.Column.Usage usage = it.next();
             aggStarFactTable.loadLevel(usage);
         }
+        aggStar.hasIgnoredColumns =
+            dbTable.getColumnUsages(UsageType.IGNORE).hasNext();
 
         // 5. for each distinct-count measure, populate a list of the levels
         //    which it is OK to roll up
@@ -449,6 +451,10 @@ public class AggStar {
 
     private static final Logger JOIN_CONDITION_LOGGER =
             Logger.getLogger(AggStar.Table.JoinCondition.class);
+
+    public boolean hasIgnoredColumns() {
+        return hasIgnoredColumns;
+    }
 
     /**
      * Base Table class for the FactTable and DimTable classes.

--- a/src/main/mondrian/rolap/aggmatcher/Recognizer.java
+++ b/src/main/mondrian/rolap/aggmatcher/Recognizer.java
@@ -5,10 +5,9 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2005-2005 Julian Hyde
-// Copyright (C) 2005-2012 Pentaho and others
+// Copyright (C) 2005-2014 Pentaho and others
 // All Rights Reserved.
 */
-
 package mondrian.rolap.aggmatcher;
 
 import mondrian.olap.*;
@@ -757,6 +756,8 @@ abstract class Recognizer {
                     dbFactTable.getName(),
                     aggColumn.getName());
                 unusedColumnMsgs.put(aggColumn.getName(), msg);
+                // since the column has no usage it will be ignored
+                makeIgnore(aggColumn);
             }
         }
         for (String msg : unusedColumnMsgs.values()) {

--- a/testsrc/main/mondrian/rolap/agg/AggregationOnDistinctCountMeasuresTest.java
+++ b/testsrc/main/mondrian/rolap/agg/AggregationOnDistinctCountMeasuresTest.java
@@ -1,12 +1,11 @@
 /*
-* This software is subject to the terms of the Eclipse Public License v1.0
-* Agreement, available at the following URL:
-* http://www.eclipse.org/legal/epl-v10.html.
-* You must accept the terms of that agreement to use this software.
-*
-* Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (c) 2002-2014 Pentaho Corporation..  All rights reserved.
 */
-
 package mondrian.rolap.agg;
 
 import mondrian.calc.TupleList;
@@ -1112,9 +1111,6 @@ public class AggregationOnDistinctCountMeasuresTest extends BatchTestCase {
         // directly into optimizeChildren like some of the tests below rather
         // than using SQL pattern verification.
         SqlPattern[] patterns = {
-            /*
-            new SqlPattern(SqlPattern.Dialect.DERBY, derbySql, derbySql),
-            */
             new SqlPattern(
                 Dialect.DatabaseProduct.ACCESS, accessSql, accessSql)};
 
@@ -1550,9 +1546,9 @@ public class AggregationOnDistinctCountMeasuresTest extends BatchTestCase {
             + "      <AggExclude name=\"agg_pl_01_sales_fact_1997\"/>"
             + "      <AggName name=\"agg_c_10_sales_fact_1997\">"
             + "           <AggFactCount column=\"FACT_COUNT\"/>"
-            + "           <AggIgnoreColumn column=\"store_sales\"/>"
-            + "           <AggIgnoreColumn column=\"store_cost\"/>"
-            + "           <AggIgnoreColumn column=\"unit_sales\"/>"
+            + "           <AggMeasure name=\"[Measures].[Store Sales]\" column=\"store_sales\"/>"
+            + "           <AggMeasure name=\"[Measures].[Store Cost]\" column=\"store_cost\"/>"
+            + "           <AggMeasure name=\"[Measures].[Unit Sales]\" column=\"unit_sales\"/>"
             + "           <AggMeasure name=\"[Measures].[Customer Count]\" column=\"customer_count\" />"
             + "           <AggLevel name=\"[Time].[Year]\" column=\"the_year\" />"
             + "           <AggLevel name=\"[Time].[Quarter]\" column=\"quarter\" />"
@@ -1560,6 +1556,12 @@ public class AggregationOnDistinctCountMeasuresTest extends BatchTestCase {
             + "      </AggName>"
             + "  </Table>"
             + "  <DimensionUsage name=\"Time\" source=\"Time\" foreignKey=\"time_id\"/> "
+            + "<Measure name=\"Unit Sales\" column=\"unit_sales\" aggregator=\"sum\"\n"
+            + "      formatString=\"Standard\"/>\n"
+            + "  <Measure name=\"Store Cost\" column=\"store_cost\" aggregator=\"sum\"\n"
+            + "      formatString=\"#,###.00\"/>\n"
+            + "  <Measure name=\"Store Sales\" column=\"store_sales\" aggregator=\"sum\"\n"
+            + "      formatString=\"#,###.00\"/>"
             + "  <Measure name=\"Customer Count\" column=\"customer_id\" aggregator=\"distinct-count\" formatString=\"#,###\" />"
             + "</Cube>";
         final String query =


### PR DESCRIPTION
... columns are present

There's logic in AggregationManager.findAgg() which determines whether or not it's possible to omit the rollup when pulling data
from an aggregate table.  This is allowed, for example, if the granularity of the request matches the granularity of the agg table.
Formerly we were determining whether the granularity is the same  by looking at whether the bitkeys matched, and whether
the agg table was fully collapsed.  This left open the possibility that ignored or unused columns in the agg table could result in difft
 granularity.  Now we take the conservative stance that presence of any ignored column means that we have to rollup.
 Similary, for distinct-count measures, if an ignored or unused column is present, we now make the assumption that the agg table
 cannot be safely used.
