### PR TITLE
[MONDRIAN-2260] Fixes an issue where a compound slicer used with a share...

### DIFF
--- a/src/main/mondrian/rolap/RolapAggregationManager.java
+++ b/src/main/mondrian/rolap/RolapAggregationManager.java
@@ -108,7 +108,7 @@ public abstract class RolapAggregationManager {
         assert starMeasure != null;
         int starColumnCount = starMeasure.getStar().getColumnCount();
 
-        CellRequest request =
+        final CellRequest request =
             makeCellRequest(
                 currentMembers,
                 false,
@@ -116,6 +116,11 @@ public abstract class RolapAggregationManager {
                 null,
                 null,
                 evaluator);
+
+        if (request == null) {
+            // Current request cannot be processed. Per API, return null.
+            return null;
+        }
 
         /*
          * Now setting the compound keys.

--- a/testsrc/main/mondrian/rolap/VirtualCubeTest.java
+++ b/testsrc/main/mondrian/rolap/VirtualCubeTest.java
@@ -1582,6 +1582,26 @@ public class VirtualCubeTest extends BatchTestCase {
         + "Row #0: 72,024\n";
       context.assertQueryReturns(query, expected);
     }
+
+    public void testCrossjoinOptimizerWithVirtualCube() {
+        final TestContext context =
+            TestContext.instance().createSubstitutingCube(
+                "Warehouse and Sales",
+                null,
+                "<VirtualCubeMeasure cubeName=\"Sales\" name=\"[Measures].[Customer Count]\"/>",
+                null,
+                null);
+
+        context.assertQueryReturns(
+            "WITH member measures.ratio as 'measures.[Store Cost]/measures.[warehouse cost]' "
+            + " member [marital status].agg as 'aggregate({[marital status].M})' "
+            + " select non empty [Warehouse].[USA] "
+            + " * {[marital status].[marital status].members, [marital status].agg }  on 0 "
+            + "FROM [warehouse and sales] where [measures].[Customer Count]",
+            "Axis #0:\n"
+            + "{[Measures].[Customer Count]}\n"
+            + "Axis #1:\n");
+    }
 }
 
 // End VirtualCubeTest.java

--- a/testsrc/main/mondrian/test/TestContext.java
+++ b/testsrc/main/mondrian/test/TestContext.java
@@ -434,6 +434,17 @@ public class TestContext {
             s = s.substring(0, i)
                 + measureDefs
                 + s.substring(i);
+
+            // Same for VirtualCubeMeasure
+            if (i == end) {
+                i = s.indexOf("<VirtualCubeMeasure", h);
+                if (i < 0 || i > end) {
+                    i = end;
+                }
+                s = s.substring(0, i)
+                    + measureDefs
+                    + s.substring(i);
+            }
         }
 
         // Add calculated member definitions, if specified.


### PR DESCRIPTION
...d dimension within a virtual cube with a context of joining and non-joining dimensions would throw a null pointer exception. Per the API, if the request cannot be satisfied as-is, we must return null directly.