### PR TITLE
add a dialect for sparksql

### DIFF
--- a/src/main/META-INF/services/mondrian.spi.Dialect
+++ b/src/main/META-INF/services/mondrian.spi.Dialect
@@ -26,3 +26,4 @@ mondrian.spi.impl.TeradataDialect
 mondrian.spi.impl.VectorwiseDialect
 mondrian.spi.impl.VerticaDialect
 mondrian.spi.impl.IngresDialect
+mondrian.spi.impl.SparkSqlDialect

--- a/src/main/mondrian/olap/Mondrian.xml
+++ b/src/main/mondrian/olap/Mondrian.xml
@@ -1370,6 +1370,7 @@ Revision is $Id$
                 <li>luciddb</li>
                 <li>vertica</li>
                 <li>neoview</li>
+                <li>sparksql</li>
                 </ul>
             </Doc>
         </Attribute>

--- a/src/main/mondrian/olap/Mondrian_SW.xml
+++ b/src/main/mondrian/olap/Mondrian_SW.xml
@@ -1418,6 +1418,7 @@
             <Value>greenplum</Value>
             <Value>vectorwise</Value>
             <Value>hive</Value>
+            <Value>sparksql</Value>
         </Attribute>
         <CData/>
         <Code><![CDATA[

--- a/src/main/mondrian/spi/Dialect.java
+++ b/src/main/mondrian/spi/Dialect.java
@@ -849,7 +849,8 @@ public interface Dialect {
         SYBASE,
         TERADATA,
         VERTICA,
-        VECTORWISE;
+        VECTORWISE,
+        SPARKSQL;
 
         /**
          * Return the root of the family of products this database product

--- a/src/main/mondrian/spi/impl/JdbcDialectImpl.java
+++ b/src/main/mondrian/spi/impl/JdbcDialectImpl.java
@@ -1070,7 +1070,9 @@ public class JdbcDialectImpl implements Dialect {
             || upperProductName.equals("APACHE HIVE"))
         {
             return DatabaseProduct.HIVE;
-        } else if (productName.startsWith("Informix")) {
+        } else if (upperProductName.equals("SPARK SQL")) {
+            return DatabaseProduct.SPARKSQL;
+        }else if (productName.startsWith("Informix")) {
             return DatabaseProduct.INFORMIX;
         } else if (upperProductName.equals("INGRES")) {
             return DatabaseProduct.INGRES;

--- a/src/main/mondrian/spi/impl/SparkSqlDialect.java
+++ b/src/main/mondrian/spi/impl/SparkSqlDialect.java
@@ -49,7 +49,7 @@ public class SparkSqlDialect extends JdbcDialectImpl {
     protected String deduceIdentifierQuoteString(
         DatabaseMetaData databaseMetaData)
     {
-        return null;
+        return "`";
     }
 
     protected Set<List<Integer>> deduceSupportedResultSetStyles(


### PR DESCRIPTION
recently,we use spark sql
there is no SparkSqlDialect supplied by mondiran
I bulid the spark sql accroding to the hiveDialect, and this work for me , now I get the the spark sql running on saiku with mondrian3.9
