### PR TITLE
[SP-1310] - Regression MONDRIAN-2038 - Data Source (Wizard) returning ja...

### DIFF
--- a/src/main/mondrian/spi/impl/AccessDialect.java
+++ b/src/main/mondrian/spi/impl/AccessDialect.java
@@ -1,12 +1,11 @@
 /*
-* This software is subject to the terms of the Eclipse Public License v1.0
-* Agreement, available at the following URL:
-* http://www.eclipse.org/legal/epl-v10.html.
-* You must accept the terms of that agreement to use this software.
-*
-* Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (c) 2002-2014 Pentaho Corporation..  All rights reserved.
 */
-
 package mondrian.spi.impl;
 
 import java.sql.*;
@@ -42,28 +41,6 @@ public class AccessDialect extends JdbcDialectImpl {
 
     public String caseWhenElse(String cond, String thenExpr, String elseExpr) {
         return "IIF(" + cond + "," + thenExpr + "," + elseExpr + ")";
-    }
-
-    public void quoteDateLiteral(StringBuilder buf, String value) {
-        Date date;
-        try {
-            /*
-             * The format of the 'value' parameter is not certain.
-             * Some JDBC drivers will return a timestamp even though
-             * we ask for a date (access is one of them). We must try to
-             * convert both formats.
-             */
-            date = Date.valueOf(value);
-        } catch (IllegalArgumentException ex) {
-            try {
-                date =
-                    new Date(Timestamp.valueOf(value).getTime());
-            } catch (IllegalArgumentException ex2) {
-                throw new NumberFormatException(
-                    "Illegal DATE literal:  " + value);
-            }
-        }
-        quoteDateLiteral(buf, value, date);
     }
 
     protected void quoteDateLiteral(

--- a/src/main/mondrian/spi/impl/OracleDialect.java
+++ b/src/main/mondrian/spi/impl/OracleDialect.java
@@ -4,7 +4,7 @@
 // http://www.eclipse.org/legal/epl-v10.html.
 // You must accept the terms of that agreement to use this software.
 //
-// Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+// Copyright (c) 2002-2014 Pentaho Corporation..  All rights reserved.
 */
 package mondrian.spi.impl;
 
@@ -131,32 +131,6 @@ public class OracleDialect extends JdbcDialectImpl {
         quoteStringLiteral(sb, suffix);
         sb.append(")");
         return sb.toString();
-    }
-
-    public void quoteDateLiteral(StringBuilder buf, String value) {
-        Date date;
-        // the ansi spec for <date string> ::=
-        // <years value> <minus sign> <months value> <minus sign> <days value>
-        final String ansiDateLiteralFormat = "\\d{2,4}-\\d{1,2}-\\d{1,2}";
-        try {
-              // The format of the 'value' parameter is not certain.
-              // Some JDBC drivers will return a timestamp even though
-              // we ask for a date (oracle is one of them). We must try to
-              // convert both formats.
-            if (Pattern.matches(ansiDateLiteralFormat, value)) {
-                date = Date.valueOf(value);
-            } else {
-                date = new Date(Timestamp.valueOf(value).getTime());
-            }
-        } catch (IllegalArgumentException ex) {
-            throw new NumberFormatException(
-                "Illegal DATE literal:  " + value);
-        }
-        // Date.toString formats date in the date escape
-        // format yyyy-mm-dd, which is consistent with the
-        // ansi DATE literal spec.
-        assert Pattern.matches(ansiDateLiteralFormat, date.toString());
-        quoteDateLiteral(buf, date.toString(), date);
     }
 
     /**

--- a/testsrc/main/mondrian/test/DialectTest.java
+++ b/testsrc/main/mondrian/test/DialectTest.java
@@ -608,12 +608,15 @@ public class DialectTest extends TestCase {
         // We need to construct a valid date literal in either case.
         // See http://jira.pentaho.com/browse/MONDRIAN-1819 and
         // http://jira.pentaho.com/browse/MONDRIAN-626
-        Dialect oracleDialect = new OracleDialect();
+        //
+        // verify jdbc dialect - some jdbc drivers return TIMESTAMP too
+        // http://jira.pentaho.com/browse/MONDRIAN-2038
+        Dialect jdbcDialect = new JdbcDialectImpl();
         StringBuilder buf = new StringBuilder();
-        oracleDialect.quoteDateLiteral(buf, "2003-12-12");
+        jdbcDialect.quoteDateLiteral(buf, "2003-12-12");
         assertEquals("DATE '2003-12-12'", buf.toString());
         buf = new StringBuilder();
-        oracleDialect.quoteDateLiteral(buf, "2007-01-15 00:00:00.0");
+        jdbcDialect.quoteDateLiteral(buf, "2007-01-15 00:00:00.0");
         assertEquals("DATE '2007-01-15'", buf.toString());
 
         if (getDialect().getDatabaseProduct()


### PR DESCRIPTION
...va SQLDataException: ORA-01861: literal does not match format string. (5.1)

added attempt of parsing string to TimeStamp if it isn't Date
removed quoteDateLiteral() from AccessDialect and OracleDialect - it is the same as it's parent now

It's the same fix for MONDRIAN-2038
@lucboudreau verify please. 

related PR https://github.com/pentaho/pentaho-metadata/pull/35
