### PR TITLE
[SP-1703][ANALYZER-2655] Invalid Agg table SQL generated by native filter when

### DIFF
--- a/bin/checkFile.awk
+++ b/bin/checkFile.awk
@@ -330,7 +330,7 @@ FNR < headerCount {
 /^\/\/ Copyright .* Pentaho/ && strict > 1 {
     # We assume that '--strict' is only invoked on files currently being
     # edited. Therefore we would expect the copyright to be current.
-    if ($0 !~ /-2014/) {
+    if ($0 !~ /-2015/) {
         error(fname, FNR, "copyright is not current");
     }
 }

--- a/src/main/mondrian/rolap/SqlTupleReader.java
+++ b/src/main/mondrian/rolap/SqlTupleReader.java
@@ -6,7 +6,7 @@
 //
 // Copyright (C) 2004-2005 TONBELLER AG
 // Copyright (C) 2005-2005 Julian Hyde
-// Copyright (C) 2005-2014 Pentaho and others
+// Copyright (C) 2005-2015 Pentaho and others
 // All Rights Reserved.
 */
 package mondrian.rolap;
@@ -1074,29 +1074,19 @@ public class SqlTupleReader implements TupleReader {
                 && SqlMemberSource.isLevelCollapsed(
                     aggStar,
                     (RolapCubeLevel)currLevel);
-
             boolean multipleCols =
                 SqlMemberSource.levelContainsMultipleColumns(currLevel);
 
             if (levelCollapsed && !multipleCols) {
                 // if this is a single column collapsed level, there is
                 // no need to join it with dimension tables
-                RolapStar.Column starColumn =
-                    ((RolapCubeLevel) currLevel).getStarKeyColumn();
-                int bitPos = starColumn.getBitPosition();
-                AggStar.Table.Column aggColumn = aggStar.lookupColumn(bitPos);
-                String q = aggColumn.generateExprString(sqlQuery);
-                final String qAlias =
-                    sqlQuery.addSelectGroupBy(q, starColumn.getInternalType());
-                if (whichSelect == WhichSelect.ONLY) {
-                    sqlQuery.addOrderBy(
-                        q, qAlias, true, false, true, true);
-                }
-                aggColumn.getTable().addToFrom(sqlQuery, false, true);
+                addAggColumnToSql(
+                    sqlQuery, whichSelect, aggStar, (RolapCubeLevel)currLevel);
                 continue;
             }
 
-            MondrianDef.Expression keyExp = currLevel.getKeyExp();
+            MondrianDef.Expression keyExp = getKeyExprOrAggColExp(
+                currLevel, levelCollapsed, aggStar);
             MondrianDef.Expression ordinalExp = currLevel.getOrdinalExp();
             MondrianDef.Expression captionExp = currLevel.getCaptionExp();
             MondrianDef.Expression parentExp = currLevel.getParentExp();
@@ -1119,7 +1109,7 @@ public class SqlTupleReader implements TupleReader {
             }
 
             String keySql = keyExp.getExpression(sqlQuery);
-            String ordinalSql = ordinalExp.getExpression(sqlQuery);
+
 
             if (!levelCollapsed) {
                 hierarchy.addToFrom(sqlQuery, keyExp);
@@ -1153,7 +1143,8 @@ public class SqlTupleReader implements TupleReader {
 
             // Figure out the order-by part
             final String orderByAlias;
-            if (!ordinalSql.equals(keySql)) {
+            if (!currLevel.getKeyExp().equals(currLevel.getOrdinalExp())) {
+                String ordinalSql = ordinalExp.getExpression(sqlQuery);
                 orderByAlias = sqlQuery.addSelect(ordinalSql, null);
                 if (needsGroupBy) {
                     sqlQuery.addGroupBy(ordinalSql, orderByAlias);
@@ -1178,15 +1169,18 @@ public class SqlTupleReader implements TupleReader {
                 // join to dimension tables starting
                 // at the lowest granularity and working
                 // towards the fact table
-                hierarchy.addToFromInverse(sqlQuery, keyExp);
+                hierarchy.addToFromInverse(sqlQuery, currLevel.getKeyExp());
 
                 RolapStar.Column starColumn =
                     ((RolapCubeLevel) currLevel).getStarKeyColumn();
                 int bitPos = starColumn.getBitPosition();
                 AggStar.Table.Column aggColumn = aggStar.lookupColumn(bitPos);
                 RolapStar.Condition condition =
-                    new RolapStar.Condition(keyExp, aggColumn.getExpression());
+                    new RolapStar.Condition(
+                        currLevel.getKeyExp(),
+                        aggColumn.getExpression());
                 sqlQuery.addWhere(condition.toString(sqlQuery));
+                aggColumn.getTable().addToFrom(sqlQuery, false, true);
             }
 
             RolapProperty[] properties = currLevel.getProperties();
@@ -1217,6 +1211,56 @@ public class SqlTupleReader implements TupleReader {
                 }
             }
         }
+    }
+
+    /**
+     * Returns the Expression associated with the level's
+     * KeyExp, or the Expression associated with the level's
+     * AggStar column if the level is collapsed and aggStar is defined.
+     */
+    private MondrianDef.Expression getKeyExprOrAggColExp(
+        RolapLevel level, boolean levelCollapsed, AggStar aggStar)
+    {
+        if (aggStar == null || !levelCollapsed) {
+            return level.getKeyExp();
+        } else {
+            AggStar.Table.Column aggColumn = getAggColumn(
+                aggStar, (RolapCubeLevel)level);
+            if (aggColumn == null) {
+                throw new MondrianException(
+                    String.format(
+                        "Expected level [%s] to have a collapsed attribute "
+                        + "on aggregate table '%s'", level.getName(),
+                        aggStar.getFactTable().getName()));
+            }
+            return aggColumn.getExpression();
+        }
+    }
+
+    private void addAggColumnToSql(
+        SqlQuery sqlQuery, WhichSelect whichSelect, AggStar aggStar,
+        RolapCubeLevel level)
+    {
+        RolapStar.Column starColumn =
+            level.getStarKeyColumn();
+        AggStar.Table.Column aggColumn = getAggColumn(aggStar, level);
+        String aggColExp = aggColumn.generateExprString(sqlQuery);
+        final String colAlias =
+            sqlQuery.addSelectGroupBy(aggColExp, starColumn.getInternalType());
+        if (whichSelect == WhichSelect.ONLY) {
+            sqlQuery.addOrderBy(
+                aggColExp, colAlias, true, false, true, true);
+        }
+        aggColumn.getTable().addToFrom(sqlQuery, false, true);
+    }
+
+    private AggStar.Table.Column getAggColumn(
+        AggStar aggStar, RolapCubeLevel level)
+    {
+        RolapStar.Column starColumn =
+            level.getStarKeyColumn();
+        int bitPos = starColumn.getBitPosition();
+        return aggStar.lookupColumn(bitPos);
     }
 
     /**

--- a/testsrc/main/mondrian/rolap/TestAggregationManager.java
+++ b/testsrc/main/mondrian/rolap/TestAggregationManager.java
@@ -5,7 +5,7 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2002-2005 Julian Hyde
-// Copyright (C) 2005-2014 Pentaho and others
+// Copyright (C) 2005-2015 Pentaho and others
 // All Rights Reserved.
 //
 // jhyde, 28 September, 2002
@@ -1282,6 +1282,7 @@ public class TestAggregationManager extends BatchTestCase {
     public void testOrdinalExprAggTuplesAndChildren() {
         // this verifies that we can load properties, ordinals, etc out of
         // agg tables in member lookups (tuples and children)
+        propSaver.set(propSaver.properties.GenerateFormattedSql, true);
         if (!(MondrianProperties.instance().UseAggregates.get()
                 && MondrianProperties.instance().ReadAggregates.get()))
         {
@@ -1344,7 +1345,32 @@ public class TestAggregationManager extends BatchTestCase {
         SqlPattern[] patterns = {
             new SqlPattern(
                 ACCESS_MYSQL,
-                "select `agg_g_ms_pcat_sales_fact_1997`.`product_family` as `c0`, `agg_g_ms_pcat_sales_fact_1997`.`product_department` as `c1`, `product_class`.`product_category` as `c2`, `product_class`.`product_family` as `c3`, `agg_g_ms_pcat_sales_fact_1997`.`gender` as `c4` from `agg_g_ms_pcat_sales_fact_1997` as `agg_g_ms_pcat_sales_fact_1997`, `product_class` as `product_class` where `product_class`.`product_category` = `agg_g_ms_pcat_sales_fact_1997`.`product_category` and (`agg_g_ms_pcat_sales_fact_1997`.`product_category` = 'Meat' and `agg_g_ms_pcat_sales_fact_1997`.`product_department` = 'Deli' and `agg_g_ms_pcat_sales_fact_1997`.`product_family` = 'Food') and (`agg_g_ms_pcat_sales_fact_1997`.`gender` = 'M') group by `agg_g_ms_pcat_sales_fact_1997`.`product_family`, `agg_g_ms_pcat_sales_fact_1997`.`product_department`, `product_class`.`product_category`, `product_class`.`product_family`, `agg_g_ms_pcat_sales_fact_1997`.`gender` order by ISNULL(`agg_g_ms_pcat_sales_fact_1997`.`product_family`) ASC, `agg_g_ms_pcat_sales_fact_1997`.`product_family` ASC, ISNULL(`agg_g_ms_pcat_sales_fact_1997`.`product_department`) ASC, `agg_g_ms_pcat_sales_fact_1997`.`product_department` ASC, ISNULL(`product_class`.`product_category`) ASC, `product_class`.`product_category` ASC, ISNULL(`agg_g_ms_pcat_sales_fact_1997`.`gender`) ASC, `agg_g_ms_pcat_sales_fact_1997`.`gender` ASC",
+                "select\n"
+                + "    `agg_g_ms_pcat_sales_fact_1997`.`product_family` as `c0`,\n"
+                + "    `agg_g_ms_pcat_sales_fact_1997`.`product_department` as `c1`,\n"
+                + "    `agg_g_ms_pcat_sales_fact_1997`.`product_category` as `c2`,\n"
+                + "    `product_class`.`product_family` as `c3`,\n"
+                + "    `agg_g_ms_pcat_sales_fact_1997`.`gender` as `c4`\n"
+                + "from\n"
+                + "    `agg_g_ms_pcat_sales_fact_1997` as `agg_g_ms_pcat_sales_fact_1997`,\n"
+                + "    `product_class` as `product_class`\n"
+                + "where\n"
+                + "    `product_class`.`product_category` = `agg_g_ms_pcat_sales_fact_1997`.`product_category`\n"
+                + "and\n"
+                + "    (`agg_g_ms_pcat_sales_fact_1997`.`product_category` = 'Meat' and `agg_g_ms_pcat_sales_fact_1997`.`product_department` = 'Deli' and `agg_g_ms_pcat_sales_fact_1997`.`product_family` = 'Food')\n"
+                + "and\n"
+                + "    (`agg_g_ms_pcat_sales_fact_1997`.`gender` = 'M')\n"
+                + "group by\n"
+                + "    `agg_g_ms_pcat_sales_fact_1997`.`product_family`,\n"
+                + "    `agg_g_ms_pcat_sales_fact_1997`.`product_department`,\n"
+                + "    `agg_g_ms_pcat_sales_fact_1997`.`product_category`,\n"
+                + "    `product_class`.`product_family`,\n"
+                + "    `agg_g_ms_pcat_sales_fact_1997`.`gender`\n"
+                + "order by\n"
+                + "    ISNULL(`agg_g_ms_pcat_sales_fact_1997`.`product_family`) ASC, `agg_g_ms_pcat_sales_fact_1997`.`product_family` ASC,\n"
+                + "    ISNULL(`agg_g_ms_pcat_sales_fact_1997`.`product_department`) ASC, `agg_g_ms_pcat_sales_fact_1997`.`product_department` ASC,\n"
+                + "    ISNULL(`agg_g_ms_pcat_sales_fact_1997`.`product_category`) ASC, `agg_g_ms_pcat_sales_fact_1997`.`product_category` ASC,\n"
+                + "    ISNULL(`agg_g_ms_pcat_sales_fact_1997`.`gender`) ASC, `agg_g_ms_pcat_sales_fact_1997`.`gender` ASC",
                 null)
         };
 

--- a/testsrc/main/mondrian/rolap/aggmatcher/MultipleColsInTupleAggTest.java
+++ b/testsrc/main/mondrian/rolap/aggmatcher/MultipleColsInTupleAggTest.java
@@ -1,16 +1,19 @@
 /*
-* This software is subject to the terms of the Eclipse Public License v1.0
-* Agreement, available at the following URL:
-* http://www.eclipse.org/legal/epl-v10.html.
-* You must accept the terms of that agreement to use this software.
-*
-* Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
 */
-
 package mondrian.rolap.aggmatcher;
 
+import mondrian.olap.Axis;
 import mondrian.olap.MondrianProperties;
 import mondrian.olap.Result;
+import mondrian.rolap.RolapAxis;
+import mondrian.spi.Dialect;
+import mondrian.test.SqlPattern;
 
 /**
  * Testcase for levels that contain multiple columns and are
@@ -26,6 +29,12 @@ public class MultipleColsInTupleAggTest extends AggTableTestCase {
 
     public MultipleColsInTupleAggTest(String name) {
         super(name);
+    }
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        propSaver.set(propSaver.properties.GenerateFormattedSql, true);
     }
 
     protected String getFileName() {
@@ -94,6 +103,132 @@ public class MultipleColsInTupleAggTest extends AggTableTestCase {
             + "Row #0: 15\n");
     }
 
+    public void testNativeFilterWithoutMeasures() throws Exception {
+        if (!isApplicable()) {
+            return;
+        }
+        // Native filter without any measures hit an edge case that
+        // could fail to include the Agg star in the WHERE clause,
+        // and could also mishandle the field referred to in the native
+        // HAVING clause.  ANALYZER-2655
+        getTestContext().assertQueryReturns(
+            "select "
+            + "Filter([Product].[Category].members, "
+            + "Product.CurrentMember.Caption MATCHES (\"(?i).*Two.*\") )"
+            + " on columns "
+            + "from [Fact]",
+            "Axis #0:\n"
+            + "{}\n"
+            + "Axis #1:\n"
+            + "{[Product].[Cat Two]}\n"
+            + "Row #0: 33\n");
+        //  CurrentMember.Name should map to
+        // `test_lp_xxx_fact`.`product_category`, with 2 member matches
+        getTestContext().assertQueryReturns(
+            "select "
+            + "Filter([Product].[Product Category].members, "
+            + "Product.CurrentMember.Name MATCHES (\"(?i).*Two.*\") )"
+            + " on columns "
+            + "from [Fact]",
+            "Axis #0:\n"
+            + "{}\n"
+            + "Axis #1:\n"
+            + "{[Product].[Cat Two].[Prod Cat Two]}\n"
+            + "{[Product].[Cat One].[Prod Cat Two]}\n"
+            + "Row #0: 16\n"
+            + "Row #0: 18\n");
+        // .Caption is defined as `product_cat`.`cap`.
+        // [Cat One].[Prod Cat Two] has just one caption matching -- "PCTwo"
+        getTestContext().assertQueryReturns(
+            "select "
+            + "Filter([Product].[Product Category].Members, "
+            + "Product.CurrentMember.Caption MATCHES (\"(?i).*Two.*\") )"
+            + " on columns "
+            + "from [Fact]",
+            "Axis #0:\n"
+            + "{}\n"
+            + "Axis #1:\n"
+            + "{[Product].[Cat One].[Prod Cat Two]}\n"
+            + "Row #0: 18\n");
+    }
+
+    public void testNativeFilterWithoutMeasuresAndLevelWithProps()
+        throws Exception
+    {
+        if (!isApplicable()) {
+            return;
+        }
+        // similar to the previous test, but verifies a case where
+        // a level property is the extra column that requires joining
+        // agg star back to the dim table.  This test also uses the bottom
+        // level of the dim
+        final String query = "select "
+            + "Filter([Product].[Product Name].members, "
+            + "Product.CurrentMember.Caption MATCHES (\"(?i).*Two.*\") )"
+            + " on columns "
+            + "from [Fact] ";
+        getTestContext().assertQueryReturns(
+            query,
+            "Axis #0:\n"
+            + "{}\n"
+            + "Axis #1:\n"
+            + "{[Product].[Cat One].[Prod Cat One].[Two]}\n"
+            + "Row #0: 6\n");
+
+        assertQuerySql(
+            query,
+            new SqlPattern[] {
+                new SqlPattern(
+                    Dialect.DatabaseProduct.MYSQL,
+                "select\n"
+                + "    `cat`.`cat` as `c0`,\n"
+                + "    `cat`.`cap` as `c1`,\n"
+                + "    `cat`.`ord` as `c2`,\n"
+                + "    `cat`.`name3` as `c3`,\n"
+                + "    `product_cat`.`name2` as `c4`,\n"
+                + "    `product_cat`.`cap` as `c5`,\n"
+                + "    `product_cat`.`ord` as `c6`,\n"
+                + "    `test_lp_xx2_fact`.`prodname` as `c7`,\n"
+                + "    `product_csv`.`color` as `c8`\n"
+                + "from\n"
+                + "    `product_csv` as `product_csv`,\n"
+                + "    `product_cat` as `product_cat`,\n"
+                + "    `cat` as `cat`,\n"
+                + "    `test_lp_xx2_fact` as `test_lp_xx2_fact`\n"
+                + "where\n"
+                + "    `product_cat`.`cat` = `cat`.`cat`\n"
+                + "and\n"
+                + "    `product_csv`.`prod_cat` = `product_cat`.`prod_cat`\n"
+                + "and\n"
+                + "    `product_csv`.`name1` = `test_lp_xx2_fact`.`prodname`\n"
+                + "group by\n"
+                + "    `cat`.`cat`,\n"
+                + "    `cat`.`cap`,\n"
+                + "    `cat`.`ord`,\n"
+                + "    `cat`.`name3`,\n"
+                + "    `product_cat`.`name2`,\n"
+                + "    `product_cat`.`cap`,\n"
+                + "    `product_cat`.`ord`,\n"
+                + "    `test_lp_xx2_fact`.`prodname`,\n"
+                + "    `product_csv`.`color`\n"
+                + "having\n"
+                + "    UPPER(c7) REGEXP '.*TWO.*'\n"
+                + "order by\n"
+                + "    ISNULL(`cat`.`ord`) ASC, `cat`.`ord` ASC,\n"
+                + "    ISNULL(`product_cat`.`ord`) ASC, `product_cat`.`ord` ASC,\n"
+                + "    ISNULL(`test_lp_xx2_fact`.`prodname`) ASC, "
+                + "`test_lp_xx2_fact`.`prodname` ASC", null)});
+
+        Axis axis = getTestContext().withCube("Fact").executeAxis(
+            "Filter([Product].[Product Name].members, "
+            + "Product.CurrentMember.Caption MATCHES (\"(?i).*Two.*\") )");
+        assertEquals(
+            "Member property value was not loaded correctly.",
+            "Black",
+            ((RolapAxis) axis).getTupleList().get(0).get(0)
+                .getPropertyValue("Product Color"));
+    }
+
     public void testChildSelection() throws Exception {
         if (!isApplicable()) {
             return;
@@ -124,6 +259,11 @@ public class MultipleColsInTupleAggTest extends AggTableTestCase {
            + "  <AggLevel column='product_category' "
            + "            name='[Product].[Product Category]'/>\n"
            + " </AggName>\n"
+            + " <AggName name='test_lp_xx2_fact'>\n"
+            + "  <AggFactCount column='fact_count'/>\n"
+            + "  <AggMeasure column='amount' name='[Measures].[Total]'/>\n"
+            + "  <AggLevel column='prodname' name='[Product].[Product Name]' collapsed='false'/>\n"
+            + " </AggName>\n"
            + "</Table>"
            + "<Dimension name='Store' foreignKey='store_id'>\n"
            + " <Hierarchy hasAll='true' primaryKey='store_id'>\n"
@@ -150,7 +290,9 @@ public class MultipleColsInTupleAggTest extends AggTableTestCase {
            + "column='name2' ordinalColumn='ord' captionColumn='cap' "
            + "uniqueMembers='false'/>\n"
            + " <Level name='Product Name' table='product_csv' column='name1' "
-           + "uniqueMembers='true'/>\n"
+           + "uniqueMembers='true'>\n"
+            + "<Property name='Product Color' table='product_csv' column='color' />"
+            + "</Level>"
            + " </Hierarchy>\n"
            + "</Dimension>\n"
            + "<Measure name='Total' \n"

--- a/testsrc/main/mondrian/rolap/aggmatcher/multiple_cols_in_tuple_agg.csv
+++ b/testsrc/main/mondrian/rolap/aggmatcher/multiple_cols_in_tuple_agg.csv
@@ -38,17 +38,17 @@
 11,5
 # product dimension t1
 ## TableName: product_csv
-## ColumnNames: prod_id,prod_cat,name1
-## ColumnTypes: INTEGER,INTEGER,VARCHAR(30)
+## ColumnNames: prod_id,prod_cat,name1,color
+## ColumnTypes: INTEGER,INTEGER,VARCHAR(30),VARCHAR(30)
 ## NosOfRows: 8
-1,1,One
-2,1,Two
-3,2,Three
-4,2,Four
-5,3,Five
-6,3,Six
-7,4,Seven
-8,4,Eight
+1,1,One,Blue
+2,1,Two,Black
+3,2,Three,Brown
+4,2,Four,Purple
+5,3,Five,Olive
+6,3,Six,Orange
+7,4,Seven,Cyan
+8,4,Eight,Pink
 # product dimension t2
 ## TableName: product_cat
 ## ColumnNames: prod_cat,cat,name2,ord,cap
@@ -65,3 +65,16 @@
 ## NosOfRows: 2
 1,Cat One,2,COne
 2,Cat Two,1,CTwo
+# aggregate over prod_id
+## TableName: test_lp_xx2_fact
+## ColumnNames: prodname,amount,fact_count
+## ColumnTypes: VARCHAR(30),INTEGER,INTEGER
+## NosOfRows: 8
+One,9,2
+Two,6,2
+Three,9,2
+Four,9,2
+Five,9,2
+Six,8,2
+Seven,8,2
+Eight,8,2

--- a/testsrc/main/mondrian/test/loader/CsvDBTestCase.java
+++ b/testsrc/main/mondrian/test/loader/CsvDBTestCase.java
@@ -5,13 +5,13 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2005-2005 Julian Hyde
-// Copyright (C) 2005-2012 Pentaho and others
+// Copyright (C) 2005-2015 Pentaho and others
 // All Rights Reserved.
 */
-
 package mondrian.test.loader;
 
 import mondrian.olap.Schema;
+import mondrian.rolap.BatchTestCase;
 import mondrian.spi.Dialect;
 import mondrian.test.FoodMartTestCase;
 import mondrian.test.TestContext;
@@ -33,7 +33,7 @@ import java.sql.SQLException;
  *
  * @author Richard M. Emberson
  */
-public abstract class CsvDBTestCase extends FoodMartTestCase {
+public abstract class CsvDBTestCase extends BatchTestCase {
 
     private CsvDBLoader loader;
     private CsvDBLoader.Table[] tables;


### PR DESCRIPTION
the filter condition excludes measures and the level has extra columns
(properties, ordinalColumn, etc.)

Addresses a couple of cases mishandled by SqlTupleReader when joining
collapsed attributes which have additional columns that need to be
read from the dimension table(s).  For example, there may be need to
read ordinal column, or property values.  The existing logic worked
well enough in most cases, but made two faulty assumptions:

1) It assumed the aggstar will be joined in via the constraint, which
may not always be the case.
2) It assumed using the dimensional attribute in the select list
instead of the agg star attribute wouldn't have an impact.  This
normally shouldn't matter--the collapsed attribute and the
corresponding attribute from the dim table are identical-- but native
filter expects the filter constraint column from the aggstar to be
present.
(cherry picked from commit 2a7c64a)