### PR TITLE
[MONDRIAN-2057] For hierarchies with explicit default members, use the

### DIFF
--- a/src/main/mondrian/olap/Hierarchy.java
+++ b/src/main/mondrian/olap/Hierarchy.java
@@ -56,6 +56,11 @@ public interface Hierarchy extends OlapElement, Annotated {
     boolean hasAll();
 
     /**
+     * True if the default member was explicitly defined in the schema.
+     */
+    boolean isDefaultMemberExplicit();
+
+    /**
      * Creates a member of this hierarchy. If this is the measures hierarchy, a
      * calculated member is created, and <code>formula</code> must not be null.
      */

--- a/src/main/mondrian/rolap/RolapCubeHierarchy.java
+++ b/src/main/mondrian/rolap/RolapCubeHierarchy.java
@@ -353,6 +353,11 @@ public class RolapCubeHierarchy extends RolapHierarchy {
         return currentDefaultMember;
     }
 
+    @Override
+    public boolean isDefaultMemberExplicit() {
+        return rolapHierarchy.isDefaultMemberExplicit();
+    }
+
     /**
      * Looks up a {@link RolapCubeMember} corresponding to a {@link RolapMember}
      * of the underlying hierarchy. Safe to be called while the hierarchy is

--- a/src/main/mondrian/rolap/RolapHierarchy.java
+++ b/src/main/mondrian/rolap/RolapHierarchy.java
@@ -513,6 +513,10 @@ public class RolapHierarchy extends HierarchyBase {
         return xmlHierarchy;
     }
 
+    public boolean isDefaultMemberExplicit() {
+        return defaultMemberName != null;
+    }
+
     public Member getDefaultMember() {
         // use lazy initialization to get around bootstrap issues
         if (defaultMember == null) {

--- a/src/main/mondrian/rolap/RolapResult.java
+++ b/src/main/mondrian/rolap/RolapResult.java
@@ -783,7 +783,7 @@ public class RolapResult extends ResultBase {
             if (d.getDimensionType() == DimensionType.TimeDimension) {
                 continue;
             }
-            if (!em.isAll()) {
+            if (!em.isAll() && !h.isDefaultMemberExplicit()) {
                 List<Member> rootMembers =
                     schemaReader.getHierarchyRootMembers(h);
                 if (em.isMeasure()) {


### PR DESCRIPTION
single member for axis evaluation.

Conflicts:
    src/main/mondrian/rolap/RolapCubeHierarchy.java
