### PR TITLE
[MONDRIAN-2208] - Impala / Hive Dialect doesn't quote TIMESTAMP values p...

### DIFF
--- a/src/main/mondrian/spi/impl/HiveDialect.java
+++ b/src/main/mondrian/spi/impl/HiveDialect.java
@@ -4,7 +4,7 @@
 // http://www.eclipse.org/legal/epl-v10.html.
 // You must accept the terms of that agreement to use this software.
 //
-// Copyright (C) 2011-2013 Pentaho and others
+// Copyright (C) 2011-2014 Pentaho and others
 // All Rights Reserved.
 */
 package mondrian.spi.impl;
@@ -155,6 +155,21 @@ public class HiveDialect extends JdbcDialectImpl {
 
     public boolean allowsJoinOn() {
         return false;
+    }
+    
+    public void quoteTimestampLiteral(
+        StringBuilder buf,
+        String value)
+    {
+        try {
+            Timestamp.valueOf(value);
+        } catch (IllegalArgumentException ex) {
+            throw new NumberFormatException(
+                "Illegal TIMESTAMP literal:  " + value);
+        }
+        buf.append("cast( ");
+        Util.singleQuoteString(value, buf);
+        buf.append(" as timestamp )");
     }
 }
 

--- a/testsrc/main/mondrian/test/DialectTest.java
+++ b/testsrc/main/mondrian/test/DialectTest.java
@@ -1530,7 +1530,16 @@ public class DialectTest extends TestCase {
         assertEquals(SqlStatement.Type.OBJECT, type);
     }
 
-
+    public void testHiveTimestampQuoteLiteral() throws SQLException {
+      /*MONDRIAN-2208*/
+      Dialect hiveDbDialect =
+          TestContext.getFakeDialect(Dialect.DatabaseProduct.HIVE);
+      StringBuilder buf = new StringBuilder();
+      hiveDbDialect.quoteTimestampLiteral( buf, "2014-10-29 10:27:55.12");
+      assertEquals( 
+          "TIMESTAMP literal for Hive requires special syntax (cast)",
+          "cast( '2014-10-29 10:27:55.12' as timestamp )", buf.toString());
+    }
 
     public static class MockResultSetMetadata
         extends DelegatingInvocationHandler
@@ -1587,7 +1596,6 @@ public class DialectTest extends TestCase {
             return scale;
         }
     }
-
 }
 
 // End DialectTest.java


### PR DESCRIPTION
...roperly (5.2 Suite)

Neither Hive nor Impala support ANSI timestamp literal.
The following construct should be used instead:
    cast( 'YYYY-MM-DD hh:mm:ss[fffff]' as timestamp )

This is what was implemented in HiveDialect.
The unit test is too strightforward.
The same case is covered in mondrian-tck NativeFilterTest.testCompoundPredicateNoJoinsDateLiteralSyntax().
The problem with tck is that Foodmart schema for hive does not contain neither DATE nor TIMESTAMP columns.

That should be taken into account that Hive2 supports DATE datatype and ANSI literal for it.
In order to leverage this a separate Dialect implementation should be done (how to distiguish between Hive1 and Hive2?)

The fix was manually verified with Analyzer for Hive1 (0.8), Hive2 (0.12) and Impala on Cludera 4.7 and 5.1
