### PR TITLE
[SP-1337] - Backport of MONDRIAN-2107 - Incorrect segment rollup with ov...

### DIFF
--- a/src/main/mondrian/rolap/RolapUtil.java
+++ b/src/main/mondrian/rolap/RolapUtil.java
@@ -5,7 +5,7 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2001-2005 Julian Hyde
-// Copyright (C) 2005-2013 Pentaho and others
+// Copyright (C) 2005-2014 Pentaho and others
 // All Rights Reserved.
 //
 // jhyde, 22 December, 2001
@@ -636,7 +636,7 @@ public class RolapUtil {
         return result.getRootEvaluator();
     }
 
-    static interface ExecuteQueryHook {
+    public static interface ExecuteQueryHook {
         void onExecuteQuery(String sql);
     }
 

--- a/src/main/mondrian/rolap/agg/AbstractSegmentBody.java
+++ b/src/main/mondrian/rolap/agg/AbstractSegmentBody.java
@@ -4,7 +4,7 @@
 // http://www.eclipse.org/legal/epl-v10.html.
 // You must accept the terms of that agreement to use this software.
 //
-// Copyright (C) 2011-2013 Pentaho and others
+// Copyright (c) 2011-2014 Pentaho Corporation..  All rights reserved.
 // All Rights Reserved.
 */
 package mondrian.rolap.agg;
@@ -117,7 +117,11 @@ abstract class AbstractSegmentBody implements SegmentBody {
                 }
                 int k = ordinals.length - 1;
                 while (k >= 0) {
-                    if (ordinals[k] < axisValueSets[k].size() - 1) {
+                    int j = 1;
+                    if (nullAxisFlags[k]) {
+                        j = 0;
+                    }
+                    if (ordinals[k] < axisValueSets[k].size() - j) {
                         ++ordinals[k];
                         break;
                     } else {

--- a/testsrc/main/mondrian/rolap/agg/SegmentBuilderTest.java
+++ b/testsrc/main/mondrian/rolap/agg/SegmentBuilderTest.java
@@ -4,7 +4,7 @@
 // http://www.eclipse.org/legal/epl-v10.html.
 // You must accept the terms of that agreement to use this software.
 //
-// Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+// Copyright (c) 2002-2014 Pentaho Corporation..  All rights reserved.
 */
 package mondrian.rolap.agg;
 
@@ -12,8 +12,7 @@ import mondrian.olap.*;
 import mondrian.rolap.*;
 import mondrian.spi.*;
 import mondrian.test.*;
-import mondrian.util.ByteString;
-import mondrian.util.Pair;
+import mondrian.util.*;
 
 import java.util.*;
 
@@ -23,6 +22,8 @@ import java.util.*;
  * @author mcampbell
  */
 public class SegmentBuilderTest extends BatchTestCase {
+
+    public static final double MOCK_CELL_VALUE = 123.123;
 
     protected void setUp() throws Exception {
         super.setUp();
@@ -34,6 +35,287 @@ public class SegmentBuilderTest extends BatchTestCase {
             MondrianProperties.instance().SparseSegmentDensityThreshold, .5);
         propSaver.set(
             MondrianProperties.instance().SparseSegmentCountThreshold, 1000);
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        super.tearDown();
+        RolapUtil.setHook(null);
+    }
+
+    public void testRollupWithNullAxisVals() {
+        // Perform two rollups.  One with two columns each containing 3 values.
+        // The second with two columns containing 2 values + null.
+        // The rolled up values should be equal in the two cases.
+        Pair<SegmentHeader, SegmentBody> rollupNoNulls = SegmentBuilder.rollup(
+            makeSegmentMap(
+                new String[] {"col1", "col2"}, null, 3, 9, true,
+                new boolean[] {false, false}),// each axis sets null axis flag=F
+            new HashSet<String>(Arrays.asList("col2")),
+            null, RolapAggregator.Sum, Dialect.Datatype.Numeric);
+        Pair<SegmentHeader, SegmentBody> rollupWithNullMembers =
+            SegmentBuilder.rollup(
+                makeSegmentMap(
+                    new String[] {"col1", "col2"}, null, 2, 9, true,
+                    // each axis sets null axis flag=T
+                    new boolean[] {true, true}),
+                new HashSet<String>(Arrays.asList("col2")),
+                null, RolapAggregator.Sum, Dialect.Datatype.Numeric);
+        assertArraysAreEqual(
+            (double[]) rollupNoNulls.getValue().getValueArray(),
+            (double[]) rollupWithNullMembers.getValue().getValueArray());
+        assertTrue(
+            "Rolled up column should have nullAxisFlag set.",
+            rollupWithNullMembers.getValue().getNullAxisFlags().length == 1
+                && rollupWithNullMembers.getValue().getNullAxisFlags()[0]);
+        assertEquals(
+            "col2",
+            rollupWithNullMembers.getKey().getConstrainedColumns()
+                .get(0).columnExpression);
+    }
+
+    public void testRollupWithMixOfNullAxisValues() {
+        // constructed segment has 3 columns:
+        //    2 values in the first
+        //    2 values + null in the second and third
+        //  = 18 values
+        Pair<SegmentHeader, SegmentBody> rollup = SegmentBuilder.rollup(
+            makeSegmentMap(
+                new String[] {"col1", "col2", "col3"}, null, 2, 18, true,
+                // col2 & col3 have nullAxisFlag=T
+                new boolean[] {false, true, true}),
+            new HashSet<String>(Arrays.asList("col2")),
+            null, RolapAggregator.Sum, Dialect.Datatype.Numeric);
+
+        // expected value is 6 * MOCK_CELL_VALUE for each of 3 column values,
+        // since each of the 18 cells are being rolled up to 3 buckets
+        double expectedVal = 6 * MOCK_CELL_VALUE;
+        assertArraysAreEqual(
+            new double[] { expectedVal, expectedVal, expectedVal },
+            (double[]) rollup.getValue().getValueArray());
+        assertTrue(
+            "Rolled up column should have nullAxisFlag set.",
+            rollup.getValue().getNullAxisFlags().length == 1
+                && rollup.getValue().getNullAxisFlags()[0]);
+        assertEquals(
+            "col2",
+            rollup.getKey().getConstrainedColumns()
+                .get(0).columnExpression);
+    }
+
+    public void testRollup2ColumnsWithMixOfNullAxisValues() {
+        // constructed segment has 3 columns:
+        //    2 values in the first
+        //    2 values + null in the second and third
+        //  = 18 values
+        Pair<SegmentHeader, SegmentBody> rollup = SegmentBuilder.rollup(
+            makeSegmentMap(
+                new String[] {"col1", "col2", "col3"}, null, 2, 12, true,
+                // col2 & col3 have nullAxisFlag=T
+                new boolean[] {false, true, false}),
+            new HashSet<String>(Arrays.asList("col1", "col2")),
+            null, RolapAggregator.Sum, Dialect.Datatype.Numeric);
+
+        // expected value is 2 * MOCK_CELL_VALUE for each of 3 column values,
+        // since each of the 12 cells are being rolled up to 3 * 2 buckets
+        double expectedVal = 2 * MOCK_CELL_VALUE;
+        assertArraysAreEqual(
+            new double[] {expectedVal, expectedVal, expectedVal,
+                expectedVal, expectedVal, expectedVal},
+            (double[]) rollup.getValue().getValueArray());
+        assertTrue(
+            "Rolled up column should have nullAxisFlag set to false for "
+            + "the first column, true for second column.",
+            rollup.getValue().getNullAxisFlags().length == 2
+                && !rollup.getValue().getNullAxisFlags()[0]
+                && rollup.getValue().getNullAxisFlags()[1]);
+        assertEquals(
+            "col1",
+            rollup.getKey().getConstrainedColumns()
+                .get(0).columnExpression);
+        assertEquals(
+            "col2",
+            rollup.getKey().getConstrainedColumns()
+                .get(1).columnExpression);
+    }
+
+    public void testMultiSegRollupWithMixOfNullAxisValues() {
+        // rolls up 2 segments.
+        // Segment 1 has 3 columns:
+        //    2 values in the first
+        //    1 values + null in the second
+        //    2 vals + null in the third
+        //  = 12 values
+        //  Segment 2 has the same 3 columns, difft values for 3rd column.
+        //
+        //  none of the columns are wildcarded.
+        final Map<SegmentHeader, SegmentBody> map = makeSegmentMap(
+            new String[]{"col1", "col2", "col3"},
+            new String[][]{{"col1A", "col1B"}, {"col2A"}, {"col3A", "col3B"}},
+            -1, 12, false,
+            // col2 & col3 have nullAxisFlag=T
+            new boolean[]{false, true, true});
+        map.putAll(
+            makeSegmentMap(
+                new String[]{"col1", "col2", "col3"},
+                new String[][]{{"col1A", "col1B"}, {"col2A"}, {"col3C",
+                    "col3D"}},
+                -1, 8, false,
+                // col3 has nullAxisFlag=T
+                new boolean[]{false, true, false}));
+        Pair<SegmentHeader, SegmentBody> rollup = SegmentBuilder.rollup(
+            map,
+            new HashSet<String>(Arrays.asList("col2")),
+            null, RolapAggregator.Sum, Dialect.Datatype.Numeric);
+        // expected value is 10 * MOCK_CELL_VALUE for each of 2 column values,
+        // since the 20 cells across 2 segments are being rolled up to 2 buckets
+        double expectedVal = 10 * MOCK_CELL_VALUE;
+        assertArraysAreEqual(
+            new double[]{ expectedVal, expectedVal},
+            (double[]) rollup.getValue().getValueArray());
+        assertTrue(
+            "Rolled up column should have nullAxisFlag set to true for "
+            + "a single column.",
+            rollup.getValue().getNullAxisFlags().length == 1
+                && rollup.getValue().getNullAxisFlags()[0]);
+        assertEquals(
+            "col2",
+            rollup.getKey().getConstrainedColumns()
+                .get(0).columnExpression);
+    }
+
+    private void assertArraysAreEqual(double[] expected, double[] actual) {
+        assertTrue(
+            "Expected double array:  "
+                + Arrays.toString(expected)
+                + ", but got "
+                + Arrays.toString(actual),
+            doubleArraysEqual(actual, expected));
+    }
+
+    private boolean doubleArraysEqual(
+        double[] valueArray, double[] expectedVal)
+    {
+        if (valueArray.length != expectedVal.length) {
+            return false;
+        }
+        double within = 0.00000001;
+        for (int i = 0; i < valueArray.length; i++) {
+            if (Math.abs(valueArray[i] - expectedVal[i]) > within) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public void testNullMemberOffset() {
+        // verifies that presence of a null member does not cause
+        // offsets to be incorrect for a Segment rollup.
+        // First query loads the cache with a segment that can fulfill the
+        // second query.
+        executeQuery(
+            "select [Store Size in SQFT].[Store Sqft].members * "
+            + "gender.gender.members  on 0 from sales");
+        assertQueryReturns(
+            "select non empty [Store Size in SQFT].[Store Sqft].members on 0"
+            + "from sales",
+            "Axis #0:\n"
+            + "{}\n"
+            + "Axis #1:\n"
+            + "{[Store Size in SQFT].[#null]}\n"
+            + "{[Store Size in SQFT].[20319]}\n"
+            + "{[Store Size in SQFT].[21215]}\n"
+            + "{[Store Size in SQFT].[22478]}\n"
+            + "{[Store Size in SQFT].[23598]}\n"
+            + "{[Store Size in SQFT].[23688]}\n"
+            + "{[Store Size in SQFT].[27694]}\n"
+            + "{[Store Size in SQFT].[28206]}\n"
+            + "{[Store Size in SQFT].[30268]}\n"
+            + "{[Store Size in SQFT].[33858]}\n"
+            + "{[Store Size in SQFT].[39696]}\n"
+            + "Row #0: 39,329\n"
+            + "Row #0: 26,079\n"
+            + "Row #0: 25,011\n"
+            + "Row #0: 2,117\n"
+            + "Row #0: 25,663\n"
+            + "Row #0: 21,333\n"
+            + "Row #0: 41,580\n"
+            + "Row #0: 2,237\n"
+            + "Row #0: 23,591\n"
+            + "Row #0: 35,257\n"
+            + "Row #0: 24,576\n");
+    }
+
+    public void testNullMemberOffset2ColRollup() {
+        // verifies that presence of a null member does not cause
+        // offsets to be incorrect for a Segment rollup involving 2
+        // columns.  This tests a case where
+        // SegmentBuilder.computeAxisMultipliers needs to factor in
+        // the null axis flag.
+        executeQuery(
+            "select [Store Size in SQFT].[Store Sqft].members * "
+            + "[store].[store state].members * time.[quarter].members on 0"
+            + " from sales where [Product].[Food].[Produce].[Vegetables].[Fresh Vegetables]");
+        assertQueryReturns(
+            "select non empty [Store Size in SQFT].[Store Sqft].members "
+            + " * [store].[store state].members  on 0"
+            + "from sales where [Product].[Food].[Produce].[Vegetables].[Fresh Vegetables]",
+            "Axis #0:\n"
+            + "{[Product].[Food].[Produce].[Vegetables].[Fresh Vegetables]}\n"
+            + "Axis #1:\n"
+            + "{[Store Size in SQFT].[#null], [Store].[USA].[CA]}\n"
+            + "{[Store Size in SQFT].[#null], [Store].[USA].[WA]}\n"
+            + "{[Store Size in SQFT].[20319], [Store].[USA].[OR]}\n"
+            + "{[Store Size in SQFT].[21215], [Store].[USA].[WA]}\n"
+            + "{[Store Size in SQFT].[22478], [Store].[USA].[CA]}\n"
+            + "{[Store Size in SQFT].[23598], [Store].[USA].[CA]}\n"
+            + "{[Store Size in SQFT].[23688], [Store].[USA].[CA]}\n"
+            + "{[Store Size in SQFT].[27694], [Store].[USA].[OR]}\n"
+            + "{[Store Size in SQFT].[28206], [Store].[USA].[WA]}\n"
+            + "{[Store Size in SQFT].[30268], [Store].[USA].[WA]}\n"
+            + "{[Store Size in SQFT].[33858], [Store].[USA].[WA]}\n"
+            + "{[Store Size in SQFT].[39696], [Store].[USA].[WA]}\n"
+            + "Row #0: 1,967\n"
+            + "Row #0: 947\n"
+            + "Row #0: 2,065\n"
+            + "Row #0: 1,827\n"
+            + "Row #0: 165\n"
+            + "Row #0: 2,109\n"
+            + "Row #0: 1,665\n"
+            + "Row #0: 3,382\n"
+            + "Row #0: 162\n"
+            + "Row #0: 1,875\n"
+            + "Row #0: 2,668\n"
+            + "Row #0: 1,907\n");
+    }
+
+    public void testSegmentBodyIterator() {
+        // checks that cell key coordinates are generated correctly
+        // when a null member is present.
+        List<Pair<SortedSet<Comparable>, Boolean>> axes =
+            new ArrayList<Pair<SortedSet<Comparable>, Boolean>>();
+        axes.add(new Pair<SortedSet<Comparable>, Boolean>(
+            new TreeSet<Comparable>(
+                Arrays.asList(
+                    new String[] { "foo1", "bar1"})), true)); // nullAxisFlag=T
+        axes.add(new Pair<SortedSet<Comparable>, Boolean>(
+            new TreeSet<Comparable>(
+                Arrays.asList(new String[] { "foo2", "bar2", "baz3"})), false));
+        SegmentBody testBody = new DenseIntSegmentBody(
+            new BitSet(), new int[]{1, 2, 3, 4, 5, 6, 7, 8, 9},
+            axes);
+        Map valueMap = testBody.getValueMap();
+        assertEquals(
+            "{(0, 0)=1, "
+            + "(0, 1)=2, "
+            + "(0, 2)=3, "
+            + "(1, 0)=4, "
+            + "(1, 1)=5, "
+            + "(1, 2)=6, "
+            + "(2, 0)=7, "
+            + "(2, 1)=8, "
+            + "(2, 2)=9}",
+            valueMap.toString());
     }
 
     public void testSparseRollup() {
@@ -77,7 +359,8 @@ public class SegmentBuilderTest extends BatchTestCase {
         Pair<SegmentHeader, SegmentBody> rollup =
             SegmentBuilder.rollup(
                 makeSegmentMap(
-                    new String[] {"col1", "col2", "col3"}, 47000, 4),
+                    new String[] {"col1", "col2", "col3"},
+                    null, 47000, 4, false, null),
                 new HashSet<String>(Arrays.asList("col1", "col2")),
                 null, RolapAggregator.Sum, Dialect.Datatype.Numeric);
         assertTrue(rollup.right instanceof SparseSegmentBody);
@@ -93,7 +376,8 @@ public class SegmentBuilderTest extends BatchTestCase {
         Pair<SegmentHeader, SegmentBody> rollup =
             SegmentBuilder.rollup(
                 makeSegmentMap(
-                    new String[] {"col1", "col2", "col3"}, 44000, 4),
+                    new String[] {"col1", "col2", "col3"},
+                    null, 44000, 4, false, null),
                 new HashSet<String>(Arrays.asList("col1", "col2")),
                 null, RolapAggregator.Sum, Dialect.Datatype.Numeric);
         assertTrue(rollup.right instanceof SparseSegmentBody);
@@ -104,7 +388,8 @@ public class SegmentBuilderTest extends BatchTestCase {
         Pair<SegmentHeader, SegmentBody> rollup =
             SegmentBuilder.rollup(
                 makeSegmentMap(
-                    new String[] {"col1", "col2", "col3"}, 10, 15),
+                    new String[] {"col1", "col2", "col3"},
+                    null, 10, 15, false, null),
                 new HashSet<String>(Arrays.asList("col1", "col2")),
                 null, RolapAggregator.Sum, Dialect.Datatype.Numeric);
         assertTrue(rollup.right instanceof DenseDoubleSegmentBody);
@@ -114,10 +399,143 @@ public class SegmentBuilderTest extends BatchTestCase {
             SegmentBuilder.rollup(
                 makeSegmentMap(
                     new String[] {"col1", "col2", "col3", "col4"},
-                    11, 10000),   // 1331 possible intersections (11*3)
+                    null, 11, 10000, false, null),
+                    // 1331 possible intersections (11*3)
                 new HashSet<String>(Arrays.asList("col1", "col2", "col3")),
                 null, RolapAggregator.Sum, Dialect.Datatype.Numeric);
         assertTrue(rollup.right instanceof DenseDoubleSegmentBody);
+    }
+
+    public void testOverlappingSegments() {
+        // MONDRIAN-2107
+        // The segments created by the first 2 queries below overlap on
+        //  [1997].[Q1].[1].  The rollup of these two segments should not
+        // doubly-add that cell.
+        // Also, these two segments have predicates optimized for 'quarter'
+        // since 3 out of 4 quarters are present.  This means the
+        //  header.getValues() will be null.  This has the potential
+        // to cause issues with rollup since one segment body will have
+        // 3 values for quarter, the other segment body will have a different
+        // set of values.
+        getTestContext().flushSchemaCache();
+        TestContext context = getTestContext().withFreshConnection();
+
+        context.executeQuery(
+            "select "
+            + "{[Time].[1997].[Q1].[1], [Time].[1997].[Q1].[2], [Time].[1997].[Q1].[3], "
+            + "[Time].[1997].[Q2].[4], [Time].[1997].[Q2].[5], [Time].[1997].[Q2].[6],"
+            + "[Time].[1997].[Q3].[7]} on 0 from sales");
+        context.executeQuery(
+            "select "
+            + "{[Time].[1997].[Q1].[1], [Time].[1997].[Q3].[8], [Time].[1997].[Q3].[9], "
+            + "[Time].[1997].[Q4].[10], [Time].[1997].[Q4].[11], [Time].[1997].[Q4].[12],"
+            + "[Time].[1998].[Q1].[1], [Time].[1998].[Q3].[8], [Time].[1998].[Q3].[9], "
+            + "[Time].[1998].[Q4].[10], [Time].[1998].[Q4].[11], [Time].[1998].[Q4].[12]}"
+            + "on 0 from sales");
+
+        RolapUtil.setHook(
+            new RolapUtil.ExecuteQueryHook()
+        {
+            public void onExecuteQuery(String sql) {
+                //  We shouldn't see a sum of unit_sales in SQL if using rollup.
+                assertFalse(
+                    "Expected cells to be pulled from cache",
+                    sql.matches(".*sum\\([^ ]+unit_sales.*"));
+            }
+        });
+        context.assertQueryReturns(
+            "select [Time].[1997].children on 0 from sales",
+            "Axis #0:\n"
+            + "{}\n"
+            + "Axis #1:\n"
+            + "{[Time].[1997].[Q1]}\n"
+            + "{[Time].[1997].[Q2]}\n"
+            + "{[Time].[1997].[Q3]}\n"
+            + "{[Time].[1997].[Q4]}\n"
+            + "Row #0: 66,291\n"
+            + "Row #0: 62,610\n"
+            + "Row #0: 65,848\n"
+            + "Row #0: 72,024\n");
+    }
+
+    public void testNonOverlappingRollupWithUnconstrainedColumn() {
+        // MONDRIAN-2107
+        // The two segments loaded by the 1st 2 queries will have predicates
+        // optimized for Name.  Prior to the fix for 2107 this would
+        // result in roughly half of the customers having empty results
+        // for the 3rd query, since the values of only one of the two
+        // segments would be loaded into the AxisInfo.
+        getTestContext().flushSchemaCache();
+        TestContext context = getTestContext().withFreshConnection();
+        final String query = "select customers.[name].members on 0 from sales";
+        propSaver.set(propSaver.properties.EnableInMemoryRollup, false);
+        Result result = context.executeQuery(query);
+
+        getTestContext().flushSchemaCache();
+        context = getTestContext().withFreshConnection();
+        propSaver.set(propSaver.properties.EnableInMemoryRollup, true);
+        context.executeQuery(
+            "select "
+            + "{[customers].[name].members} on 0 from sales where gender.f");
+        context.executeQuery(
+            "select "
+            + "{[customers].[name].members} on 0 from sales where gender.m");
+
+        RolapUtil.setHook(
+            new RolapUtil.ExecuteQueryHook()
+        {
+            public void onExecuteQuery(String sql) {
+                //  We shouldn't see a sum of unit_sales in SQL if using rollup.
+                assertFalse(
+                    "Expected cells to be pulled from cache",
+                    sql.matches(".*sum\\([^ ]+unit_sales.*"));
+            }
+        });
+
+        context.assertQueryReturns(
+            query,
+            context.toString(result));
+    }
+
+    public void testNonOverlappingRollupWithUnconstrainedColumnAndHasNull() {
+        // MONDRIAN-2107
+        // Creates 10 segments, one for each city, with various sets
+        // of [Store Sqft].  Some contain NULL, some do not.
+        // Results from rollup should match results from a query not pulling
+        // from cache.
+        String[] states = {"[Canada].BC", "[USA].CA", "[Mexico].DF",
+            "[Mexico].Guerrero", "[Mexico].Jalisco", "[USA].[OR]",
+            "[Mexico].Veracruz", "[USA].WA", "[Mexico].Yucatan",
+            "[Mexico].Zacatecas"};
+        getTestContext().flushSchemaCache();
+        TestContext context = getTestContext().withFreshConnection();
+        final String query =
+            "select [Store Size in SQFT].[Store Sqft].members on 0 from sales";
+
+        Result result = context.executeQuery(query);
+        getTestContext().flushSchemaCache();
+        context = getTestContext().withFreshConnection();
+        for (String state : states) {
+            context.executeQuery(
+                String.format(
+                    "select "
+                    + "{[Store Size in SQFT].[Store Sqft].members} on 0 "
+                    + "from sales where store.%s", state));
+        }
+        RolapUtil.setHook(
+            new RolapUtil.ExecuteQueryHook()
+        {
+            public void onExecuteQuery(String sql) {
+                //  We shouldn't see a sum of unit_sales in SQL if using rollup.
+                assertFalse(
+                    "Expected cell to be pulled from cache",
+                    sql.matches(".*sum\\([^ ]+unit_sales.*"));
+            }
+        });
+
+        context.assertQueryReturns(
+            query,
+            context.toString(result));
     }
 
     public void testBadRollupCausesGreaterThan12Iterations() {
@@ -173,7 +591,15 @@ public class SegmentBuilderTest extends BatchTestCase {
                 + "on 0 from sales"},
             new String[] {
                 "26f2dc1bd8a454424158c348d0e3c64e3c20e00fa807d56442b8a580728e9953",
+                    // ^^^
+                    //    {time_by_day.the_year=('1998')}
+                    //    {time_by_day.quarter=('Q1','Q2','Q3')}
+                    //    {time_by_day.month_of_year=('2','3','4','5','6','7')}]
                 "b76369e0fb17e67bc777aa1e5d2d2d81627992488eb70bb45432ecb6ff6752c9"
+                    // ^^^
+                    // {time_by_day.the_year=(*)}
+                    // {time_by_day.quarter=('Q1','Q3','Q4')}
+                    // {time_by_day.month_of_year=('1','8','9','10','11','12')}]
             },
             new String[]{
                 // rollup columns
@@ -210,7 +636,16 @@ public class SegmentBuilderTest extends BatchTestCase {
                 + "on 0 from sales"},
             new String[] {
               "464a73cb907ccee680acd79a3b03181ddc6b8c2d9cf8b75ea81fcc6d634d8d57",
+                // ^^^
+                //    {time_by_day.the_year=('1997')}
+                //    {product_class.product_family=(*)}
+                //    {product_class.product_department=('Alcoholic Beverages',
+                //     'Baked Goods','Beverages','Periodicals')}]
               "38fec44b20434448aa8c6191ac34ca96157e6db5bb50586d4dc4a55d7385a0f0"
+                // ^^^
+                //    {time_by_day.the_year=('1997')}
+                //    {product_class.product_family=('Drink')}
+                //    {product_class.product_department=('Dairy')}]
             },
             new String[]{
                 "product_class.product_family"
@@ -242,7 +677,16 @@ public class SegmentBuilderTest extends BatchTestCase {
                 + "on 0 from sales"},
             new String[] {
                 "464a73cb907ccee680acd79a3b03181ddc6b8c2d9cf8b75ea81fcc6d634d8d57",
+                    // ^^^
+                    //    {time_by_day.the_year=('1997')}
+                    // {product_class.product_family=('Drink','Non-Consumable')}
+                    // {product_class.product_department=('Alcoholic Beverages',
+                    //  'Beverages','Periodicals')}]
                 "4b7d7b408d42891e03b496368c619e5385a743c72b6e07caa48eacf4adeb9f93"
+                    // ^^^
+                    //    {time_by_day.the_year=('1997')}
+                    //    {product_class.product_family=('Drink')}
+                    //    {product_class.product_department=('Dairy')}]
             },
             new String[]{
                 "product_class.product_family"
@@ -275,8 +719,22 @@ public class SegmentBuilderTest extends BatchTestCase {
                 + "{[Product].[Drink].[Beverages]} on 0 from sales"},
             new String[] {
                 "464a73cb907ccee680acd79a3b03181ddc6b8c2d9cf8b75ea81fcc6d634d8d57",
+                    // ^^^
+                    //    {time_by_day.the_year=('1997')}
+                    //    {product_class.product_family=('Drink')}
+                    //    {product_class.product_department=('Dairy')}]
                 "9f15599949884e63cf5167e8f857d7da133bb0781602b538f3c0eb00106e5bf4",
+                    // ^^^
+                    //    {time_by_day.the_year=('1997')}
+                    //    {product_class.product_family=('Drink')}
+                    //    {product_class.product_department=('Beverages')}]
                 "2e68abec3aa76aad4d6cd742cfc19e448b48fabf33b3c1cdf1a34062428a71e3"
+                    // ^^^
+                    //    {time_by_day.the_year=('1997')}
+                    //    {product_class.product_family=
+                    //                              ('Drink','Non-Consumable')}
+                    //    {product_class.product_department=
+                    //                  ('Alcoholic Beverages','Periodicals')}]
             },
             new String[]{
                 "product_class.product_family"
@@ -431,6 +889,11 @@ public class SegmentBuilderTest extends BatchTestCase {
                 }
             }
         }
+
+        assertFalse(String.format(
+            "SegmentMap is empty. No segmentIds matched test parameters. "
+            + "Full segment cache: %s", headers), testMap.isEmpty());
+
         return testMap;
     }
 
@@ -443,12 +906,18 @@ public class SegmentBuilderTest extends BatchTestCase {
      * values array.
      */
     private Map<SegmentHeader, SegmentBody> makeSegmentMap(
-        String[] colNames, int numValsPerCol, int numPopulatedCells)
+        String[] colNames, String[][] colVals,
+        int numValsPerCol, int numPopulatedCells,
+        boolean wildcardCols, boolean[] nullAxisFlags)
     {
+        if (colVals == null) {
+            colVals = dummyColumnValues(colNames.length, numValsPerCol);
+        }
+
         Pair<SegmentHeader, SegmentBody> headerBody = makeDummyHeaderBodyPair(
             colNames,
-            dummyColumnValues(colNames.length, numValsPerCol),
-            numPopulatedCells);
+            colVals,
+            numPopulatedCells, wildcardCols, nullAxisFlags);
         Map<SegmentHeader, SegmentBody> map =
             new HashMap<SegmentHeader, SegmentBody>();
         map.put(headerBody.left, headerBody.right);
@@ -457,7 +926,8 @@ public class SegmentBuilderTest extends BatchTestCase {
     }
 
     private Pair<SegmentHeader, SegmentBody> makeDummyHeaderBodyPair(
-        String[] colExps, String[][] colVals, int numCellVals)
+        String[] colExps, String[][] colVals, int numCellVals,
+        boolean wildcardCols, boolean[] nullAxisFlags)
     {
         final List<SegmentColumn> constrainedColumns =
             new ArrayList<SegmentColumn>();
@@ -466,19 +936,24 @@ public class SegmentBuilderTest extends BatchTestCase {
             new ArrayList<Pair<SortedSet<Comparable>, Boolean>>();
         for (int i = 0; i < colVals.length; i++) {
             String colExp = colExps[i];
+            SortedSet<Comparable> headerVals = null;
             SortedSet<Comparable> vals =
                 new TreeSet<Comparable>(Arrays.<Comparable>asList(colVals[i]));
+            if (!wildcardCols) {
+                headerVals = vals;
+            }
+            boolean nullAxisFlag = nullAxisFlags != null && nullAxisFlags[i];
             constrainedColumns.add(
                 new SegmentColumn(
                     colExp,
                     colVals[i].length,
-                    vals));
-            axes.add(Pair.of(vals, Boolean.FALSE));
+                    headerVals));
+            axes.add(Pair.of(vals, nullAxisFlag));
         }
 
         Object [] cells = new Object[numCellVals];
         for (int i = 0; i < numCellVals; i++) {
-            cells[i] = 123.123; // assign a non-null val
+            cells[i] = MOCK_CELL_VALUE; // assign a non-null val
         }
         return Pair.<SegmentHeader, SegmentBody>of(
             new SegmentHeader(


### PR DESCRIPTION
...erlapping segments (5.0)

cherry-pick of e9d83e9b14a4827f4a3d7d20d8299ff5b3919d37

@lucboudreau we were asked to port this fix to 5.0 (Mondrian 3.6)
