### PR TITLE
[MONDRIAN-2057] For hierarchies with explicit default members, use the

### DIFF
--- a/src/main/mondrian/olap/Hierarchy.java
+++ b/src/main/mondrian/olap/Hierarchy.java
@@ -69,6 +69,11 @@ public interface Hierarchy extends OlapElement, Annotated {
     boolean hasAll();
 
     /**
+     * True if the default member was explicitly defined in the schema.
+     */
+    boolean isDefaultMemberExplicit();
+
+    /**
      * Creates a member of this hierarchy. If this is the measures hierarchy, a
      * calculated member is created, and <code>formula</code> must not be null.
      */

--- a/src/main/mondrian/rolap/RolapCubeHierarchy.java
+++ b/src/main/mondrian/rolap/RolapCubeHierarchy.java
@@ -36,6 +36,11 @@ public class RolapCubeHierarchy extends RolapHierarchy {
     RolapMember defaultMember;
 
     /**
+     * true if the default member was explicitly specified in the schema.
+     */
+    boolean defaultMemberExplicit = false;
+
+    /**
      * Creates a RolapCubeHierarchy.
      *
      * @param schemaLoader Schema loader
@@ -242,6 +247,14 @@ public class RolapCubeHierarchy extends RolapHierarchy {
         if (member != null) {
             this.defaultMember = member;
         }
+    }
+
+    public boolean isDefaultMemberExplicit() {
+        return defaultMemberExplicit;
+    }
+
+    public void setDefaultMemberExplicit(boolean defaultMemberExplicit) {
+        this.defaultMemberExplicit = defaultMemberExplicit;
     }
 
     void setMemberReader(MemberReader memberReader) {

--- a/src/main/mondrian/rolap/RolapHierarchy.java
+++ b/src/main/mondrian/rolap/RolapHierarchy.java
@@ -193,6 +193,10 @@ public class RolapHierarchy extends HierarchyBase {
         return ((RolapDimension) dimension).schema;
     }
 
+    public boolean isDefaultMemberExplicit() {
+        throw new UnsupportedOperationException();
+    }
+
     public RolapMember getDefaultMember() {
         throw new UnsupportedOperationException();
     }

--- a/src/main/mondrian/rolap/RolapResult.java
+++ b/src/main/mondrian/rolap/RolapResult.java
@@ -781,6 +781,9 @@ public class RolapResult extends ResultBase {
                         measureMembers.add(mm);
                     }
                 } else {
+                    if (h.isDefaultMemberExplicit()) {
+                        continue;
+                    }
                     if (h.hasAll()) {
                         for (Member m : rootMembers) {
                             if (m.isAll()) {

--- a/src/main/mondrian/rolap/RolapSchemaLoader.java
+++ b/src/main/mondrian/rolap/RolapSchemaLoader.java
@@ -6116,6 +6116,7 @@ public class RolapSchemaLoader {
                     lookup(cube.getSchemaReader(), cubeHierarchy);
                 if (member != null) {
                     setDefaultMember(cubeHierarchy, member);
+                    cubeHierarchy.setDefaultMemberExplicit(true);
                 } else {
                     ++failureCount;
                 }

--- a/testsrc/main/mondrian/rolap/NonEmptyTest.java
+++ b/testsrc/main/mondrian/rolap/NonEmptyTest.java
@@ -644,6 +644,10 @@ public class NonEmptyTest extends BatchTestCase {
             + "Row #0: TV\n");
     }
 
+    /**
+     * This bug is directly linked to the current behavior in RolapResult.loadSpecialMembers()
+     * Without grabbing all the root members of the Promotions dimension, unexpected behavior occurs.
+     */
     public void testBug1515302() {
         TestContext ctx = TestContext.instance().legacy().create(
             null,
@@ -718,6 +722,60 @@ public class NonEmptyTest extends BatchTestCase {
             + "Row #15: 65\n"
             + "Row #16: 3\n"
             + "Row #17: 366\n");
+    }
+
+    /**
+     * This is a companion to the previous test.  It demonstrates the narrowing behavior
+     * if the default member is explicitly set for Promotions.
+     */
+    public void testExplicitDefaultMemberBehavior() {
+        TestContext ctx = TestContext.instance().legacy().create(
+            null,
+            "<Cube name=\"Bug1515302\"> \n"
+            + "  <Table name=\"sales_fact_1997\"/> \n"
+            + "  <Dimension name=\"Promotions\" foreignKey=\"promotion_id\"> \n"
+            + "    <Hierarchy hasAll=\"false\" primaryKey=\"promotion_id\" defaultMember=\"[Promotions].[Bag Stuffers]\"> \n"
+            + "      <Table name=\"promotion\"/> \n"
+            + "      <Level name=\"Promotion Name\" column=\"promotion_name\" uniqueMembers=\"true\"/> \n"
+            + "    </Hierarchy> \n"
+            + "  </Dimension> \n"
+            + "  <Dimension name=\"Customers\" foreignKey=\"customer_id\"> \n"
+            + "    <Hierarchy hasAll=\"true\" allMemberName=\"All Customers\" primaryKey=\"customer_id\"> \n"
+            + "      <Table name=\"customer\"/> \n"
+            + "      <Level name=\"Country\" column=\"country\" uniqueMembers=\"true\"/> \n"
+            + "      <Level name=\"State Province\" column=\"state_province\" uniqueMembers=\"true\"/> \n"
+            + "      <Level name=\"City\" column=\"city\" uniqueMembers=\"false\"/> \n"
+            + "      <Level name=\"Name\" column=\"customer_id\" type=\"Numeric\" uniqueMembers=\"true\"/> \n"
+            + "    </Hierarchy> \n"
+            + "  </Dimension> \n"
+            + "  <Measure name=\"Unit Sales\" column=\"unit_sales\" aggregator=\"sum\"/> \n"
+            + "</Cube> \n",
+            null,
+            null,
+            null,
+            null);
+
+        ctx.assertQueryReturns(
+            "select {[Measures].[Unit Sales]} on columns, "
+            + "non empty crossjoin({[Promotions].[Big Promo]}, "
+            + "Descendants([Customers].[USA], [City], "
+            + "SELF_AND_BEFORE)) on rows "
+            + "from [Bug1515302]",
+            "Axis #0:\n"
+            + "{}\n"
+            + "Axis #1:\n"
+            + "{[Measures].[Unit Sales]}\n"
+            + "Axis #2:\n"
+            + "{[Promotions].[Promotions].[Big Promo], [Customers].[Customers].[USA]}\n"
+            + "{[Promotions].[Promotions].[Big Promo], [Customers].[Customers].[USA].[WA]}\n"
+            + "{[Promotions].[Promotions].[Big Promo], [Customers].[Customers].[USA].[WA].[Anacortes]}\n"
+            + "{[Promotions].[Promotions].[Big Promo], [Customers].[Customers].[USA].[WA].[Bellingham]}\n"
+            + "{[Promotions].[Promotions].[Big Promo], [Customers].[Customers].[USA].[WA].[Sedro Woolley]}\n"
+            + "Row #0: 1,789\n"
+            + "Row #1: 1,789\n"
+            + "Row #2: 20\n"
+            + "Row #3: 15\n"
+            + "Row #4: 3\n");
     }
 
     /**


### PR DESCRIPTION
single member for axis evaluation.
