### PR TITLE
[BACKLOG-2384] Changes to better support loading and caching of

### DIFF
--- a/src/main/mondrian/olap/DelegatingSchemaReader.java
+++ b/src/main/mondrian/olap/DelegatingSchemaReader.java
@@ -6,10 +6,9 @@
 //
 // Copyright (C) 2003-2005 Julian Hyde
 // Copyright (C) 2004-2005 TONBELLER AG
-// Copyright (C) 2005-2012 Pentaho
+// Copyright (C) 2005-2015 Pentaho
 // All Rights Reserved.
 */
-
 package mondrian.olap;
 
 import mondrian.calc.Calc;
@@ -262,6 +261,13 @@ public abstract class DelegatingSchemaReader implements SchemaReader {
     {
         return schemaReader.lookupMemberChildByName(
             member, memberName, matchType);
+    }
+
+    public List<Member> lookupMemberChildrenByNames(
+        Member parent, List<Id.NameSegment> childNames, MatchType matchType)
+    {
+        return schemaReader.lookupMemberChildrenByNames(
+            parent, childNames, matchType);
     }
 
     public NativeEvaluator getNativeSetEvaluator(

--- a/src/main/mondrian/olap/IdBatchResolver.java
+++ b/src/main/mondrian/olap/IdBatchResolver.java
@@ -1,0 +1,463 @@
+/*
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (C) 2006-2015 Pentaho and others
+// All Rights Reserved.
+ */
+package mondrian.olap;
+
+import mondrian.mdx.*;
+
+import org.apache.commons.collections.*;
+import org.apache.log4j.Logger;
+
+import java.util.*;
+
+import static org.apache.commons.collections.CollectionUtils.filter;
+
+/**
+ * Used to collect and resolve identifiers in groups of children
+ * where possible.  For example, if an enumerated set within an MDX
+ * query includes references to 10 stores under the parent
+ *
+ *   [USA].[CA].[San Francisco]
+ *
+ * the class will attempt to identify those 10 identifiers
+ * and issue a single lookup, resulting in fewer and more efficient
+ * SQL queries.
+ * The resulting collection of resolved identifiers is returned in a
+ * map of <QueryPart, QueryPart>, where the unresolved Exp object acts
+ * as the key.
+ *
+ * This class makes no assurances that all identifiers will be resolved.
+ * The map returned by .resolve() will include only those identifiers
+ * successfully resolved.
+ *
+ */
+public final class IdBatchResolver {
+    static final Logger LOGGER = Logger.getLogger(IdBatchResolver.class);
+
+    private final Query query;
+    private final Formula[] formulas;
+    private final QueryAxis[] axes;
+    private final Cube cube;
+
+    // dimension and hierarchy unique names are collected during init
+    // to assist in classifying Ids as potentially resolvable to members.
+    private final Collection<String> dimensionUniqueNames =
+        new ArrayList<String>();
+    private final Collection<String> hierarchyUniqueNames =
+        new ArrayList<String>();
+    // level names are checked against the identifiers to avoid incorrectly
+    // interpreting a Dimension.Level reference as Dimension.Member.
+    private final Collection<String> levelNames =
+        new ArrayList<String>();
+
+    // Set of identifiers, sorted via IdComparator, which orders based
+    // first on segment length (shortest to longest), then alphabetically.
+    private  SortedSet<Id> identifiers = new TreeSet<Id>(new IdComparator());
+
+    public IdBatchResolver(Query query) {
+        this.query = query;
+        formulas = query.getFormulas();
+        axes = query.getAxes();
+        cube = query.getCube();
+        initOlapElementNames();
+        initIdentifiers();
+    }
+
+    /**
+     * Initializes the dimensionUniqueNames, hierarchyUniqueNames and
+     * levelNames collections based on the contents of cube.  These collections
+     * will be used to help determine whether identifiers correspond to
+     * a dimension/hierarchy/level.
+     */
+    private void initOlapElementNames() {
+        dimensionUniqueNames.addAll(
+            getOlapElementNames(cube.getDimensions(), true));
+        for (Dimension dim : cube.getDimensions()) {
+            hierarchyUniqueNames.addAll(
+                getOlapElementNames(dim.getHierarchies(), true));
+            for (Hierarchy hier : dim.getHierarchies()) {
+                levelNames.addAll(getOlapElementNames(hier.getLevels(), false));
+            }
+        }
+    }
+
+    /**
+     * Initializes the identifiers collection by walking the axes
+     * and formulas in the query and adding each encountered Id.
+     * Finally, expands the set of identifiers to include parents.  E.g.
+     * if the identifier
+     *   [Store].[All Store].[USA].[CA]
+     * is encountered, this will be expanded to include
+     *   [Store].[All Store].[USA]
+     *   [Store].[All Store]
+     */
+    private void initIdentifiers() {
+        MdxVisitor identifierVisitor = new IdentifierVisitor(identifiers);
+        for (QueryAxis axis : axes) {
+            axis.accept(identifierVisitor);
+        }
+        if (query.getSlicerAxis() != null) {
+            query.getSlicerAxis().accept(identifierVisitor);
+        }
+        for (Formula formula : formulas) {
+            formula.accept(identifierVisitor);
+        }
+        expandIdentifiers(identifiers);
+    }
+
+    /**
+     * Attempts to resolve the identifiers contained in the query in
+     * batches based on the parent, e.g. looking up and resolving the
+     * states in the set:
+     *   { [Store].[USA].[CA], [Store].[USA].[OR] }
+     * together rather than individually.
+     * Note that there is no guarantee that all identifiers will be
+     * resolved.  Calculated members, for example, are explicitly not
+     * handled here.  The purpose of this class is to improve efficiency
+     * of resolution of non-calculated members, but must be followed
+     * by more thorough expression resolution.
+     *
+     * @return  a Map of the expressions Id elements mapped to their
+     * respective resolved Exp.
+     */
+    public Map<QueryPart, QueryPart> resolve() {
+        return resolveInParentGroupings(identifiers);
+    }
+
+    /**
+     *  Loops through the SortedSet of Ids, attempting to load sets of
+     *  children of parent Ids.
+     *  The loop below assumes the the SortedSet is ordered by segment
+     *  size from smallest to largest, such that parent identifiers will
+     *  occur before their children.
+     */
+    private  Map<QueryPart, QueryPart> resolveInParentGroupings(
+        SortedSet<Id> identifiers)
+    {
+        final Map<QueryPart, QueryPart> resolvedIdentifiers =
+            new HashMap<QueryPart, QueryPart>();
+
+        while (identifiers.size() > 0) {
+            Id parent = identifiers.first();
+            identifiers.remove(parent);
+
+            if (!supportedIdentifier(parent)) {
+                continue;
+            }
+            Exp exp = (Exp)resolvedIdentifiers.get(parent);
+            if (exp == null) {
+                exp = lookupExp(resolvedIdentifiers, parent);
+            }
+            Member parentMember = getMemberFromExp(exp);
+            if (!supportedMember(parentMember)) {
+                continue;
+            }
+            batchResolveChildren(
+                parent, parentMember, identifiers, resolvedIdentifiers);
+        }
+        return resolvedIdentifiers;
+    }
+
+    /**
+     * Find the children of Id parent in the identifiers set and resolves
+     * all supported children together, adding them to the resolvedIdentifiers
+     * map.
+     */
+    private void batchResolveChildren(
+        Id parent, Member parentMember, SortedSet<Id> identifiers,
+        Map<QueryPart, QueryPart> resolvedIdentifiers)
+    {
+        final List<Id> children = findChildIds(parent, identifiers);
+        final List<Id.NameSegment> childNameSegments =
+            collectChildrenNameSegments(parentMember, children);
+
+        if (childNameSegments.size() > 0) {
+            List<Member> childMembers =
+                lookupChildrenByNames(parentMember, childNameSegments);
+            addChildrenToResolvedMap(
+                resolvedIdentifiers, children, childMembers);
+        }
+    }
+
+    private Exp lookupExp(
+        Map<QueryPart, QueryPart> resolvedIdentifiers, Id parent)
+    {
+        try {
+            Exp exp = Util.lookup(query, parent.getSegments(), false);
+            resolvedIdentifiers.put(parent, (QueryPart)exp);
+            return exp;
+        } catch (Exception exception) {
+            LOGGER.info(
+                String.format(
+                    "Failed to resolve '%s' during batch ID "
+                    + "resolution.",
+                    parent));
+        }
+        return null;
+    }
+
+    /**
+     * Correlates each child Id we started with to it's associated
+     * Member, if present.  Updates the resolvedIdentifiers map with
+     * the association.
+     */
+    private void addChildrenToResolvedMap(
+        Map<QueryPart, QueryPart> resolvedIdentifiers, List<Id> children,
+        List<Member> childMembers)
+    {
+        for (Member child : childMembers) {
+            for (Id childId : children) {
+                if (!resolvedIdentifiers.containsKey(childId)
+                    && getLastSegment(childId).matches(child.getName()))
+                {
+                    resolvedIdentifiers.put(
+                        childId, (QueryPart)Util.createExpr(child));
+                }
+            }
+        }
+    }
+
+    /**
+     * Performs a lookup of a set of children under parentMember.
+     */
+    private List<Member> lookupChildrenByNames(
+        Member parentMember,
+        List<Id.NameSegment> childNameSegments)
+    {
+        try {
+            return query.getSchemaReader(true)
+                .lookupMemberChildrenByNames(
+                    parentMember,
+                    childNameSegments, MatchType.EXACT);
+        } catch (Exception e) {
+            LOGGER.info(
+                String.format(
+                    "Failure while looking up children of '%s' during  "
+                    + "batch member resolution.  Child member refs:  %s",
+                    parentMember,
+                    Arrays.toString(childNameSegments.toArray())), e);
+        }
+        // don't want to fail at this point.  Member resolution still has
+        // another chance to succeed.
+        return Collections.emptyList();
+    }
+
+    /**
+     * Filters the children list to those that contain identifiers
+     * we think we can batch resolve, then transforms the Id list
+     * to the corresponding NameSegment.
+     */
+    private List<Id.NameSegment> collectChildrenNameSegments(
+        final Member parentMember, List<Id> children)
+    {
+        filter(
+            children, new Predicate() {
+            // remove children we can't support
+                @Override
+                public boolean evaluate(Object theId)
+                {
+                    Id id = (Id)theId;
+                    return !Util.matches(parentMember, id.getSegments())
+                        && supportedIdentifier(id);
+                }
+            });
+        return new ArrayList(
+            CollectionUtils.collect(
+                children, new Transformer()
+            {
+                // convert the collection to a list of NameSegments
+            @Override
+            public Object transform(Object theId) {
+                Id id = (Id)theId;
+                return getLastSegment(id);
+            }
+        }));
+    }
+
+    private Id.Segment getLastSegment(Id id) {
+        int segSize = id.getSegments().size();
+        return id.getSegments().get(segSize - 1);
+    }
+
+    /**
+     * Checks various conditions to determine whether
+     * the given identifier is likely to be resolvable at this point.
+     */
+    private boolean supportedIdentifier(Id id) {
+        Id.Segment seg = getLastSegment(id);
+        if (!(seg instanceof Id.NameSegment)) {
+            // we can't batch resolve members identified by key
+            return false;
+        }
+        return (isPossibleMemberRef(id))
+            && !segmentIsCalcMember(id.getSegments())
+            && !id.getSegments().get(0).matches("Measures");
+    }
+
+    private boolean supportedMember(Member member) {
+        return !(member == null
+            || member.equals(
+                member.getHierarchy().getNullMember())
+            || member.isMeasure());
+    }
+
+    /**
+     * Returns the [All] member from HierarchyExpr and DimensionExpr
+     * associated with hierarchies that have an All member.
+     * Returns the member associated with a MemberExpr.
+     * For all other Exp returns null.
+     */
+    private Member getMemberFromExp(Exp exp) {
+        if (exp instanceof DimensionExpr) {
+            Hierarchy hier = ((DimensionExpr)exp)
+                .getDimension().getHierarchy();
+            if (hier.hasAll()) {
+                return hier.getAllMember();
+            }
+        } else if (exp instanceof HierarchyExpr) {
+            Hierarchy hier = ((HierarchyExpr)exp)
+                .getHierarchy();
+            if (hier.hasAll()) {
+                return hier.getAllMember();
+            }
+        } else if (exp instanceof MemberExpr) {
+            return ((MemberExpr)exp).getMember();
+        }
+        return null;
+    }
+
+    /**
+     * Returns a collection of strings corresponding to the name
+     * or uniqueName of each OlapElement in olapElements, based on the
+     * flag uniqueName.
+     */
+    private Collection<String> getOlapElementNames(
+        OlapElement[] olapElements, final boolean uniqueName)
+    {
+        return CollectionUtils.collect(
+            Arrays.asList(olapElements),
+            new Transformer() {
+                @Override
+                public Object transform(Object o) {
+                    return uniqueName ? ((OlapElement)o).getUniqueName()
+                        : ((OlapElement)o).getName();
+                }
+            });
+    }
+
+    /**
+     * Returns true if the Id is something that will potentially translate into
+     * either the All/Default member of a dimension/hierarchy,
+     * or a specific member.
+     * This filters out references that we'd be unlikely to effectively
+     * handle.
+     */
+    private boolean isPossibleMemberRef(Id id) {
+        int size = id.getSegments().size();
+
+        if (size == 1) {
+            //Id.Segment seg = id.getSegments().get(0);
+            return segListMatchInUniqueNames(
+                id.getSegments(), dimensionUniqueNames)
+                || segListMatchInUniqueNames(
+                    id.getSegments(), hierarchyUniqueNames);
+        }
+        if (MondrianProperties.instance().SsasCompatibleNaming.get()
+            && size == 2)
+        {
+            return segListMatchInUniqueNames(
+                id.getSegments(), hierarchyUniqueNames);
+        }
+        if (segMatchInNames(getLastSegment(id), levelNames)) {
+            // conservative.  false on any match of any level name
+            return false;
+        }
+        // don't support "shortcut" member references references
+        return size > 1;
+    }
+
+    private boolean segListMatchInUniqueNames(
+        List<Id.Segment> segments, Collection<String> names)
+    {
+        String segUniqueName = Util.implode(segments);
+        for (String name : names) {
+           if (Util.equalName(segUniqueName, name)) {
+               return true;
+           }
+        }
+        return false;
+    }
+
+    private boolean segMatchInNames(
+        Id.Segment seg, Collection<String> names)
+    {
+        for (String name : names) {
+            if (seg.matches(name)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean segmentIsCalcMember(final List<Id.Segment> checkSegments) {
+        return query.getSchemaReader(true)
+            .getCalculatedMember(checkSegments) != null;
+    }
+
+    private List<Id> findChildIds(Id parent, SortedSet<Id> identifiers) {
+        List<Id> childIds = new ArrayList<Id>();
+        for (Id id : identifiers) {
+            final List<Id.Segment> idSeg = id.getSegments();
+            final List<Id.Segment> parentSegments = parent.getSegments();
+            final int parentSegSize = parentSegments.size();
+            if (idSeg.size() == parentSegSize + 1
+                && parent.getSegments().equals(
+                    idSeg.subList(0, parentSegSize)))
+            {
+                childIds.add(id);
+            }
+        }
+        return childIds;
+    }
+
+    /**
+     * Adds each parent segment to the set.
+     */
+    private void expandIdentifiers(Set<Id> identifiers) {
+        Set<Id> expandedIdentifiers = new HashSet<Id>();
+        for (Id id : identifiers) {
+            for (int i = 1; i < id.getSegments().size(); i++) {
+                expandedIdentifiers.add(new Id(id.getSegments().subList(0, i)));
+            }
+        }
+        identifiers.addAll(expandedIdentifiers);
+    }
+
+    /**
+     * Sorts shorter segments first, then by string compare.
+     * This allows processing parents first during the lookup loop,
+     * which is required by the algorithm.
+     */
+    private static class IdComparator implements Comparator<Id> {
+        public int compare(Id o1, Id o2) {
+            List<Id.Segment> o1Seg = o1.getSegments();
+            List<Id.Segment> o2Seg = o2.getSegments();
+
+            if (o1Seg.size() > o2Seg.size()) {
+                return 1;
+            } else if (o1Seg.size() < o2Seg.size()) {
+                return -1;
+            } else {
+                return o1Seg.toString()
+                    .compareTo(o2Seg.toString());
+            }
+        }
+    }
+}
+// End IdBatchResolver.java

--- a/src/main/mondrian/olap/IdentifierVisitor.java
+++ b/src/main/mondrian/olap/IdentifierVisitor.java
@@ -1,0 +1,28 @@
+/*
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (C) 2006-2015 Pentaho and others
+// All Rights Reserved.
+ */
+package mondrian.olap;
+
+import mondrian.mdx.*;
+
+import java.util.*;
+
+public class IdentifierVisitor extends MdxVisitorImpl {
+    private final Set<Id> identifiers;
+
+    public IdentifierVisitor(Set<Id> identifiers) {
+        this.identifiers = identifiers;
+    }
+
+    public Object visit(Id id) {
+        identifiers.add(id);
+        return null;
+    }
+}
+// End IdentifierVisitor.java

--- a/src/main/mondrian/olap/MondrianProperties.xml
+++ b/src/main/mondrian/olap/MondrianProperties.xml
@@ -1439,6 +1439,29 @@ only if external statistics were not available.</p>
     </PropertyDefinition>
 
     <PropertyDefinition>
+        <Name>LevelPreCacheThreshold</Name>
+        <Path>mondrian.rolap.precache.threshold</Path>
+        <Description>
+            <p>
+                Property which governs whether child members or members of a level are precached
+                when child or level members are requested within a
+                query expression.  For example,
+                if an expression references two child members in the store dimension,
+                like <code>{ [Store].[USA].[CA], [Store].[USA].[OR] }</code>, precaching will
+                load *all* children under [USA] rather than just the 2 requested.
+                The threshold value is
+                compared against the cardinality of the level to determine
+                whether or not precaching should be performed.  If cardinality is
+                lower than the threshold value Mondrian will precache.  Setting
+                this property to 0 effectively disables precaching.
+            </p>
+        </Description>
+        <Core>true</Core>
+        <Type>int</Type>
+        <Default>300</Default>
+    </PropertyDefinition>
+
+    <PropertyDefinition>
         <Name>WebappDeploy</Name>
         <Path>mondrian.webapp.deploy</Path>
         <Description>

--- a/src/main/mondrian/olap/Query.java
+++ b/src/main/mondrian/olap/Query.java
@@ -5,10 +5,9 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 1998-2005 Julian Hyde
-// Copyright (C) 2005-2013 Pentaho and others
+// Copyright (C) 2005-2015 Pentaho and others
 // All Rights Reserved.
 */
-
 package mondrian.olap;
 
 import mondrian.calc.*;
@@ -23,7 +22,7 @@ import mondrian.util.ArrayStack;
 
 import org.apache.commons.collections.collection.CompositeCollection;
 
-import org.olap4j.impl.IdentifierParser;
+import org.olap4j.impl.*;
 import org.olap4j.mdx.IdentifierSegment;
 
 import java.io.PrintWriter;
@@ -40,7 +39,7 @@ import java.util.*;
  * <h3>Query control</h3>
  *
  * <p>Most queries are model citizens, executing quickly (often using cached
- * results from previous queries), but some queries take more time, or more
+ * results from previous queries), but som queries take more time, or more
  * database resources, or more results, than is reasonable. Mondrian offers
  * three ways to control rogue queries:<ul>
  *
@@ -306,7 +305,18 @@ public class Query extends QueryPart {
     public Validator createValidator() {
         return createValidator(
             statement.getSchema().getFunTable(),
-            false);
+            false,
+            new HashMap<QueryPart, QueryPart>());
+    }
+
+
+    public Validator createValidator(
+        Map<QueryPart, QueryPart> resolvedIdentifiers)
+    {
+        return createValidator(
+            statement.getSchema().getFunTable(),
+            false,
+            resolvedIdentifiers);
     }
 
     /**
@@ -325,7 +335,21 @@ public class Query extends QueryPart {
         return new QueryValidator(
             functionTable,
             alwaysResolveFunDef,
-            Query.this);
+            Query.this,
+            new HashMap<QueryPart, QueryPart>());
+    }
+
+
+    public Validator createValidator(
+        FunTable functionTable,
+        boolean alwaysResolveFunDef,
+        Map<QueryPart, QueryPart> resolvedIdentifiers)
+    {
+        return new QueryValidator(
+            functionTable,
+            alwaysResolveFunDef,
+            Query.this,
+            resolvedIdentifiers);
     }
 
     /**
@@ -443,7 +467,12 @@ public class Query extends QueryPart {
      * tree in any way.
      */
     public void resolve() {
-        final Validator validator = createValidator();
+        // Before commencing validation, create all calculated members
+        // and calculated sets
+        createFormulaElements();
+        Map<QueryPart, QueryPart> resolvedIdentifiers =
+            new IdBatchResolver(this).resolve();
+        final Validator validator = createValidator(resolvedIdentifiers);
         resolve(validator); // resolve self and children
         // Create a dummy result so we can use its evaluator
         final Evaluator evaluator = RolapUtil.createEvaluator(statement);
@@ -451,6 +480,17 @@ public class Query extends QueryPart {
             createCompiler(
                 evaluator, validator, Collections.singletonList(resultStyle));
         compile(compiler);
+    }
+
+    private void createFormulaElements() {
+        if (formulas != null) {
+            // Resolving of formulas should be done in two parts
+            // because formulas might depend on each other, so all calculated
+            // mdx elements have to be defined during resolve.
+            for (Formula formula : formulas) {
+                formula.createElement(this);
+            }
+        }
     }
 
     /**
@@ -527,17 +567,6 @@ public class Query extends QueryPart {
      * @param validator Validator
      */
     public void resolve(Validator validator) {
-        // Before commencing validation, create all calculated members,
-        // calculated sets, and parameters.
-        if (formulas != null) {
-            // Resolving of formulas should be done in two parts
-            // because formulas might depend on each other, so all calculated
-            // mdx elements have to be defined during resolve.
-            for (Formula formula : formulas) {
-                formula.createElement(validator.getQuery());
-            }
-        }
-
         // Register all parameters.
         parameters.clear();
         parametersByName.clear();
@@ -1519,7 +1548,7 @@ public class Query extends QueryPart {
                 if (member == null) {
                     continue;
                 }
-                if (!match(member, nameParts)) {
+                if (!Util.matches(member, nameParts)) {
                     continue;
                 }
                 if (!query.getConnection().getRole().canAccess(member)) {
@@ -1530,36 +1559,7 @@ public class Query extends QueryPart {
             return null;
         }
 
-        private static boolean match(
-            Member member, List<Id.Segment> nameParts)
-        {
-            if (Util.equalName(Util.implode(nameParts),
-                member.getUniqueName()))
-            {
-                // exact match
-                return true;
-            }
-            Id.Segment segment = nameParts.get(nameParts.size() - 1);
-            while (member.getParentMember() != null) {
-                if (!segment.matches(member.getName())) {
-                    return false;
-                }
-                member = member.getParentMember();
-                nameParts = nameParts.subList(0, nameParts.size() - 1);
-                segment = nameParts.get(nameParts.size() - 1);
-            }
-            if (segment.matches(member.getName())) {
-                return Util.equalName(
-                    member.getHierarchy().getUniqueName(),
-                    Util.implode(nameParts.subList(0, nameParts.size() - 1)));
-            } else if (member.isAll()) {
-                return Util.equalName(
-                    member.getHierarchy().getUniqueName(),
-                    Util.implode(nameParts));
-            } else {
-                return false;
-            }
-        }
+
 
         public List<Member> getCalculatedMembers(Hierarchy hierarchy) {
             List<Member> result = new ArrayList<Member>();
@@ -1788,9 +1788,10 @@ public class Query extends QueryPart {
          * @param query Query
          */
         public QueryValidator(
-            FunTable functionTable, boolean alwaysResolveFunDef, Query query)
+            FunTable functionTable, boolean alwaysResolveFunDef, Query query,
+            Map<QueryPart, QueryPart> resolvedIdentifiers)
         {
-            super(functionTable);
+            super(functionTable, resolvedIdentifiers);
             this.alwaysResolveFunDef = alwaysResolveFunDef;
             this.query = query;
             this.schemaReader = new ScopedSchemaReader(this, true);

--- a/src/main/mondrian/olap/SchemaReader.java
+++ b/src/main/mondrian/olap/SchemaReader.java
@@ -5,10 +5,9 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2003-2005 Julian Hyde
-// Copyright (C) 2005-2012 Pentaho
+// Copyright (C) 2005-2015 Pentaho
 // All Rights Reserved.
 */
-
 package mondrian.olap;
 
 import mondrian.calc.Calc;
@@ -461,13 +460,21 @@ public interface SchemaReader {
         MatchType matchType);
 
     /**
+     * Finds a list of child members with the given names.
+     */
+    List<Member> lookupMemberChildrenByNames(
+        Member parent,
+        List<Id.NameSegment> childNames,
+        MatchType matchType);
+
+    /**
      * Returns an object which can evaluate an expression in native SQL, or
      * null if this is not possible.
      *
      * @param fun Function
      * @param args Arguments to the function
      * @param evaluator Evaluator, provides context
-     * @param calc
+     * @param calc the calc to be natively evaluated
      */
     NativeEvaluator getNativeSetEvaluator(
         FunDef fun,

--- a/src/main/mondrian/olap/Util.java
+++ b/src/main/mondrian/olap/Util.java
@@ -5,7 +5,7 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2001-2005 Julian Hyde
-// Copyright (C) 2005-2014 Pentaho and others
+// Copyright (C) 2005-2015 Pentaho and others
 // All Rights Reserved.
 */
 package mondrian.olap;
@@ -2062,6 +2062,38 @@ public class Util extends XOMUtil {
             throw unexpected(segment.getQuoting());
         }
     }
+
+    public static boolean matches(
+        Member member, List<Id.Segment> nameParts)
+    {
+        if (Util.equalName(Util.implode(nameParts),
+            member.getUniqueName()))
+        {
+            // exact match
+            return true;
+        }
+        Id.Segment segment = nameParts.get(nameParts.size() - 1);
+        while (member.getParentMember() != null) {
+            if (!segment.matches(member.getName())) {
+                return false;
+            }
+            member = member.getParentMember();
+            nameParts = nameParts.subList(0, nameParts.size() - 1);
+            segment = nameParts.get(nameParts.size() - 1);
+        }
+        if (segment.matches(member.getName())) {
+            return Util.equalName(
+                member.getHierarchy().getUniqueName(),
+                Util.implode(nameParts.subList(0, nameParts.size() - 1)));
+        } else if (member.isAll()) {
+            return Util.equalName(
+                member.getHierarchy().getUniqueName(),
+                Util.implode(nameParts));
+        } else {
+            return false;
+        }
+    }
+
 
     public static RuntimeException newElementNotFoundException(
         int category,

--- a/src/main/mondrian/olap/ValidatorImpl.java
+++ b/src/main/mondrian/olap/ValidatorImpl.java
@@ -1,12 +1,12 @@
 /*
-* This software is subject to the terms of the Eclipse Public License v1.0
-* Agreement, available at the following URL:
-* http://www.eclipse.org/legal/epl-v10.html.
-* You must accept the terms of that agreement to use this software.
-*
-* Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (C) 2002-2015 Pentaho
+// All Rights Reserved.
 */
-
 package mondrian.olap;
 
 import mondrian.mdx.*;
@@ -50,11 +50,15 @@ abstract class ValidatorImpl implements Validator {
      *
      * @param funTable Function table
      *
+     * @param resolvedIdentifiers map of already resolved Ids
      * @pre funTable != null
      */
-    protected ValidatorImpl(FunTable funTable) {
+    protected ValidatorImpl(
+        FunTable funTable, Map<QueryPart, QueryPart> resolvedIdentifiers)
+    {
         Util.assertPrecondition(funTable != null, "funTable != null");
         this.funTable = funTable;
+        resolvedNodes.putAll(resolvedIdentifiers);
     }
 
     public Exp validate(Exp exp, boolean scalar) {

--- a/src/main/mondrian/rolap/ChildByNameConstraint.java
+++ b/src/main/mondrian/rolap/ChildByNameConstraint.java
@@ -5,17 +5,16 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2004-2005 TONBELLER AG
-// Copyright (C) 2006-2012 Pentaho
+// Copyright (C) 2006-2015 Pentaho
 // All Rights Reserved.
 */
-
 package mondrian.rolap;
 
 import mondrian.olap.Id;
 import mondrian.rolap.aggmatcher.AggStar;
 import mondrian.rolap.sql.SqlQuery;
 
-import java.util.Arrays;
+import java.util.*;
 
 /**
  * Constraint which optimizes the search for a child by name. This is used
@@ -26,7 +25,7 @@ import java.util.Arrays;
  * @author avix
  */
 class ChildByNameConstraint extends DefaultMemberChildrenConstraint {
-    private final String childName;
+    private final String[] childNames;
     private final Object cacheKey;
 
     /**
@@ -35,8 +34,18 @@ class ChildByNameConstraint extends DefaultMemberChildrenConstraint {
      * @param childName Name of child
      */
     public ChildByNameConstraint(Id.NameSegment childName) {
-        this.childName = childName.name;
+        this.childNames = new String[]{childName.name};
         this.cacheKey = Arrays.asList(ChildByNameConstraint.class, childName);
+    }
+
+    public ChildByNameConstraint(List<Id.NameSegment> childNames) {
+        this.childNames = new String[childNames.size()];
+        int i = 0;
+        for (Id.NameSegment name : childNames) {
+            this.childNames[i++] = name.name;
+        }
+        this.cacheKey = Arrays.asList(
+            ChildByNameConstraint.class, this.childNames);
     }
 
     @Override
@@ -60,15 +69,19 @@ class ChildByNameConstraint extends DefaultMemberChildrenConstraint {
         super.addLevelConstraint(query, baseCube, aggStar, level);
         query.addWhere(
             SqlConstraintUtils.constrainLevel(
-                level, query, baseCube, aggStar, childName, true));
+                level, query, baseCube, aggStar, childNames, true));
     }
 
     public String toString() {
-        return "ChildByNameConstraint(" + childName + ")";
+        return "ChildByNameConstraint(" + Arrays.toString(childNames) + ")";
     }
 
     public Object getCacheKey() {
         return cacheKey;
+    }
+
+    public List<String> getChildNames() {
+        return Arrays.asList(childNames);
     }
 
 }

--- a/src/main/mondrian/rolap/RolapSchemaReader.java
+++ b/src/main/mondrian/rolap/RolapSchemaReader.java
@@ -5,7 +5,7 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2003-2005 Julian Hyde
-// Copyright (C) 2005-2014 Pentaho
+// Copyright (C) 2005-2015 Pentaho
 // All Rights Reserved.
 */
 package mondrian.rolap;
@@ -523,6 +523,19 @@ public class RolapSchemaReader
                 + "\", exception: " + e.getMessage());
         }
         return null;
+    }
+
+    public List<Member> lookupMemberChildrenByNames(
+        Member parent, List<Id.NameSegment> childNames, MatchType matchType)
+    {
+        MemberChildrenConstraint constraint = sqlConstraintFactory
+            .getChildrenByNamesConstraint(
+                (RolapMember) parent, childNames);
+        List<RolapMember> children =
+            internalGetMemberChildren(parent, constraint);
+        List<Member> childMembers = new ArrayList<Member>();
+        childMembers.addAll(children);
+        return childMembers;
     }
 
     public Member getCalculatedMember(List<Id.Segment> nameParts) {

--- a/src/main/mondrian/rolap/SmartIncrementalCache.java
+++ b/src/main/mondrian/rolap/SmartIncrementalCache.java
@@ -1,0 +1,70 @@
+/*
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (C) 2001-2005 Julian Hyde
+// Copyright (C) 2005-2015 Pentaho and others
+// All Rights Reserved.
+*/
+package mondrian.rolap;
+
+import mondrian.rolap.cache.*;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
+
+/**
+ * Uses a SmartCache to store a collection of values.
+ * Supplements put operations with an "addToEntry", which
+ * supports incrementally adding to the collection associated
+ * with key.
+ */
+public class SmartIncrementalCache<K, V extends Collection> {
+    SmartCache<K, V> cache;
+
+    public SmartIncrementalCache() {
+        cache = new SoftSmartCache<K, V>();
+    }
+
+    public V put(final K  key, final V value) {
+        return cache.put(key, value);
+    }
+
+    public V get(K key) {
+        return cache.get(key);
+    }
+
+    public void clear() {
+        cache.clear();
+    }
+
+    public void addToEntry(final K key, final V value) {
+        cache
+            .execute(
+                new SmartCache.SmartCacheTask
+                    <K, V>() {
+                    public void execute(Iterator<Map.Entry<K, V>> iterator) {
+                        // iterator is ignored,
+                        // we're updating a single entry and
+                        // we have the key.
+                        if (cache.get(key) == null) {
+                            cache.put(key, value);
+                        } else {
+                            cache.get(key).addAll(value);
+                        }
+                    } });
+    }
+
+    SmartCache<K, V> getCache() {
+        return cache;
+    }
+
+    void setCache(SmartCache<K, V> cache) {
+        this.cache = cache;
+    }
+
+}
+// End SmartIncrementalCache.java

--- a/src/main/mondrian/rolap/SqlConstraintUtils.java
+++ b/src/main/mondrian/rolap/SqlConstraintUtils.java
@@ -11,6 +11,8 @@
 */
 package mondrian.rolap;
 
+import mondrian.calc.*;
+import mondrian.mdx.*;
 import mondrian.olap.*;
 import mondrian.olap.fun.*;
 import mondrian.resource.MondrianResource;
@@ -21,8 +23,6 @@ import mondrian.rolap.aggmatcher.AggStar;
 import mondrian.rolap.sql.*;
 import mondrian.spi.Dialect;
 import mondrian.util.FilteredIterableList;
-import mondrian.calc.*;
-import mondrian.mdx.*;
 
 import org.apache.log4j.Logger;
 
@@ -1504,6 +1504,19 @@ public class SqlConstraintUtils {
         }
     }
 
+    public static String constrainLevel(
+        RolapLevel level,
+        SqlQuery query,
+        RolapCube baseCube,
+        AggStar aggStar,
+        String columnValue,
+        boolean caseSensitive)
+    {
+        return constrainLevel(
+            level, query, baseCube, aggStar,
+            new String[] {columnValue}, caseSensitive);
+    }
+
     /**
      * Generates a sql expression constraining a level by some value
      *
@@ -1522,7 +1535,7 @@ public class SqlConstraintUtils {
         SqlQuery query,
         RolapCube baseCube,
         AggStar aggStar,
-        String columnValue,
+        String[] columnValue,
         boolean caseSensitive)
     {
         // this method can be called within the context of shared members,
@@ -1570,30 +1583,84 @@ public class SqlConstraintUtils {
 
         String constraint;
 
-        if (RolapUtil.mdxNullLiteral().equalsIgnoreCase(columnValue)) {
-            constraint = columnString + " is " + RolapUtil.sqlNullLiteral;
-        } else {
-            if (datatype.isNumeric()) {
-                // make sure it can be parsed
-                Double.valueOf(columnValue);
-            }
-            final StringBuilder buf = new StringBuilder();
-            query.getDialect().quote(buf, columnValue, datatype);
-            String value = buf.toString();
-            if (caseSensitive && datatype == Dialect.Datatype.String) {
-                // Some databases (like DB2) compare case-sensitive. We convert
-                // the value to upper-case in the DBMS (e.g. UPPER('Foo'))
-                // rather than in Java (e.g. 'FOO') in case the DBMS is running
-                // a different locale.
-                if (!MondrianProperties.instance().CaseSensitive.get()) {
-                    columnString = query.getDialect().toUpper(columnString);
-                    value = query.getDialect().toUpper(value);
-                }
-            }
+        constraint = getColumnValueConstraint(
+            query, columnValue,
+            caseSensitive, columnString, datatype);
 
-            constraint = columnString + " = " + value;
+        return constraint;
+    }
+
+    private static String getColumnValueConstraint(
+        SqlQuery query, String[] columnValues, boolean caseSensitive,
+        String columnString, Dialect.Datatype datatype)
+    {
+        String constraint;
+        List<String> values = new ArrayList<String>();
+        boolean containsNull = false;
+
+        for (String columnValue : columnValues) {
+            if (RolapUtil.mdxNullLiteral().equalsIgnoreCase(columnValue)) {
+                containsNull = true;
+                //constraint = columnString + " is " + RolapUtil.sqlNullLiteral;
+            } else {
+                if (datatype.isNumeric()) {
+                    // make sure it can be parsed
+                    Double.valueOf(columnValue);
+                }
+                final StringBuilder buf = new StringBuilder();
+                query.getDialect().quote(buf, columnValue, datatype);
+                String value = buf.toString();
+                if (caseSensitive && datatype == Dialect.Datatype.String) {
+                    // Some databases (like DB2) compare case-sensitive.
+                    // We convert
+                    // the value to upper-case in the DBMS (e.g. UPPER('Foo'))
+                    // rather than in Java (e.g. 'FOO') in case the DBMS is
+                    // running  a different locale.
+                    if (!MondrianProperties.instance().CaseSensitive.get()) {
+                        value = query.getDialect().toUpper(value);
+                    }
+                }
+                values.add(value);
+            }
         }
 
+        if (caseSensitive && datatype == Dialect.Datatype.String
+            && !MondrianProperties.instance().CaseSensitive.get())
+        {
+            columnString = query.getDialect().toUpper(columnString);
+        }
+
+        if (values.size() == 1) {
+            if (containsNull) {
+                constraint = columnString + " IS " + RolapUtil.sqlNullLiteral;
+            } else {
+                constraint = columnString + " = " + values.get(0);
+            }
+        } else {
+            StringBuilder builder = new StringBuilder();
+            builder.append("( ");
+            if (values.size() > 0) {
+                builder.append(columnString)
+                    .append(" IN (");
+                for (int i = 0; i < values.size(); i++) {
+                    String value = values.get(i);
+                    builder.append(value);
+                    if (i < values.size() - 1) {
+                        builder.append(",");
+                    }
+                }
+                builder.append(")");
+            }
+            if (containsNull) {
+                if (values.size() > 0) {
+                    builder.append(" OR ");
+                }
+                builder.append(columnString)
+                    .append(" IS NULL ");
+            }
+            builder.append(")");
+            constraint = builder.toString();
+        }
         return constraint;
     }
 

--- a/testsrc/main/mondrian/olap/IdBatchResolverTest.java
+++ b/testsrc/main/mondrian/olap/IdBatchResolverTest.java
@@ -1,0 +1,504 @@
+/*
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (C) 2006-2015 Pentaho and others
+// All Rights Reserved.
+ */
+package mondrian.olap;
+
+import mondrian.parser.*;
+import mondrian.rolap.*;
+import mondrian.server.*;
+
+import org.apache.commons.collections.*;
+
+import org.mockito.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.mockito.Mockito.*;
+
+public class IdBatchResolverTest  extends BatchTestCase {
+
+    private Query query;
+
+    @Captor
+    private ArgumentCaptor<List<Id.NameSegment>> childNames;
+
+    @Captor
+    private ArgumentCaptor<Member> parentMember;
+
+    @Captor
+    private ArgumentCaptor<MatchType> matchType;
+
+    @Override
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    public void testSimpleEnum() {
+        assertContains(
+            "Resolved map omitted one or more members",
+            batchResolve(
+                "SELECT "
+                + "{[Product].[Food].[Dairy],"
+                + "[Product].[Food].[Deli],"
+                + "[Product].[Food].[Eggs],"
+                + "[Product].[Food].[Produce],"
+                + "[Product].[Food].[Starchy Foods]}"
+                + "on 0 FROM SALES"),
+            list(
+                "[Product].[Food].[Dairy]",
+                "[Product].[Food].[Deli]",
+                "[Product].[Food].[Eggs]",
+                "[Product].[Food].[Produce]",
+                "[Product].[Food].[Starchy Foods]"));
+
+        // verify lookupMemberChildrenByNames is called as expected with
+        // batched children's names.
+        verify(
+            query.getSchemaReader(true), times(2))
+            .lookupMemberChildrenByNames(
+                parentMember.capture(),
+                childNames.capture(),
+                matchType.capture());
+
+        assertEquals(
+            "[Product].[All Products]",
+            parentMember.getAllValues().get(0).getUniqueName());
+        assertTrue(childNames.getAllValues().get(0).size() == 1);
+        assertEquals(
+            "Food",
+            childNames.getAllValues().get(0).get(0).getName());
+
+        assertEquals(
+            "[Product].[Food]",
+            parentMember.getAllValues().get(1).getUniqueName());
+        assertTrue(childNames.getAllValues().get(1).size() == 5);
+
+        assertEquals(
+            "[[Dairy], [Deli], [Eggs], [Produce], [Starchy Foods]]",
+            sortedNames(childNames.getAllValues().get(1)));
+    }
+
+    public void testCalcMemsNotResolved() {
+        assertFalse(
+            "Resolved map should not contain calc members",
+            batchResolve(
+                "with member time.foo as '1' member time.bar as '2' "
+                + " select "
+                + " {[Time].[foo], [Time].[bar], "
+                + "  [Time].[1997],"
+                + "  [Time].[1997].[Q1], [Time].[1997].[Q2]} "
+                + " on 0 from sales ")
+                .removeAll(list("[Time].[foo]", "[Time].[bar]")));
+        // .removeAll will only return true if the set has changed, i.e. if
+        // one ore more of the members were present.
+    }
+
+    public void testLevelReferenceHandled() {
+        // make sure ["Week", 1997] don't get batched as children of
+        // [Time.Weekly].[All]
+        batchResolve(
+            "with member Gender.levelRef as "
+            + "'Sum(Descendants([Time.Weekly].CurrentMember, [Time.Weekly].Week))' "
+            + "select Gender.levelRef on 0 from sales where [Time.Weekly].[1997]");
+        verify(
+            query.getSchemaReader(true), times(1))
+            .lookupMemberChildrenByNames(
+                parentMember.capture(),
+                childNames.capture(),
+                matchType.capture());
+        assertEquals(
+            "[Time.Weekly].[All Time.Weeklys]",
+            parentMember.getAllValues().get(0).getUniqueName());
+        assertEquals(
+            "[[1997]]",
+            sortedNames(childNames.getAllValues().get(0)));
+    }
+
+
+    public void testPhysMemsResolvedWhenCalcsMixedIn() {
+        assertContains(
+            "Resolved map omitted one or more members",
+            batchResolve(
+                "with member time.foo as '1' member time.bar as '2' "
+                + " select "
+                + " {[Time].[foo], [Time].[bar], "
+                + "  [Time].[1997],"
+                + "  [Time].[1997].[Q1], [Time].[1997].[Q2]} "
+                + " on 0 from sales "),
+            list(
+                "[Time].[1997]",
+                "[Time].[1997].[Q1]",
+                "[Time].[1997].[Q2]"));
+        verify(
+            query.getSchemaReader(true), times(1))
+            .lookupMemberChildrenByNames(
+                parentMember.capture(),
+                childNames.capture(),
+                matchType.capture());
+        assertEquals(
+            "[Time].[1997]",
+            parentMember.getAllValues().get(0).getUniqueName());
+        assertTrue(childNames.getAllValues().get(0).size() == 2);
+        assertEquals(
+            "[[Q1], [Q2]]",
+            sortedNames(childNames.getAllValues().get(0)));
+    }
+
+
+    public void testAnalyzerFilterMdx() {
+        assertContains(
+            "Resolved map omitted one or more members",
+            batchResolve(
+                "WITH\n"
+                + "SET [*NATIVE_CJ_SET] AS 'NONEMPTYCROSSJOIN([*BASE_MEMBERS__Promotions_],[*BASE_MEMBERS__Store_])'\n"
+                + "SET [*BASE_MEMBERS__Store_] AS '{[Store].[USA].[WA].[Bellingham],[Store].[USA].[CA].[Beverly Hills],[Store].[USA].[WA].[Bremerton],[Store].[USA].[CA].[Los Angeles]}'\n"
+                + "SET [*SORTED_COL_AXIS] AS 'ORDER([*CJ_COL_AXIS],[Promotions].CURRENTMEMBER.ORDERKEY,BASC)'\n"
+                + "SET [*BASE_MEMBERS__Measures_] AS '{[Measures].[*FORMATTED_MEASURE_0]}'\n"
+                + "SET [*CJ_ROW_AXIS] AS 'GENERATE([*NATIVE_CJ_SET], {([Store].CURRENTMEMBER)})'\n"
+                + "SET [*BASE_MEMBERS__Promotions_] AS '{[Promotions].[Bag Stuffers],[Promotions].[Best Savings],[Promotions].[Big Promo],[Promotions].[Big Time Discounts],[Promotions].[Big Time Savings],[Promotions].[Bye Bye Baby]}'\n"
+                + "SET [*SORTED_ROW_AXIS] AS 'ORDER([*CJ_ROW_AXIS],[Store].CURRENTMEMBER.ORDERKEY,BASC,ANCESTOR([Store].CURRENTMEMBER,[Store].[Store State]).ORDERKEY,BASC)'\n"
+                + "SET [*CJ_COL_AXIS] AS 'GENERATE([*NATIVE_CJ_SET], {([Promotions].CURRENTMEMBER)})'\n"
+                + "MEMBER [Measures].[*FORMATTED_MEASURE_0] AS '[Measures].[Unit Sales]', FORMAT_STRING = 'Standard', SOLVE_ORDER=500\n"
+                + "SELECT\n"
+                + "CROSSJOIN([*SORTED_COL_AXIS],[*BASE_MEMBERS__Measures_]) ON COLUMNS\n"
+                + ",NON EMPTY\n"
+                + "[*SORTED_ROW_AXIS] ON ROWS\n"
+                + "FROM [Sales]"),
+            list(
+                "[Store].[USA].[WA].[Bellingham]",
+                "[Store].[USA].[CA].[Beverly Hills]",
+                "[Store].[USA].[WA].[Bremerton]",
+                "[Store].[USA].[CA].[Los Angeles]",
+                "[Promotions].[Bag Stuffers]", "[Promotions].[Best Savings]",
+                "[Promotions].[Big Promo]", "[Promotions].[Big Time Discounts]",
+                "[Promotions].[Big Time Savings]",
+                "[Promotions].[Bye Bye Baby]"));
+
+        verify(
+            query.getSchemaReader(true), times(5))
+            .lookupMemberChildrenByNames(
+                parentMember.capture(),
+                childNames.capture(),
+                matchType.capture());
+
+        assertEquals(
+            "[Promotions].[All Promotions]",
+            parentMember.getAllValues().get(0).getUniqueName());
+        assertTrue(childNames.getAllValues().get(0).size() == 6);
+        assertEquals(
+            "[[Bag Stuffers], [Best Savings], [Big Promo], "
+            + "[Big Time Discounts], [Big Time Savings], [Bye Bye Baby]]",
+            sortedNames(childNames.getAllValues().get(0)));
+
+        assertEquals(
+            "[Store].[USA].[CA]",
+            parentMember.getAllValues().get(3).getUniqueName());
+        assertTrue(childNames.getAllValues().get(3).size() == 2);
+        assertEquals(
+            "[[Beverly Hills], [Los Angeles]]",
+            sortedNames(childNames.getAllValues().get(3)));
+    }
+
+    public void testSetWithNullMember() {
+        assertContains(
+            "Resolved map omitted one or more members",
+            batchResolve(
+                "WITH\n"
+                + "SET [*NATIVE_CJ_SET] AS 'FILTER([*BASE_MEMBERS__Store Size in SQFT_], NOT ISEMPTY ([Measures].[Unit Sales]))'\n"
+                + "SET [*BASE_MEMBERS__Store Size in SQFT_] AS '{[Store Size in SQFT].[#null],[Store Size in SQFT].[20319],[Store Size in SQFT].[21215],[Store Size in SQFT].[22478],[Store Size in SQFT].[23598]}'\n"
+                + "SET [*BASE_MEMBERS__Measures_] AS '{[Measures].[*FORMATTED_MEASURE_0]}'\n"
+                + "SET [*CJ_SLICER_AXIS] AS 'GENERATE([*NATIVE_CJ_SET], {([Store Size in SQFT].CURRENTMEMBER)})'\n"
+                + "MEMBER [Measures].[*FORMATTED_MEASURE_0] AS '[Measures].[Unit Sales]', FORMAT_STRING = 'Standard', SOLVE_ORDER=500\n"
+                + "SELECT\n"
+                + "[*BASE_MEMBERS__Measures_] ON COLUMNS\n"
+                + "FROM [Sales]\n"
+                + "WHERE ([*CJ_SLICER_AXIS])"),
+            list(
+                "[Store Size in SQFT].[#null]",
+                "[Store Size in SQFT].[20319]",
+                "[Store Size in SQFT].[21215]",
+                "[Store Size in SQFT].[22478]",
+                "[Store Size in SQFT].[23598]"));
+
+        verify(
+            query.getSchemaReader(true), times(1))
+            .lookupMemberChildrenByNames(
+                parentMember.capture(),
+                childNames.capture(),
+                matchType.capture());
+
+        assertEquals(
+            "[Store Size in SQFT].[All Store Size in SQFTs]",
+            parentMember.getAllValues().get(0).getUniqueName());
+        assertTrue(childNames.getAllValues().get(0).size() == 5);
+        assertEquals(
+            "[[#null], [20319], [21215], [22478], [23598]]",
+            sortedNames(childNames.getAllValues().get(0)));
+    }
+
+    public void testMultiHierarchyNonSSAS() {
+        propSaver.set(propSaver.properties.SsasCompatibleNaming, false);
+        assertContains(
+            "Resolved map omitted one or more members",
+            batchResolve(
+                "WITH\n"
+                + "SET [*NATIVE_CJ_SET] AS 'FILTER([*BASE_MEMBERS__Time.Weekly_], NOT ISEMPTY ([Measures].[Unit Sales]))'\n"
+                + "SET [*BASE_MEMBERS__Time.Weekly_] AS '{[Time.Weekly].[1997].[4],[Time.Weekly].[1997].[5],[Time.Weekly].[1997].[6]}'\n"
+                + "SET [*BASE_MEMBERS__Measures_] AS '{[Measures].[*FORMATTED_MEASURE_0]}'\n"
+                + "SET [*CJ_SLICER_AXIS] AS 'GENERATE([*NATIVE_CJ_SET], {([Time.Weekly].CURRENTMEMBER)})'\n"
+                + "MEMBER [Measures].[*FORMATTED_MEASURE_0] AS '[Measures].[Unit Sales]', FORMAT_STRING = 'Standard', SOLVE_ORDER=500\n"
+                + "SELECT\n"
+                + "[*BASE_MEMBERS__Measures_] ON COLUMNS\n"
+                + "FROM [Sales]\n"
+                + "WHERE ([*CJ_SLICER_AXIS])"),
+            list(
+                "[Time.Weekly].[1997].[4]",
+                "[Time.Weekly].[1997].[5]",
+                "[Time.Weekly].[1997].[6]"));
+
+        verify(
+            query.getSchemaReader(true), times(2))
+            .lookupMemberChildrenByNames(
+                parentMember.capture(),
+                childNames.capture(),
+                matchType.capture());
+        assertEquals(
+            "[Time.Weekly].[All Time.Weeklys]",
+            parentMember.getAllValues().get(0).getUniqueName());
+        assertTrue(childNames.getAllValues().get(0).size() == 1);
+        assertEquals(
+            "1997",
+            childNames.getAllValues().get(0).get(0).getName());
+        assertEquals(
+            "[[4], [5], [6]]",
+            sortedNames(childNames.getAllValues().get(1)));
+    }
+
+    public void testMultiHierarchySSAS() {
+        propSaver.set(propSaver.properties.SsasCompatibleNaming, true);
+        assertContains(
+            "Resolved map omitted one or more members",
+            batchResolve(
+                "WITH\n"
+                + "SET [*NATIVE_CJ_SET] AS 'FILTER([*BASE_MEMBERS__Time.Weekly_], NOT ISEMPTY ([Measures].[Unit Sales]))'\n"
+                + "SET [*BASE_MEMBERS__Time.Weekly_] AS '{[Time].[Weekly].[1997].[4],[Time].[Weekly].[1997].[5],[Time].[Weekly].[1997].[6]}'\n"
+                + "SET [*BASE_MEMBERS__Measures_] AS '{[Measures].[*FORMATTED_MEASURE_0]}'\n"
+                + "SET [*CJ_SLICER_AXIS] AS 'GENERATE([*NATIVE_CJ_SET], {([Time].[Weekly].CURRENTMEMBER)})'\n"
+                + "MEMBER [Measures].[*FORMATTED_MEASURE_0] AS '[Measures].[Unit Sales]', FORMAT_STRING = 'Standard', SOLVE_ORDER=500\n"
+                + "SELECT\n"
+                + "[*BASE_MEMBERS__Measures_] ON COLUMNS\n"
+                + "FROM [Sales]\n"
+                + "WHERE ([*CJ_SLICER_AXIS])"),
+            list(
+                "[Time].[Weekly].[1997].[4]",
+                "[Time].[Weekly].[1997].[5]",
+                "[Time].[Weekly].[1997].[6]"));
+
+        verify(
+            query.getSchemaReader(true), times(2))
+            .lookupMemberChildrenByNames(
+                parentMember.capture(),
+                childNames.capture(),
+                matchType.capture());
+        assertEquals(
+            "[Time].[Weekly].[All Weeklys]",
+            parentMember.getAllValues().get(0).getUniqueName());
+        assertTrue(
+            childNames.getAllValues().get(0).size() == 1);
+        assertEquals(
+            "1997",
+            childNames.getAllValues().get(0).get(0).getName());
+        assertEquals(
+            "[[4], [5], [6]]",
+            sortedNames(childNames.getAllValues().get(1)));
+    }
+
+    public void testParentChild() {
+        // P-C resolution will not result in consolidated SQL, but it should
+        // still correctly identify children and attempt to resolve them
+        // together.
+        assertContains(
+            "Resolved map omitted one or more members",
+            batchResolve(
+                "WITH\n"
+                + "SET [*NATIVE_CJ_SET] AS 'FILTER([*BASE_MEMBERS__Employees_], NOT ISEMPTY ([Measures].[Number of Employees]))'\n"
+                + "SET [*BASE_MEMBERS__Employees_] AS '{[Employees].[Sheri Nowmer].[Derrick Whelply],[Employees].[Sheri Nowmer].[Michael Spence]}'\n"
+                + "SET [*BASE_MEMBERS__Measures_] AS '{[Measures].[*FORMATTED_MEASURE_0]}'\n"
+                + "SET [*CJ_SLICER_AXIS] AS 'GENERATE([*NATIVE_CJ_SET], {([Employees].CURRENTMEMBER)})'\n"
+                + "MEMBER [Measures].[*FORMATTED_MEASURE_0] AS '[Measures].[Number of Employees]', FORMAT_STRING = '#,#', SOLVE_ORDER=500\n"
+                + "SELECT\n"
+                + "[*BASE_MEMBERS__Measures_] ON COLUMNS\n"
+                + "FROM [HR]\n"
+                + "WHERE ([*CJ_SLICER_AXIS])"),
+                list(
+                    "[Employees].[Sheri Nowmer].[Derrick Whelply]",
+                    "[Employees].[Sheri Nowmer].[Michael Spence]"));
+
+        verify(
+            query.getSchemaReader(true), times(2))
+            .lookupMemberChildrenByNames(
+                parentMember.capture(),
+                childNames.capture(),
+                matchType.capture());
+        assertEquals(
+            "[Employees].[Sheri Nowmer]",
+            parentMember.getAllValues().get(1).getUniqueName());
+        assertTrue(childNames.getAllValues().get(1).size() == 2);
+    }
+
+
+    private void assertContains(
+        String msg, Collection<String> strings, Collection<String> list)
+    {
+        if (!strings.containsAll(list)) {
+            List<String> copy = new ArrayList<String>(list);
+            copy.removeAll(strings);
+            fail(
+                String.format(
+                    "%s\nMissing: %s", msg,
+                Arrays.toString(copy.toArray())));
+        }
+    }
+
+    public Set<String> batchResolve(String mdx) {
+        IdBatchResolver batchResolver = makeTestBatchResolver(mdx);
+        Map<QueryPart, QueryPart> resolvedIdents = batchResolver.resolve();
+        Set<String> resolvedNames = getResolvedNames(resolvedIdents);
+        return resolvedNames;
+    }
+
+    private String sortedNames(List<Id.NameSegment> items) {
+        Collections.sort(
+            items, new Comparator<Id.NameSegment>()
+        {
+            @Override
+            public int compare(Id.NameSegment o1, Id.NameSegment o2) {
+                return o1.getName().compareTo(o2.getName());
+            }
+        });
+        return Arrays.toString(items.toArray());
+    }
+
+    private Collection<String> list(String... items) {
+        return Arrays.asList(items);
+    }
+
+    private Set<String> getResolvedNames(
+        Map<QueryPart, QueryPart> resolvedIdents)
+    {
+        return new HashSet(
+            CollectionUtils
+            .collect(
+                resolvedIdents.keySet(),
+                new Transformer()
+                {
+                    @Override
+                    public Object transform(Object o) {
+                        return o.toString();
+                    }
+                }));
+    }
+
+    public IdBatchResolver makeTestBatchResolver(String mdx) {
+        getTestContext().flushSchemaCache();
+        Parser.FactoryImpl factoryImpl = new FactoryImplTestWrapper();
+        MdxParserValidator parser = new JavaccParserValidatorImpl(factoryImpl);
+
+        RolapConnection conn = (RolapConnection) spy(
+            getTestContext().withFreshConnection().getConnection());
+        when(conn.createParser()).thenReturn(parser);
+
+        query = conn.parseQuery(mdx);
+        Locus.push(new Locus(new Execution(
+            query.getStatement(), Integer.MAX_VALUE),
+            "batchResolveTest", "batchResolveTest"));
+
+        return new IdBatchResolver(query);
+    }
+
+    private class QueryTestWrapper extends Query {
+        private SchemaReader spyReader;
+
+        public QueryTestWrapper(
+            Statement statement,
+            Formula[] formulas,
+            QueryAxis[] axes,
+            String cube,
+            QueryAxis slicerAxis,
+            QueryPart[] cellProps,
+            boolean strictValidation)
+        {
+            super(
+                statement,
+                Util.lookupCube(statement.getSchemaReader(), cube, true),
+                formulas,
+                axes,
+                slicerAxis,
+                cellProps,
+                new Parameter[0],
+                strictValidation);
+        }
+
+        @Override
+        public void resolve() {
+            // for testing purposes we want to defer resolution till after
+            //  Query init (resolve is called w/in constructor).
+            // We do still need formulas to be created, though.
+            if (getFormulas() != null) {
+                for (Formula formula : getFormulas()) {
+                    formula.createElement(this);
+                }
+            }
+        }
+
+        @Override
+        public synchronized SchemaReader getSchemaReader(
+            boolean accessControlled)
+        {
+            if (spyReader == null) {
+                spyReader = spy(super.getSchemaReader(accessControlled));
+            }
+            return spyReader;
+        }
+    }
+
+    public class FactoryImplTestWrapper extends Parser.FactoryImpl {
+
+        @Override
+        public Query makeQuery(
+            Statement statement,
+            Formula[] formulae,
+            QueryAxis[] axes,
+            String cube,
+            Exp slicer,
+            QueryPart[] cellProps,
+            boolean strictValidation)
+        {
+            final QueryAxis slicerAxis =
+                slicer == null
+                    ? null
+                    : new QueryAxis(
+                        false, slicer, AxisOrdinal.StandardAxisOrdinal.SLICER,
+                        QueryAxis.SubtotalVisibility.Undefined, new Id[0]);
+            return new QueryTestWrapper(
+                statement, formulae, axes, cube, slicerAxis, cellProps,
+                strictValidation);
+        }
+    }
+}
+
+// End IdBatchResolverTest.java

--- a/testsrc/main/mondrian/rolap/BatchTestCase.java
+++ b/testsrc/main/mondrian/rolap/BatchTestCase.java
@@ -5,29 +5,40 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2004-2005 Julian Hyde
-// Copyright (C) 2005-2013 Pentaho and others
+// Copyright (C) 2005-2015 Pentaho and others
 // All Rights Reserved.
 */
-
 package mondrian.rolap;
 
 import mondrian.calc.ResultStyle;
-import mondrian.olap.*;
+import mondrian.olap.Axis;
+import mondrian.olap.CacheControl;
+import mondrian.olap.Connection;
+import mondrian.olap.Cube;
+import mondrian.olap.Id;
+import mondrian.olap.Member;
+import mondrian.olap.MondrianProperties;
+import mondrian.olap.Query;
+import mondrian.olap.Result;
+import mondrian.olap.Util;
 import mondrian.rolap.RolapNative.*;
 import mondrian.rolap.agg.*;
+import mondrian.rolap.cache.HardSmartCache;
 import mondrian.server.Execution;
 import mondrian.server.Locus;
 import mondrian.spi.Dialect;
-import mondrian.test.*;
+import mondrian.util.Pair;
+
+import mondrian.test.FoodMartTestCase;
+import mondrian.test.SqlPattern;
+import mondrian.test.TestContext;
 
 import org.apache.log4j.Logger;
 
 import org.eigenbase.util.property.IntegerProperty;
 
 import java.io.*;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.Future;
 
 /**
@@ -476,7 +487,8 @@ public class BatchTestCase extends FoodMartTestCase {
             // Create a dummy DataSource which will throw a 'bomb' if it is
             // asked to execute a particular SQL statement, but will otherwise
             // behave exactly the same as the current DataSource.
-            RolapUtil.setHook(new TriggerHook(trigger));
+            final TriggerHook hook = new TriggerHook(trigger);
+            RolapUtil.setHook(hook);
             Bomb bomb = null;
             try {
                 if (bypassSchemaCache) {
@@ -503,18 +515,20 @@ public class BatchTestCase extends FoodMartTestCase {
                 RolapUtil.setHook(null);
             }
             if (negative) {
-                if (bomb != null) {
+                if (bomb != null || hook.foundMatch()) {
                     fail("forbidden query [" + sql + "] detected");
                 }
             } else {
-                if (bomb == null) {
+                if (bomb == null && !hook.foundMatch()) {
                     fail("expected query [" + sql + "] did not occur");
                 }
-                assertEquals(
-                    replaceQuotes(
-                        sql.replaceAll("\r\n", "\n")),
-                    replaceQuotes(
-                        bomb.sql.replaceAll("\r\n", "\n")));
+                if (bomb != null) {
+                    assertEquals(
+                        replaceQuotes(
+                            sql.replaceAll("\r\n", "\n")),
+                        replaceQuotes(
+                            bomb.sql.replaceAll("\r\n", "\n")));
+                }
             }
         }
 
@@ -737,6 +751,16 @@ public class BatchTestCase extends FoodMartTestCase {
 
         return new CellRequestConstraint(
             aggConstraintTables, aggConstraintColumns, aggConstraintValues);
+    }
+
+    void clearAndHardenCache(MemberCacheHelper helper) {
+        helper.mapLevelToMembers.setCache(
+            new HardSmartCache<Pair<RolapLevel, Object>, List<RolapMember>>());
+        helper.mapMemberToChildren.setCache(
+            new HardSmartCache<Pair<RolapMember, Object>, List<RolapMember>>());
+        helper.mapKeyToMember.clear();
+        helper.mapParentToNamedChildren.setCache(
+            new HardSmartCache<RolapMember, Collection<RolapMember>>());
     }
 
     protected RolapStar.Measure getMeasure(String cube, String measureName) {
@@ -1077,6 +1101,7 @@ public class BatchTestCase extends FoodMartTestCase {
 
     private static class TriggerHook implements RolapUtil.ExecuteQueryHook {
         private final String trigger;
+        private boolean foundMatch = false;
 
         public TriggerHook(String trigger) {
             this.trigger =
@@ -1100,6 +1125,9 @@ public class BatchTestCase extends FoodMartTestCase {
             // ignore quotes
             String s = replaceQuotes(sql);
             String t = replaceQuotes(trigger);
+            if (s.startsWith(t) && !foundMatch) {
+                foundMatch = true;
+            }
             return s.startsWith(t);
         }
 
@@ -1107,6 +1135,10 @@ public class BatchTestCase extends FoodMartTestCase {
             if (matchTrigger(sql)) {
                 throw new Bomb(sql);
             }
+        }
+
+        public boolean foundMatch() {
+            return foundMatch;
         }
     }
 

--- a/testsrc/main/mondrian/rolap/DataSourceChangeListenerTest.java
+++ b/testsrc/main/mondrian/rolap/DataSourceChangeListenerTest.java
@@ -5,10 +5,9 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2007-2008 Bart Pappyn
-// Copyright (C) 2007-2012 Pentaho
+// Copyright (C) 2007-2015 Pentaho
 // All Rights Reserved.
 */
-
 package mondrian.rolap;
 
 import mondrian.olap.*;
@@ -29,7 +28,7 @@ import java.util.*;
  * @author Bart Pappyn
  * @since Jan 05, 2007
  */
-public class DataSourceChangeListenerTest extends FoodMartTestCase {
+public class DataSourceChangeListenerTest extends BatchTestCase {
 
     public DataSourceChangeListenerTest() {
         super();
@@ -72,29 +71,17 @@ public class DataSourceChangeListenerTest extends FoodMartTestCase {
         // tests.
         SmartMemberReader smr = getSmartMemberReader("Store");
         MemberCacheHelper smrch = (MemberCacheHelper)smr.getMemberCache();
-        smrch.mapLevelToMembers.setCache(
-            new HardSmartCache<Pair<RolapLevel, Object>, List<RolapMember>>());
-        smrch.mapMemberToChildren.setCache(
-            new HardSmartCache<Pair<RolapMember, Object>, List<RolapMember>>());
-        smrch.mapKeyToMember = new HardSmartCache<Object, RolapMember>();
 
         MemberCacheHelper rcsmrch =
             ((RolapCubeHierarchy.RolapCubeHierarchyMemberReader) smr)
                 .getRolapCubeMemberCacheHelper();
-        rcsmrch.mapLevelToMembers.setCache(
-            new HardSmartCache<Pair<RolapLevel, Object>, List<RolapMember>>());
-        rcsmrch.mapMemberToChildren.setCache(
-            new HardSmartCache<Pair<RolapMember, Object>, List<RolapMember>>());
-        rcsmrch.mapKeyToMember = new HardSmartCache<Object, RolapMember>();
 
         SmartMemberReader ssmr = getSharedSmartMemberReader("Store");
         MemberCacheHelper ssmrch = (MemberCacheHelper)ssmr.getMemberCache();
-        ssmrch.mapLevelToMembers.setCache(
-            new HardSmartCache<Pair<RolapLevel, Object>, List<RolapMember>>());
-        ssmrch.mapMemberToChildren.setCache(
-            new HardSmartCache<Pair<RolapMember, Object>, List<RolapMember>>());
-        ssmrch.mapKeyToMember = new HardSmartCache<Object, RolapMember>();
 
+        clearAndHardenCache(ssmrch);
+        clearAndHardenCache(rcsmrch);
+        clearAndHardenCache(smrch);
 
         // Create a dummy DataSource which will throw a 'bomb' if it is asked
         // to execute a particular SQL statement, but will otherwise behave
@@ -138,17 +125,9 @@ public class DataSourceChangeListenerTest extends FoodMartTestCase {
             assertEquals("[]", s3);
 
             // Manually clear the cache to make compare sql result later on
-            smrch.mapKeyToMember.clear();
-            smrch.mapLevelToMembers.clear();
-            smrch.mapMemberToChildren.clear();
-
-            ssmrch.mapKeyToMember.clear();
-            ssmrch.mapLevelToMembers.clear();
-            ssmrch.mapMemberToChildren.clear();
-
-            rcsmrch.mapKeyToMember.clear();
-            rcsmrch.mapLevelToMembers.clear();
-            rcsmrch.mapMemberToChildren.clear();
+            clearAndHardenCache(smrch);
+            clearAndHardenCache(ssmrch);
+            clearAndHardenCache(rcsmrch);
 
             // Run query again, to make sure only cache is used
             Result r4 = executeQuery(
@@ -457,7 +436,7 @@ public class DataSourceChangeListenerTest extends FoodMartTestCase {
             }
         }
         if (!messages.isEmpty()) {
-            TestCase.fail(messages.size() + " threads failed\n" + messages);
+            fail(messages.size() + " threads failed\n" + messages);
         }
     }
 
@@ -501,10 +480,10 @@ public class DataSourceChangeListenerTest extends FoodMartTestCase {
         }
     }
 
-    Result executeQuery(String mdx, Connection connection) {
-        Query query = connection.parseQuery(mdx);
-        return connection.execute(query);
-    }
+//    Result executeQuery(String mdx, Connection connection) {
+//        Query query = connection.parseQuery(mdx);
+//        return connection.execute(query);
+//    }
 
     SmartMemberReader getSmartMemberReader(String hierName) {
         Connection con = getTestContext().getConnection();

--- a/testsrc/main/mondrian/rolap/MemberCacheHelperTest.java
+++ b/testsrc/main/mondrian/rolap/MemberCacheHelperTest.java
@@ -1,0 +1,202 @@
+/*
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (C) 2006-2015 Pentaho and others
+// All Rights Reserved.
+ */
+package mondrian.rolap;
+
+import mondrian.rolap.sql.MemberChildrenConstraint;
+
+import junit.framework.TestCase;
+
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+
+public class MemberCacheHelperTest extends TestCase {
+
+    @Mock
+    private RolapMember parentMember;
+
+    @Mock
+    private ChildByNameConstraint childByNameConstraint;
+
+    @Mock
+    private MemberKey memberKey;
+
+    private MemberChildrenConstraint defMemChildrenConstraint =
+        DefaultMemberChildrenConstraint.instance();
+
+    private List<RolapMember> children = new ArrayList<RolapMember>();
+
+    private MemberCacheHelper cacheHelper = new MemberCacheHelper(null);
+
+    @Override
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    public void testRoundtripChildrenUsingChildByNameConstraint() {
+        List<String> childNames = fillChildren(children, 3);
+        when(childByNameConstraint.getChildNames()).thenReturn(childNames);
+
+        cacheHelper.putChildren(parentMember, childByNameConstraint, children);
+
+        List<RolapMember> retrievedChildren =
+            cacheHelper.getChildrenFromCache(
+                parentMember, childByNameConstraint);
+
+        assertEquals(children, retrievedChildren);
+    }
+
+    public void testCachedByDefaultConstraint() {
+        List<String> childNames = fillChildren(children, 5);
+        when(childByNameConstraint.getChildNames()).thenReturn(childNames);
+
+        // cached under default constraint, but subsequent
+        // retrieval with childByName should work since all children present.
+        cacheHelper.putChildren(
+            parentMember,
+            defMemChildrenConstraint, children);
+
+        List<RolapMember> retrievedChildren =
+            cacheHelper.getChildrenFromCache(
+                parentMember,
+                childByNameConstraint);
+
+        assertEquals(children, retrievedChildren);
+    }
+
+    public void testOnlyRequestedChildrenRetrieved() {
+        // tests retrieval of a subset of children from
+        // the cache with keyed with DefaultMemberChildrenConstraint
+        List<String> childNames = fillChildren(children, 5);
+
+        int FROM = 2;
+        int TO = 5;
+        // childByName constraint defined with member names in sublist
+        when(childByNameConstraint.getChildNames()).thenReturn(
+            childNames.subList(FROM, TO));
+
+        // cached under default constraint, but subsequent
+        // retrieval with childByName should work since all children present.
+        cacheHelper.putChildren(
+            parentMember,
+            defMemChildrenConstraint, children);
+
+        List<RolapMember> retrievedChildren =
+            cacheHelper.getChildrenFromCache(
+                parentMember,
+                childByNameConstraint);
+
+        assertEquals(
+            "Expected children were not retrieved from cache.",
+            children.subList(FROM, TO), retrievedChildren);
+    }
+
+    public void testMissingChildrenNotRetrievedDefaultConst() {
+        runMissingChildrenNotRetrievedTest(defMemChildrenConstraint);
+    }
+
+    public void testMissingChildrenNotRetrievedChildByName() {
+        runMissingChildrenNotRetrievedTest(childByNameConstraint);
+    }
+
+    public void runMissingChildrenNotRetrievedTest(
+        MemberChildrenConstraint constraint)
+    {
+        fillChildren(children, 5);
+        when(childByNameConstraint.getChildNames()).thenReturn(
+            Arrays.asList(new String[]{ "Other Name", "Other Name2" }));
+
+        cacheHelper.putChildren(
+            parentMember, constraint, children);
+
+        List<RolapMember> retrievedChildren =
+            cacheHelper.getChildrenFromCache(
+                parentMember, childByNameConstraint);
+
+        assertEquals(
+            "Not expecting to retrieve anything from cache",
+            null, retrievedChildren);
+    }
+
+
+    public void testRemoveChildMemberPresentInNamedChildrenMap() {
+        List<String> childNames = fillChildren(children, 3);
+        when(childByNameConstraint.getChildNames()).thenReturn(
+            childNames.subList(1, 3));
+        List<MemberKey> childKeys = new ArrayList<MemberKey>();
+
+        for (RolapMember member : children) {
+            when(member.getParentMember()).thenReturn(parentMember);
+            MemberKey key = mockMemberKey();
+            childKeys.add(key);
+            cacheHelper.putMember(key, member);
+        }
+        cacheHelper.putMember(memberKey, parentMember);
+        cacheHelper.putChildren(parentMember, childByNameConstraint, children);
+
+        cacheHelper.removeMember(childKeys.get(0));
+
+        List<RolapMember> members =
+            cacheHelper.getChildrenFromCache(
+                parentMember, childByNameConstraint);
+
+        assertEquals(
+            "Retrieved children should not include the removed member",
+            children.subList(1, 3), members);
+    }
+
+    private MemberKey mockMemberKey() {
+        MemberKey mock = mock(MemberKey.class);
+        when(mock.getLevel()).thenReturn(mock(RolapLevel.class));
+        return mock;
+    }
+
+    private List<String> fillChildren(List<RolapMember> children, int count) {
+        List<String> names = new ArrayList<String>();
+        for (int i = 0; i < count; i++) {
+            RolapMember member = mock(RolapMember.class);
+            String name = "Member-" + i;
+            names.add(name);
+            when(member.getName()).thenReturn(name);
+            // there's a bug in mockito which causes mock objects
+            // .compareTo to always return 1
+            // https://code.google.com/p/mockito/issues/detail?id=467
+            // here's a workaround.
+            when(member.compareTo(any(RolapMember.class))).thenAnswer(
+                new Answer<Object>() {
+                    @Override
+                    public Object answer(InvocationOnMock invocation)
+                        throws Throwable
+                    {
+                        return  ((RolapMember)invocation.getMock()).getName()
+                            .compareTo(
+                                ((RolapMember) invocation.getArguments()[0])
+                                    .getName());
+                    }
+                }
+            );
+            children.add(member);
+        }
+        return names;
+    }
+}
+
+// End MemberCacheHelperTest.java

--- a/testsrc/main/mondrian/rolap/VirtualCubeTest.java
+++ b/testsrc/main/mondrian/rolap/VirtualCubeTest.java
@@ -5,13 +5,10 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2003-2005 Julian Hyde
-// Copyright (C) 2005-2012 Pentaho
+// Copyright (C) 2005-2015 Pentaho
 // All Rights Reserved.
 */
-
 package mondrian.rolap;
-
-import java.util.List;
 
 import mondrian.olap.Axis;
 import mondrian.olap.Member;
@@ -22,6 +19,8 @@ import mondrian.olap.Result;
 import mondrian.spi.Dialect;
 import mondrian.test.SqlPattern;
 import mondrian.test.TestContext;
+
+import java.util.List;
 
 /**
  * Unit tests for virtual cubes.
@@ -995,18 +994,16 @@ public class VirtualCubeTest extends BatchTestCase {
             null,
             null);
 
-        /*
-         * This test case does not actually reject the dimension constraint from
-         * an unrelated base cube. The reason is that the constraint contains an
-         * AllLevel member. Even though semantically constraining Cells using an
-         * non-existent dimension perhaps does not make sense; however, in the
-         * case where the constraint contains AllLevel member, the constraint
-         * can be considered "always true".
-         *
-         * See the next test case for a constraint that does not contain
-         * AllLevel member and hence cannot be satisfied. The cell should be
-         * empty.
-         */
+//       This test case does not actually reject the dimension constraint from
+//       an unrelated base cube. The reason is that the constraint contains an
+//       AllLevel member. Even though semantically constraining Cells using an
+//       non-existent dimension perhaps does not make sense; however, in the
+//       case where the constraint contains AllLevel member, the constraint
+//       can be considered "always true".
+//
+//       See the next test case for a constraint that does not contain
+//       AllLevel member and hence cannot be satisfied. The cell should be
+//       empty.
         testContext.assertQueryReturns(
             "with member [Warehouse].[x] as 'Aggregate([Warehouse].members)'\n"
             + "member [Measures].[foo] AS '([Warehouse].[x],[Measures].[Customer Count])'\n"
@@ -1359,6 +1356,10 @@ public class VirtualCubeTest extends BatchTestCase {
             // Generated SQL is different if NON EMPTY is evaluated in memory.
             return;
         }
+        // we want to make sure a SqlConstraint is used for retrieving
+        // [Product Family].members
+        propSaver.set(propSaver.properties.LevelPreCacheThreshold, 0);
+
         propSaver.set(propSaver.properties.GenerateFormattedSql, true);
         String query =
             "with "

--- a/testsrc/main/mondrian/rolap/sql/EffectiveMemberCacheTest.java
+++ b/testsrc/main/mondrian/rolap/sql/EffectiveMemberCacheTest.java
@@ -1,0 +1,201 @@
+/*
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (C) 2006-2015 Pentaho and others
+// All Rights Reserved.
+ */
+package mondrian.rolap.sql;
+
+import mondrian.rolap.*;
+import mondrian.spi.Dialect;
+import mondrian.test.*;
+
+public class EffectiveMemberCacheTest extends BatchTestCase {
+
+    TestContext testContext;
+
+    @Override
+    public void setUp() {
+        clearCache();
+        propSaver.set(propSaver.properties.GenerateFormattedSql, true);
+    }
+
+    public void testCachedLevelMembers() {
+        // verify query for specific members can be fulfilled by members cached
+        // from a level members query.
+        testWithAndWithoutCachedMembers(
+            "select Product.[Product Name].members on 0 from sales",
+            "select "
+            + " { [Product].[Food].[Produce].[Fruit].[Fresh Fruit].[Hermanos].[Hermanos Fancy Plums], "
+            + "[Product].[Food].[Produce].[Fruit].[Fresh Fruit].[Hermanos].[Hermanos Lemons],"
+            + "[Product].[Food].[Produce].[Fruit].[Fresh Fruit].[Hermanos].[Hermanos Plums] }"
+            + " on 0 from sales",
+            new SqlPattern[]{
+                new SqlPattern(
+                    Dialect.DatabaseProduct.MYSQL,
+                    "select\n"
+                    + "    `product`.`product_name` as `c0`\n"
+                    + "from\n"
+                    + "    `product` as `product`,\n"
+                    + "    `product_class` as `product_class`\n"
+                    + "where\n"
+                    + "    `product`.`product_class_id` = `product_class`.`product_class_id`\n"
+                    + "and\n"
+                    + "    (`product`.`brand_name` = 'Hermanos' and `product_class`.`product_subcategory` = 'Fresh Fruit' and `product_class`.`product_category` = 'Fruit' and `product_class`.`product_department` = 'Produce' and `product_class`.`product_family` = 'Food')\n"
+                    + "and\n"
+                    + "    ( UPPER(`product`.`product_name`) IN (UPPER('Hermanos Fancy Plums'),UPPER('Hermanos Lemons'),UPPER('Hermanos Plums')))\n"
+                    + "group by\n"
+                    + "    `product`.`product_name`\n"
+                    + "order by\n"
+                    + "    ISNULL(`product`.`product_name`) ASC, "
+                    + "`product`.`product_name` ASC", null)}
+        );
+    }
+
+    public void testCachedChildMembers() {
+        // verify query for specific members can be fulfilled by members cached
+        // from a child members query.
+        testWithAndWithoutCachedMembers(
+            "select [Product].[Food].[Produce].[Fruit].[Fresh Fruit].[Hermanos].Children on 0 from sales",
+            "select "
+            + " { [Product].[Food].[Produce].[Fruit].[Fresh Fruit].[Hermanos].[Hermanos Fancy Plums], "
+            + "[Product].[Food].[Produce].[Fruit].[Fresh Fruit].[Hermanos].[Hermanos Lemons],"
+            + "[Product].[Food].[Produce].[Fruit].[Fresh Fruit].[Hermanos].[Hermanos Plums] }"
+            + " on 0 from sales",
+            new SqlPattern[]{
+                new SqlPattern(
+                    Dialect.DatabaseProduct.MYSQL,
+                    "select\n"
+                    + "    `product`.`product_name` as `c0`\n"
+                    + "from\n"
+                    + "    `product` as `product`,\n"
+                    + "    `product_class` as `product_class`\n"
+                    + "where\n"
+                    + "    `product`.`product_class_id` = `product_class`.`product_class_id`\n"
+                    + "and\n"
+                    + "    (`product`.`brand_name` = 'Hermanos' and `product_class`.`product_subcategory` = 'Fresh Fruit' and `product_class`.`product_category` = 'Fruit' and `product_class`.`product_department` = 'Produce' and `product_class`.`product_family` = 'Food')\n"
+                    + "and\n"
+                    + "    ( UPPER(`product`.`product_name`) IN "
+                    + "(UPPER('Hermanos Fancy Plums'),UPPER('Hermanos Lemons'),UPPER('Hermanos Plums')))\n"
+                    + "group by\n"
+                    + "    `product`.`product_name`\n"
+                    + "order by\n"
+                    + "    ISNULL(`product`.`product_name`) ASC, "
+                    + "`product`.`product_name` ASC", null) }
+        );
+    }
+
+    public void testLevelPreCacheThreshold() {
+        // [Store Type] members cardinality falls well below
+        // LevelPreCacheThreshold.  All members should be loaded, not
+        // just the 2 referenced.
+        propSaver.set(propSaver.properties.LevelPreCacheThreshold, 300);
+
+        assertQuerySql(
+            testContext,
+            "select {[Store Type].[Gourmet Supermarket], "
+            + "[Store Type].[HeadQuarters]} on 0 from sales",
+            new SqlPattern[] {
+                new SqlPattern(
+                    Dialect.DatabaseProduct.MYSQL,
+                    "select\n"
+                    + "    `store`.`store_type` as `c0`\n"
+                    + "from\n"
+                    + "    `store` as `store`\n"
+                    + "group by\n"
+                    + "    `store`.`store_type`\n"
+                    + "order by\n"
+                    + "    ISNULL(`store`.`store_type`) ASC, "
+                    + "`store`.`store_type` ASC", null)
+            });
+    }
+
+    public void testLevelPreCacheThresholdDisabled() {
+        propSaver.set(propSaver.properties.LevelPreCacheThreshold, 0);
+
+        // with LevelPreCacheThreshold set to 0, we should not load
+        // all [store type] members, we should only retrieve the 2
+        // specified.
+        assertQuerySql(
+            testContext,
+            "select {[Store Type].[Gourmet Supermarket], "
+            + "[Store Type].[HeadQuarters]} on 0 from sales",
+            new SqlPattern[] {
+                new SqlPattern(
+                    Dialect.DatabaseProduct.MYSQL,
+                    "select\n"
+                    + "    `store`.`store_type` as `c0`\n"
+                    + "from\n"
+                    + "    `store` as `store`\n"
+                    + "where\n"
+                    + "    ( UPPER(`store`.`store_type`) IN "
+                    + "(UPPER('Gourmet Supermarket'),UPPER('HeadQuarters')))\n"
+                    + "group by\n"
+                    + "    `store`.`store_type`\n"
+                    + "order by\n"
+                    + "    ISNULL(`store`.`store_type`) ASC, "
+                    + "`store`.`store_type` ASC", null)
+            });
+    }
+
+    public void testLevelPreCacheThresholdParentDegenerate() {
+        // we should avoid pulling all deg members, regardless of cardinality.
+        // The cost of doing full scans of the fact table is assumed
+        // to be too high.
+        propSaver.set(propSaver.properties.LevelPreCacheThreshold, 1000);
+        assertQuerySql(
+            testContext,
+            "select {[Has coffee bar].[All Has coffee bars].[false]} on 0 from Store",
+            new SqlPattern[]{
+                new SqlPattern(
+                    Dialect.DatabaseProduct.MYSQL,
+                    "select\n"
+                    + "    `store`.`coffee_bar` as `c0`\n"
+                    + "from\n"
+                    + "    `store` as `store`\n"
+                    + "where\n"
+                    + "    `store`.`coffee_bar` = false\n"
+                    + "group by\n"
+                    + "    `store`.`coffee_bar`\n"
+                    + "order by\n"
+                    + "    ISNULL(`store`.`coffee_bar`) ASC, "
+                    + "`store`.`coffee_bar` ASC", null)});
+    }
+
+
+    /**
+     * Execute testMdx both with and without running the cacheMdx first,
+     * validating that sqlToLoadTestMdxMembers either fires or doesn't fire,
+     * as appropriate.
+     *
+     * Assumption is that if the cacheMdx has fired, then members shoould
+     * already be in cache and there is no need to load them.  If cacheMedx
+     * is not fired we should see the sqlToLoadTestMdxMembers.
+     */
+    private void testWithAndWithoutCachedMembers(
+        String cacheMdx, String testMdx, SqlPattern[] sqlToLoadTestMdxMembers)
+    {
+        for (boolean membersCached : new boolean[] {false, true}) {
+            clearCache();
+            if (membersCached) {
+                testContext.executeQuery(cacheMdx);
+            }
+            assertQuerySqlOrNot(
+                testContext,
+                testMdx,
+                sqlToLoadTestMdxMembers,
+                membersCached, false, false);
+        }
+    }
+
+    private void clearCache() {
+        getTestContext().flushSchemaCache();
+        testContext = getTestContext().withFreshConnection();
+    }
+
+}
+
+// End EffectiveMemberCacheTest.java

--- a/testsrc/main/mondrian/test/Main.java
+++ b/testsrc/main/mondrian/test/Main.java
@@ -5,7 +5,7 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 1998-2005 Julian Hyde
-// Copyright (C) 2005-2014 Pentaho and others
+// Copyright (C) 2005-2015 Pentaho and others
 // All Rights Reserved.
 //
 // jhyde, 21 January, 1999
@@ -22,9 +22,7 @@ import mondrian.olap4j.XmlaExtraTest;
 import mondrian.rolap.*;
 import mondrian.rolap.agg.*;
 import mondrian.rolap.aggmatcher.*;
-import mondrian.rolap.sql.CrossJoinArgFactoryTest;
-import mondrian.rolap.sql.SelectNotInGroupByTest;
-import mondrian.rolap.sql.SqlQueryTest;
+import mondrian.rolap.sql.*;
 import mondrian.server.FileRepositoryTest;
 import mondrian.spi.impl.SybaseDialectTest;
 import mondrian.test.build.CodeComplianceTest;
@@ -341,6 +339,9 @@ public class Main extends TestSuite {
             addTest(suite, CrossJoinArgFactoryTest.class);
             addTest(suite, UnionFunDefTest.class);
             addTest(suite, SybaseDialectTest.class);
+            addTest(suite, IdBatchResolverTest.class);
+            addTest(suite, MemberCacheHelperTest.class);
+            addTest(suite, EffectiveMemberCacheTest.class);
 
             boolean testNonEmpty = isRunOnce();
             if (!MondrianProperties.instance().EnableNativeNonEmpty.get()) {

--- a/testsrc/main/mondrian/test/NativeSetEvaluationTest.java
+++ b/testsrc/main/mondrian/test/NativeSetEvaluationTest.java
@@ -4,7 +4,7 @@
 // http://www.eclipse.org/legal/epl-v10.html.
 // You must accept the terms of that agreement to use this software.
 //
-// Copyright (c) 2002-2014 Pentaho Corporation
+// Copyright (c) 2002-2015 Pentaho Corporation
 // All Rights Reserved.
 */
 package mondrian.test;
@@ -657,6 +657,11 @@ public class NativeSetEvaluationTest extends BatchTestCase {
      * make it more permissable.
      */
     public void testLoopDetection() {
+        // Note that this test will fail if the query below is executed
+        // non-natively, or if the level.members expressions are replaced
+        // with enumerated sets.
+        // See http://jira.pentaho.com/browse/MONDRIAN-2337
+        propSaver.set(propSaver.properties.LevelPreCacheThreshold, 0);
         if (!MondrianProperties.instance().EnableNativeTopCount.get()) {
             return;
         }


### PR DESCRIPTION
dimension members.

1) Introduces a "batch resolution" phase prior to final expression
resolution which collects child name references and loads them at the
same time.  This avoids the one-at-a-time SQL queries for each child
member reference within an expression.  IdBatchResolver is the
relevant class.

2) To better suppport (1), this change also introduces a new caching
mechanism for ChildByNameConstraints.  If the child members { [Bob],
[Joe], [Bill] } have already been cached, MemberCacheHelper is now
smart enough to retrieve any subset of what has formerly been loaded.
This new functionanlity only works with ChildByNameConstraint checks,
since it depends on lookups by name.

3) To better handle small levels (under 300 members), this change also
adds a check for level cardinality when constructing a constraint in
SqlConstraintFactory.  In general, any level with fewer than 300
members will be loaded with a default constraint to avoid repeat
queries to the dimension table.  There are some exceptions to this,
for example degenerate dimensions are assumed to be too expensive for
full table scans, so a Sql constraint is preferred.  This is governed by
a new property called "LevelPreCacheThreshold", which can be set to
0 to disable the new behavior.