### PR TITLE
MONDRIAN-2335: SQL for dialect='postgres' in Measure expression is never used to generate native SQL

### DIFF
--- a/src/main/mondrian/rolap/sql/SqlQuery.java
+++ b/src/main/mondrian/rolap/sql/SqlQuery.java
@@ -19,6 +19,7 @@ import mondrian.spi.DialectManager;
 import mondrian.util.Pair;
 
 import java.util.*;
+
 import javax.sql.DataSource;
 
 /**
@@ -1012,8 +1013,20 @@ public class SqlQuery {
         }
 
         private static String getBestName(Dialect dialect) {
-            return dialect.getDatabaseProduct().getFamily().name()
-                .toLowerCase();
+          final String dialectName = dialect.getDatabaseProduct().getFamily()
+              .name().toLowerCase();
+          if (dialectName.equals("postgresql")) {
+              //Luc Boudreau's comment
+              // Special case for the discrepancy between the value used
+              // in schemas and the actual name of the dialect. The former is
+              // 'postgresql' while the later is 'postgres'.
+              // We can't change the schemas or we will break compatibility,
+              // so we have to switch it here.
+              // This needs to be fixed post 4.0.
+              return "postgres";
+           } else {
+             return dialectName;
+           }
         }
     }
 

--- a/testsrc/main/mondrian/rolap/sql/CodeSetTest.java
+++ b/testsrc/main/mondrian/rolap/sql/CodeSetTest.java
@@ -1,0 +1,197 @@
+/*
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (C) 2005-2015 Pentaho and others
+// All Rights Reserved.
+ */
+package mondrian.rolap.sql;
+
+import mondrian.olap.MondrianException;
+import mondrian.spi.impl.PostgreSqlDialect;
+
+import junit.framework.TestCase;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Tatsiana_Kasiankova
+ *
+ */
+public class CodeSetTest extends TestCase {
+
+  private static final String MONDRIAN_ERROR_NO_GENERIC_VARIANT =
+      "Mondrian Error:Internal error: View has no 'generic' variant";
+  private static final String POSTGRESQL_DIALECT = "postgresql";
+  private static final String SQL_CODE_FOR_POSTGRESQL_DIALECT =
+      "Code for dialect='postgresql'";
+  private static final String POSTGRES_DIALECT = "postgres";
+  private static final String SQL_CODE_FOR_POSTGRES_DIALECT =
+      "Code for dialect='postgres'";
+  private static final String GENERIC_DIALECT = "generic";
+  private static final String SQL_CODE_FOR_GENERIC_DIALECT =
+      "Code for dialect='generic'";
+
+  private static final String POSTGRESQL_PRODUCT_VERSION = "9.1.14";
+  private static final String POSTGRESQL_PRODUCT_NAME = "PostgreSQL";
+  private static final String EMPTY_NAME = "";
+  private SqlQuery.CodeSet codeSet;
+
+  @Override
+  protected void setUp() throws Exception {
+  }
+
+  /**
+   * ISSUE MONDRIAN-2335 If SqlQuery.CodeSet contains only sql code
+   * for dialect="postgres", this code should be chosen.
+   * No error should be thrown
+   *
+   * @throws Exception
+   */
+  public void testSucces_CodeSetContainsOnlyCodeForPostgresDialect()
+    throws Exception
+    {
+    PostgreSqlDialect postgreSqlDialect = new PostgreSqlDialect(
+        mockConnection(
+            POSTGRESQL_PRODUCT_NAME,
+            POSTGRESQL_PRODUCT_VERSION));
+    codeSet = new SqlQuery.CodeSet();
+    codeSet.put(POSTGRES_DIALECT, SQL_CODE_FOR_POSTGRES_DIALECT);
+    try {
+      String chooseQuery = codeSet.chooseQuery(postgreSqlDialect);
+      assertEquals(SQL_CODE_FOR_POSTGRES_DIALECT, chooseQuery);
+    } catch (MondrianException mExc) {
+      fail(
+          "Not expected any MondrianException but it occured: "
+          + mExc.getLocalizedMessage());
+    }
+  }
+
+  /**
+   * ISSUE MONDRIAN-2335 If SqlQuery.CodeSet contains sql code
+   * for both dialect="postgres" and dialect="generic",
+   * the code for dialect="postgres"should be chosen. No error should be thrown
+   *
+   * @throws Exception
+   */
+  public void testSucces_CodeSetContainsCodeForBothPostgresAndGenericDialects()
+    throws Exception
+    {
+    PostgreSqlDialect postgreSqlDialect = new PostgreSqlDialect(
+        mockConnection(
+            POSTGRESQL_PRODUCT_NAME,
+            POSTGRESQL_PRODUCT_VERSION));
+    codeSet = new SqlQuery.CodeSet();
+    codeSet.put(POSTGRES_DIALECT, SQL_CODE_FOR_POSTGRES_DIALECT);
+    codeSet.put(GENERIC_DIALECT, SQL_CODE_FOR_GENERIC_DIALECT);
+    try {
+      String chooseQuery = codeSet.chooseQuery(postgreSqlDialect);
+      assertEquals(SQL_CODE_FOR_POSTGRES_DIALECT, chooseQuery);
+    } catch (MondrianException mExc) {
+      fail(
+          "Not expected any MondrianException but it occured: "
+          + mExc.getLocalizedMessage());
+    }
+  }
+
+  /**
+   * ISSUE MONDRIAN-2335 If SqlQuery.CodeSet contains sql code
+   * for both dialect="postgres" and dialect="postgresql",
+   * the code for dialect="postgres"should be chosen. No error should be thrown
+   *
+   * @throws Exception
+   */
+  public void
+    testSucces_CodeSetContainsCodeForBothPostgresAndPostgresqlDialects()
+      throws Exception
+      {
+    PostgreSqlDialect postgreSqlDialect = new PostgreSqlDialect(
+        mockConnection(
+            POSTGRESQL_PRODUCT_NAME,
+            POSTGRESQL_PRODUCT_VERSION));
+    codeSet = new SqlQuery.CodeSet();
+    codeSet.put(POSTGRES_DIALECT, SQL_CODE_FOR_POSTGRES_DIALECT);
+    codeSet.put(POSTGRESQL_DIALECT, SQL_CODE_FOR_POSTGRESQL_DIALECT);
+    try {
+      String chooseQuery = codeSet.chooseQuery(postgreSqlDialect);
+      assertEquals(SQL_CODE_FOR_POSTGRES_DIALECT, chooseQuery);
+    } catch (MondrianException mExc) {
+      fail(
+          "Not expected any MondrianException but it occured: "
+          + mExc.getLocalizedMessage());
+    }
+  }
+
+  /**
+   * If SqlQuery.CodeSet contains sql code for dialect="generic" ,
+   * the code for dialect="generic" should be chosen. No error should be thrown
+   *
+   * @throws Exception
+   */
+  public void testSucces_CodeSetContainsOnlyCodeForGenericlDialect()
+    throws Exception
+    {
+    PostgreSqlDialect postgreSqlDialect = new PostgreSqlDialect(
+        mockConnection(
+            POSTGRESQL_PRODUCT_NAME,
+            POSTGRESQL_PRODUCT_VERSION));
+    codeSet = new SqlQuery.CodeSet();
+    codeSet.put(GENERIC_DIALECT, SQL_CODE_FOR_GENERIC_DIALECT);
+    try {
+      String chooseQuery = codeSet.chooseQuery(postgreSqlDialect);
+      assertEquals(SQL_CODE_FOR_GENERIC_DIALECT, chooseQuery);
+    } catch (MondrianException mExc) {
+      fail(
+          "Not expected any MondrianException but it occured: "
+          + mExc.getLocalizedMessage());
+    }
+  }
+
+  /**
+   * If SqlQuery.CodeSet contains no sql code with specified dialect at all
+   * (even 'generic'), the MondrianException should be thrown.
+   *
+   * @throws Exception
+   */
+  public void testMondrianExceptionThrown_WhenCodeSetContainsNOCodeForDialect()
+    throws Exception
+    {
+    PostgreSqlDialect postgreSqlDialect = new PostgreSqlDialect(
+        mockConnection(
+            POSTGRESQL_PRODUCT_NAME,
+            POSTGRESQL_PRODUCT_VERSION));
+    codeSet = new SqlQuery.CodeSet();
+    try {
+      String chooseQuery = codeSet.chooseQuery(postgreSqlDialect);
+      fail(
+          "Expected MondrianException but not occured");
+      assertEquals(SQL_CODE_FOR_GENERIC_DIALECT, chooseQuery);
+    } catch (MondrianException mExc) {
+      assertEquals(
+          MONDRIAN_ERROR_NO_GENERIC_VARIANT,
+          mExc.getLocalizedMessage());
+    }
+  }
+
+  private Connection mockConnection(
+      String dbProductName, String dbProductVersion) throws Exception
+      {
+    DatabaseMetaData dbMetaDataMock = mock(DatabaseMetaData.class);
+    when(dbMetaDataMock.getDatabaseProductName()).thenReturn(
+        dbProductName != null ? dbProductName : EMPTY_NAME);
+    when(dbMetaDataMock.getDatabaseProductVersion()).thenReturn(
+        dbProductVersion != null ? dbProductVersion : EMPTY_NAME);
+    Connection conectionMock = mock(Connection.class);
+    when(conectionMock.getMetaData()).thenReturn(dbMetaDataMock);
+    return conectionMock;
+  }
+
+}
+
+// End CodeSetTest.java

