### PR TITLE
[BACKLOG-2384]  Removing @Override annotations on implemented interface ...

### DIFF
--- a/src/main/mondrian/olap/IdBatchResolver.java
+++ b/src/main/mondrian/olap/IdBatchResolver.java
@@ -259,7 +259,6 @@ public final class IdBatchResolver {
         filter(
             children, new Predicate() {
             // remove children we can't support
-                @Override
                 public boolean evaluate(Object theId)
                 {
                     Id id = (Id)theId;
@@ -272,7 +271,6 @@ public final class IdBatchResolver {
                 children, new Transformer()
             {
                 // convert the collection to a list of NameSegments
-            @Override
             public Object transform(Object theId) {
                 Id id = (Id)theId;
                 return getLastSegment(id);
@@ -343,7 +341,6 @@ public final class IdBatchResolver {
         return CollectionUtils.collect(
             Arrays.asList(olapElements),
             new Transformer() {
-                @Override
                 public Object transform(Object o) {
                     return uniqueName ? ((OlapElement)o).getUniqueName()
                         : ((OlapElement)o).getName();

--- a/testsrc/main/mondrian/olap/IdBatchResolverTest.java
+++ b/testsrc/main/mondrian/olap/IdBatchResolverTest.java
@@ -385,7 +385,6 @@ public class IdBatchResolverTest  extends BatchTestCase {
         Collections.sort(
             items, new Comparator<Id.NameSegment>()
         {
-            @Override
             public int compare(Id.NameSegment o1, Id.NameSegment o2) {
                 return o1.getName().compareTo(o2.getName());
             }
@@ -406,7 +405,6 @@ public class IdBatchResolverTest  extends BatchTestCase {
                 resolvedIdents.keySet(),
                 new Transformer()
                 {
-                    @Override
                     public Object transform(Object o) {
                         return o.toString();
                     }

--- a/testsrc/main/mondrian/rolap/MemberCacheHelperTest.java
+++ b/testsrc/main/mondrian/rolap/MemberCacheHelperTest.java
@@ -182,7 +182,6 @@ public class MemberCacheHelperTest extends TestCase {
             // here's a workaround.
             when(member.compareTo(any(RolapMember.class))).thenAnswer(
                 new Answer<Object>() {
-                    @Override
                     public Object answer(InvocationOnMock invocation)
                         throws Throwable
                     {


### PR DESCRIPTION
...methods,

due to incompatibility with JDK 1.5.  Apparently that's only supported 1.6+.