### PR TITLE
[CLEANUP] Moving the CodeComplianceTest to the optional category. After ...

### DIFF
--- a/testsrc/main/mondrian/test/Main.java
+++ b/testsrc/main/mondrian/test/Main.java
@@ -202,6 +202,7 @@ public class Main extends TestSuite {
                 addTest(suite, QueryAllTest.class, "suite");
                 addTest(suite, QueryAllVCTest.class, "suite");
                 addTest(suite, Base64Test.class);
+                addTest(suite, CodeComplianceTest.class);
                 return suite;
             }
             addTest(suite, SegmentBuilderTest.class);
@@ -331,7 +332,6 @@ public class Main extends TestSuite {
             addTest(suite, DeadlockTest.class);
 
             addTest(suite, BlockingHashMapTest.class);
-            addTest(suite, CodeComplianceTest.class);
 
             boolean testNonEmpty = isRunOnce();
             if (!MondrianProperties.instance().EnableNativeNonEmpty.get()) {


### PR DESCRIPTION
...Julian's changes to checkStyle, there are thousands of failures. If we fix them, we'll migrate the whole code base to pentaho's official standard instead of playing catch up with the current mondrian standard. Note that we will still require all new commits to adhere to the modnrian code style for the time being. This change allows the CI results to be green so we can track the project status properly for the time being.
