### PR TITLE
update JdbcDialectImpl.java to support spark SQL1.2

### DIFF
--- a/src/main/mondrian/spi/impl/JdbcDialectImpl.java
+++ b/src/main/mondrian/spi/impl/JdbcDialectImpl.java
@@ -1067,8 +1067,8 @@ public class JdbcDialectImpl implements Dialect {
         } else if (upperProductName.indexOf("FIREBIRD") >= 0) {
             return DatabaseProduct.FIREBIRD;
         } else if (upperProductName.equals("HIVE")
-            || upperProductName.equals("APACHE HIVE"))
-        {
+            ||upperProductName.equals("APACHE HIVE")
+                ||upperProductName.equals("SPARK SQL")) {
             return DatabaseProduct.HIVE;
         } else if (productName.startsWith("Informix")) {
             return DatabaseProduct.INFORMIX;


### PR DESCRIPTION
the Spark SQL 1.2  use hive-jdbc0.13.1,hive-metastore0.13.1
when spark metadata call the  getDatabaseProductName() function, it will return "Spark SQL"
Useing the judging condition can  return the right DatabaseProduct for Spark Sql connect