--- a/testsrc/main/mondrian/test/Main.java
+++ b/testsrc/main/mondrian/test/Main.java
@@ -22,6 +22,7 @@ import mondrian.olap4j.XmlaExtraTest;
 import mondrian.rolap.*;
 import mondrian.rolap.agg.*;
 import mondrian.rolap.aggmatcher.*;
+import mondrian.rolap.sql.CodeSetTest;
 import mondrian.rolap.sql.CrossJoinArgFactoryTest;
 import mondrian.rolap.sql.SelectNotInGroupByTest;
 import mondrian.rolap.sql.SqlQueryTest;
@@ -36,7 +37,6 @@ import mondrian.util.*;
 import mondrian.xmla.*;
 import mondrian.xmla.impl.DynamicDatasourceXmlaServletTest;
 import mondrian.xmla.test.XmlaTest;
-
 import junit.framework.Test;
 import junit.framework.*;
 
@@ -360,6 +360,7 @@ public class Main extends TestSuite {
 
             addTest(suite, FastBatchingCellReaderTest.class);
             addTest(suite, SqlQueryTest.class);
+            addTest(suite, CodeSetTest.class);
 
             if (MondrianProperties.instance().EnableNativeCrossJoin.get()) {
                 addTest(suite, BatchedFillTest.class, "suite");


### PR DESCRIPTION
There is a fix proposed by Luc Boudreau and unit tests.