### PR TITLE
Update AbstractQuerySpec.java

### DIFF
--- a/src/main/mondrian/rolap/agg/AbstractQuerySpec.java
+++ b/src/main/mondrian/rolap/agg/AbstractQuerySpec.java
@@ -131,7 +131,7 @@ public abstract class AbstractQuerySpec implements QuerySpec {
             } else {
                 alias =
                     sqlQuery.addSelect(
-                        expr, column.getInternalType(), getColumnAlias(i));
+                        expr, column.getInternalType(), getColumnAlias(i).replace(' ','_');
             }
 
             if (isAggregate()) {


### PR DESCRIPTION
Sometimes the Column's alias may be two words or more: For example, when I do the drill through 
When I use the foodmart data set and use its given schema
1.I chose the the HR cube
2.Choose "org salary" as measure
3.Choose "Pay Type " as row
at this time I decide to drill through for Pay Type with value of 'Hourly'
4.I select the Management Role under the Position dimention
After doing this,
 if I use h2 database, the generate sql is bellow, the database return the right result:
select "employee"."management_role" as "Management Role" from "time_by_day" as "time_by_day", "salary" as "salary", "store" as "store", "employee" as "employee", "position" as "position", "department" as "department" where "salary"."pay_date" = "time_by_day"."the_date" and "time_by_day"."the_year" = 1997 and "salary"."employee_id" = "employee"."employee_id" and "employee"."store_id" = "store"."store_id" and "employee"."position_id" = "position"."position_id" and "position"."pay_type" = 'Hourly' and "salary"."department_id" = "department"."department_id" order by "employee"."management_role" ASC

if I use hive database, the generate sql is bellow, and the parsing error rise.
select employee.management_role as Management Role from yxqtest.time_by_day time_by_day, yxqtest.salary salaryb, yxqtest.store store, yxqtest.employee employee, yxqtest.position position, yxqtest.department department where salaryb.pay_date = time_by_day.the_date and time_by_day.the_year = 1997.0 and salaryb.employee_id = employee.employee_id and employee.store_id = store.store_id and employee.position_id = position.position_id and position.pay_type = 'Hourly' and salaryb.department_id = department.department_id order by Management Role ASC
there is two error :
1. hive doesnot support alias with more than one word.
2. requiresOrderByAlias() method is override in HiveDialect.class, it returns true. so the order by part also use the alias :" Management Role"

I am sure other dabase whose requiresOrderByAlias() method return true(like Infobright,Ingres,Neoview) will come to the same error.
It is better to transfer the alias who has more than one word into one word combine with '_'