### PR TITLE
compute column cardinality faster on PostgreSQL

### DIFF
--- a/src/main/mondrian/spi/impl/PostgreSqlDialect.java
+++ b/src/main/mondrian/spi/impl/PostgreSqlDialect.java
@@ -50,6 +50,14 @@ public class PostgreSqlDialect extends JdbcDialectImpl {
         return true;
     }
 
+    public boolean allowsCountDistinct() {
+        return false;
+    }
+
+    public boolean allowsFromQuery() {
+        return true;
+    }
+
     @Override
     protected String generateOrderByNulls(
         String expr,


### PR DESCRIPTION
in PgSQL `count(*) from (select distinct)` is much faster, than `count(distinct)`