### PR TITLE
MONDRIAN-2256

### DIFF
--- a/src/main/mondrian/udf/CurrentDateMemberUdf.java
+++ b/src/main/mondrian/udf/CurrentDateMemberUdf.java
@@ -1,12 +1,11 @@
 /*
-* This software is subject to the terms of the Eclipse Public License v1.0
-* Agreement, available at the following URL:
-* http://www.eclipse.org/legal/epl-v10.html.
-* You must accept the terms of that agreement to use this software.
-*
-* Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (c) 2002-2015 Pentaho Corporation.  All rights reserved.
 */
-
 package mondrian.udf;
 
 import mondrian.olap.*;
@@ -116,7 +115,9 @@ public class CurrentDateMemberUdf implements UserDefinedFunction {
     }
 
     public Type getReturnType(Type[] parameterTypes) {
-        return MemberType.Unknown;
+        Dimension dim = parameterTypes[0].getDimension();
+        return (dim == null) ? MemberType.Unknown : MemberType
+            .forDimension(dim);
     }
 
     public Syntax getSyntax() {

--- a/testsrc/main/mondrian/udf/CurrentDateMemberUdfTest.java
+++ b/testsrc/main/mondrian/udf/CurrentDateMemberUdfTest.java
@@ -1,12 +1,11 @@
 /*
-* This software is subject to the terms of the Eclipse Public License v1.0
-* Agreement, available at the following URL:
-* http://www.eclipse.org/legal/epl-v10.html.
-* You must accept the terms of that agreement to use this software.
-*
-* Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (c) 2002-2015 Pentaho Corporation.  All rights reserved.
 */
-
 package mondrian.udf;
 
 import mondrian.test.FoodMartTestCase;
@@ -45,6 +44,20 @@ public class CurrentDateMemberUdfTest extends FoodMartTestCase {
             + "Axis #2:\n"
             + "{[Time].[1997]}\n"
             + "Row #0: $39,431.67\n");
+    }
+
+    /**
+     * test for MONDRIAN-2256 issue. Tests if method returns member with
+     * dimension info or not. To get a number as a result you should change
+     * current year to 1997. In this case expected should be ended with
+     * "266,773\n"
+    */
+    public void testGetReturnType() {
+        String query = "WITH MEMBER [Time].[YTD] AS SUM( YTD(CurrentDateMember"
+             + "([Time], '[\"Time\"]\\.[yyyy]\\.[Qq].[m]')), Measures.[Unit Sales]) SELECT Time.YTD on 0 FROM sales";
+        String expected = "Axis #0:\n" + "{}\n" + "Axis #1:\n"
+             + "{[Time].[YTD]}\n" + "Row #0: \n";
+        assertQueryReturns(query, expected);
     }
 }
 


### PR DESCRIPTION
@lucboudreau, would you mind review/merge?
There are two commits:
1) Junit test which illustrates an problem.
2) Fix.
Files were changed according to mondrian formatting rules.
Brief sense of the fix: now we return not an empty MemberType but MemberType with dimension info in case if we can get one from parameters.