### PR TITLE
[BACKLOG-2384] Changes to better support loading and caching of dimension members.

### DIFF
--- a/bin/checkFile.awk
+++ b/bin/checkFile.awk
@@ -382,7 +382,7 @@ publicClassBraceLine && FNR == publicClassBraceLine + 1 {
 /^\/\/ Copyright .* Pentaho/ && strict > 1 {
     # We assume that '--strict' is only invoked on files currently being
     # edited. Therefore we would expect the copyright to be current.
-    if ($0 !~ /-2014/) {
+    if ($0 !~ /-2015/) {
         error(fname, FNR, "copyright is not current");
     }
 }

--- a/ivy.xml
+++ b/ivy.xml
@@ -110,7 +110,7 @@
 
         <!-- Test Jars -->
         <dependency org="junit" name="junit" rev="3.8.1" conf="test->default"/>
-        <dependency org="org.mockito" name="mockito-all" rev="1.8.5" conf="test->default"/>
+        <dependency org="org.mockito" name="mockito-all" rev="1.9.5" conf="test->default"/>
         <dependency org="xmlunit" name="xmlunit" rev="1.3" conf="test->default"/>
         <dependency org="monetdb" name="monetdb-jdbc" rev="2.8-SNAPSHOT" conf="test->default"/>
         <dependency org="pentaho" name="mondrian-data-adventureworks" rev="0.1-SNAPSHOT" conf="test->default"/>

--- a/src/main/java/mondrian/olap/DelegatingSchemaReader.java
+++ b/src/main/java/mondrian/olap/DelegatingSchemaReader.java
@@ -5,8 +5,8 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2003-2005 Julian Hyde
-// Copyright (C) 2005-2013 Pentaho
 // Copyright (C) 2004-2005 TONBELLER AG
+// Copyright (C) 2005-2015 Pentaho
 // All Rights Reserved.
 */
 package mondrian.olap;
@@ -16,6 +16,8 @@ import mondrian.rolap.RolapSchema;
 import mondrian.rolap.RolapUtil;
 
 import java.util.List;
+import java.util.Map;
+
 import javax.sql.DataSource;
 
 /**
@@ -251,6 +253,13 @@ public abstract class DelegatingSchemaReader implements SchemaReader {
     {
         return schemaReader.lookupMemberChildByName(
             member, memberName, matchType);
+    }
+
+    public List<Member> lookupMemberChildrenByNames(
+        Member parent, List<Id.NameSegment> childNames, MatchType matchType)
+    {
+        return schemaReader.lookupMemberChildrenByNames(
+            parent, childNames, matchType);
     }
 
     public NativeEvaluator getNativeSetEvaluator(

--- a/src/main/java/mondrian/olap/IdBatchResolver.java
+++ b/src/main/java/mondrian/olap/IdBatchResolver.java
@@ -1,0 +1,466 @@
+/*
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (C) 2006-2015 Pentaho and others
+// All Rights Reserved.
+ */
+package mondrian.olap;
+
+import mondrian.mdx.*;
+
+import org.apache.commons.collections.*;
+import org.apache.log4j.Logger;
+
+import java.util.*;
+
+import static org.apache.commons.collections.CollectionUtils.filter;
+
+/**
+ * Used to collect and resolve identifiers in groups of children
+ * where possible.  For example, if an enumerated set within an MDX
+ * query includes references to 10 stores under the parent
+ *
+ *   [USA].[CA].[San Francisco]
+ *
+ * the class will attempt to identify those 10 identifiers
+ * and issue a single lookup, resulting in fewer and more efficient
+ * SQL queries.
+ * The resulting collection of resolved identifiers is returned in a
+ * map of <QueryPart, QueryPart>, where the unresolved Exp object acts
+ * as the key.
+ *
+ * This class makes no assurances that all identifiers will be resolved.
+ * The map returned by .resolve() will include only those identifiers
+ * successfully resolved.
+ *
+ */
+public final class IdBatchResolver {
+    static final Logger LOGGER = Logger.getLogger(IdBatchResolver.class);
+
+    private final Query query;
+    private final Formula[] formulas;
+    private final QueryAxis[] axes;
+    private final Cube cube;
+
+    // dimension and hierarchy unique names are collected during init
+    // to assist in classifying Ids as potentially resolvable to members.
+    private final Collection<String> dimensionUniqueNames =
+        new ArrayList<String>();
+    private final Collection<String> hierarchyUniqueNames =
+        new ArrayList<String>();
+    // level names are checked against the identifiers to avoid incorrectly
+    // interpreting a Dimension.Level reference as Dimension.Member.
+    private final Collection<String> levelNames =
+        new ArrayList<String>();
+
+    // Set of identifiers, sorted via IdComparator, which orders based
+    // first on segment length (shortest to longest), then alphabetically.
+    private  SortedSet<Id> identifiers = new TreeSet<Id>(new IdComparator());
+
+    public IdBatchResolver(Query query) {
+        this.query = query;
+        formulas = query.getFormulas();
+        axes = query.getAxes();
+        cube = query.getCube();
+        initOlapElementNames();
+        initIdentifiers();
+    }
+
+    /**
+     * Initializes the dimensionUniqueNames, hierarchyUniqueNames and
+     * levelNames collections based on the contents of cube.  These collections
+     * will be used to help determine whether identifiers correspond to
+     * a dimension/hierarchy/level.
+     */
+    private void initOlapElementNames() {
+        dimensionUniqueNames.addAll(
+            getOlapElementNames(cube.getDimensions(), true));
+        for (Dimension dim : cube.getDimensions()) {
+            hierarchyUniqueNames.addAll(
+                getOlapElementNames(dim.getHierarchies(), true));
+            for (Hierarchy hier : dim.getHierarchies()) {
+                levelNames.addAll(getOlapElementNames(hier.getLevels(), false));
+            }
+        }
+    }
+
+    /**
+     * Initializes the identifiers collection by walking the axes
+     * and formulas in the query and adding each encountered Id.
+     * Finally, expands the set of identifiers to include parents.  E.g.
+     * if the identifier
+     *   [Store].[All Store].[USA].[CA]
+     * is encountered, this will be expanded to include
+     *   [Store].[All Store].[USA]
+     *   [Store].[All Store]
+     */
+    private void initIdentifiers() {
+        MdxVisitor identifierVisitor = new IdentifierVisitor(identifiers);
+        for (QueryAxis axis : axes) {
+            axis.accept(identifierVisitor);
+        }
+        if (query.getSlicerAxis() != null) {
+            query.getSlicerAxis().accept(identifierVisitor);
+        }
+        for (Formula formula : formulas) {
+            formula.accept(identifierVisitor);
+        }
+        expandIdentifiers(identifiers);
+    }
+
+    /**
+     * Attempts to resolve the identifiers contained in the query in
+     * batches based on the parent, e.g. looking up and resolving the
+     * states in the set:
+     *   { [Store].[USA].[CA], [Store].[USA].[OR] }
+     * together rather than individually.
+     * Note that there is no guarantee that all identifiers will be
+     * resolved.  Calculated members, for example, are explicitly not
+     * handled here.  The purpose of this class is to improve efficiency
+     * of resolution of non-calculated members, but must be followed
+     * by more thorough expression resolution.
+     *
+     * @return  a Map of the expressions Id elements mapped to their
+     * respective resolved Exp.
+     */
+    public Map<QueryPart, QueryPart> resolve() {
+        return resolveInParentGroupings(identifiers);
+    }
+
+    /**
+     *  Loops through the SortedSet of Ids, attempting to load sets of
+     *  children of parent Ids.
+     *  The loop below assumes the the SortedSet is ordered by segment
+     *  size from smallest to largest, such that parent identifiers will
+     *  occur before their children.
+     */
+    private  Map<QueryPart, QueryPart> resolveInParentGroupings(
+        SortedSet<Id> identifiers)
+    {
+        final Map<QueryPart, QueryPart> resolvedIdentifiers =
+            new HashMap<QueryPart, QueryPart>();
+
+        while (identifiers.size() > 0) {
+            Id parent = identifiers.first();
+            identifiers.remove(parent);
+
+            if (!supportedIdentifier(parent)) {
+                continue;
+            }
+            Exp exp = (Exp)resolvedIdentifiers.get(parent);
+            if (exp == null) {
+                exp = lookupExp(resolvedIdentifiers, parent);
+            }
+            Member parentMember = getMemberFromExp(exp);
+            if (!supportedMember(parentMember)) {
+                continue;
+            }
+            batchResolveChildren(
+                parent, parentMember, identifiers, resolvedIdentifiers);
+        }
+        return resolvedIdentifiers;
+    }
+
+    /**
+     * Find the children of Id parent in the identifiers set and resolves
+     * all supported children together, adding them to the resolvedIdentifiers
+     * map.
+     */
+    private void batchResolveChildren(
+        Id parent, Member parentMember, SortedSet<Id> identifiers,
+        Map<QueryPart, QueryPart> resolvedIdentifiers)
+    {
+        final List<Id> children = findChildIds(parent, identifiers);
+        final List<Id.NameSegment> childNameSegments =
+            collectChildrenNameSegments(parentMember, children);
+
+        if (childNameSegments.size() > 0) {
+            List<Member> childMembers =
+                lookupChildrenByNames(parentMember, childNameSegments);
+            addChildrenToResolvedMap(
+                resolvedIdentifiers, children, childMembers);
+        }
+    }
+
+    private Exp lookupExp(
+        Map<QueryPart, QueryPart> resolvedIdentifiers, Id parent)
+    {
+        try {
+            Exp exp = Util.lookup(query, parent.getSegments(), false);
+            resolvedIdentifiers.put(parent, (QueryPart)exp);
+            return exp;
+        } catch (Exception exception) {
+            LOGGER.info(
+                String.format(
+                    "Failed to resolve '%s' during batch ID "
+                    + "resolution.",
+                    parent));
+        }
+        return null;
+    }
+
+    /**
+     * Correlates each child Id we started with to it's associated
+     * Member, if present.  Updates the resolvedIdentifiers map with
+     * the association.
+     */
+    private void addChildrenToResolvedMap(
+        Map<QueryPart, QueryPart> resolvedIdentifiers, List<Id> children,
+        List<Member> childMembers)
+    {
+        for (Member child : childMembers) {
+            for (Id childId : children) {
+                if (!resolvedIdentifiers.containsKey(childId)
+                    && getLastSegment(childId).matches(child.getName()))
+                {
+                    resolvedIdentifiers.put(
+                        childId, (QueryPart)Util.createExpr(child));
+                }
+            }
+        }
+    }
+
+    /**
+     * Performs a lookup of a set of children under parentMember.
+     */
+    private List<Member> lookupChildrenByNames(
+        Member parentMember,
+        List<Id.NameSegment> childNameSegments)
+    {
+        try {
+            return query.getSchemaReader(true)
+                .lookupMemberChildrenByNames(
+                    parentMember,
+                    childNameSegments, MatchType.EXACT);
+        } catch (Exception e) {
+            LOGGER.info(
+                String.format(
+                    "Failure while looking up children of '%s' during  "
+                    + "batch member resolution.  Child member refs:  %s",
+                    parentMember,
+                    Arrays.toString(childNameSegments.toArray())), e);
+        }
+        // don't want to fail at this point.  Member resolution still has
+        // another chance to succeed.
+        return Collections.emptyList();
+    }
+
+    /**
+     * Filters the children list to those that contain identifiers
+     * we think we can batch resolve, then transforms the Id list
+     * to the corresponding NameSegment.
+     */
+    private List<Id.NameSegment> collectChildrenNameSegments(
+        final Member parentMember, List<Id> children)
+    {
+        filter(
+            children, new Predicate() {
+            // remove children we can't support
+                public boolean evaluate(Object theId)
+                {
+                    Id id = (Id)theId;
+                    return !Util.matches(parentMember, id.getSegments())
+                        && supportedIdentifier(id);
+                }
+            });
+        return new ArrayList(
+            CollectionUtils.collect(
+                children, new Transformer()
+            {
+                // convert the collection to a list of NameSegments
+            public Object transform(Object theId) {
+                Id id = (Id)theId;
+                return getLastSegment(id);
+            }
+        }));
+    }
+
+    private Id.Segment getLastSegment(Id id) {
+        int segSize = id.getSegments().size();
+        return id.getSegments().get(segSize - 1);
+    }
+
+    /**
+     * Checks various conditions to determine whether
+     * the given identifier is likely to be resolvable at this point.
+     */
+    private boolean supportedIdentifier(Id id) {
+        Id.Segment seg = getLastSegment(id);
+        if (!(seg instanceof Id.NameSegment)) {
+            // we can't batch resolve members identified by key
+            return false;
+        }
+        return (isPossibleMemberRef(id))
+            && !segmentIsCalcMember(id.getSegments())
+            && !id.getSegments().get(0).matches("Measures");
+    }
+
+    private boolean supportedMember(Member member) {
+        return !(member == null
+            || member.equals(
+                member.getHierarchy().getNullMember())
+            || member.isMeasure());
+    }
+
+    /**
+     * Returns the [All] member from HierarchyExpr and DimensionExpr
+     * associated with hierarchies that have an All member.
+     * Returns the member associated with a MemberExpr.
+     * For all other Exp returns null.
+     */
+    private Member getMemberFromExp(Exp exp) {
+        if (exp instanceof DimensionExpr) {
+            Hierarchy hier = ((DimensionExpr)exp)
+                .getDimension().getHierarchy();
+            if (hier.hasAll()) {
+                return hier.getAllMember();
+            }
+        } else if (exp instanceof HierarchyExpr) {
+            Hierarchy hier = ((HierarchyExpr)exp)
+                .getHierarchy();
+            if (hier.hasAll()) {
+                return hier.getAllMember();
+            }
+        } else if (exp instanceof MemberExpr) {
+            return ((MemberExpr)exp).getMember();
+        }
+        return null;
+    }
+
+    /**
+     * Returns a collection of strings corresponding to the name
+     * or uniqueName of each OlapElement in olapElements, based on the
+     * flag uniqueName.
+     */
+    private Collection<String> getOlapElementNames(
+        OlapElement[] olapElements, final boolean uniqueName)
+    {
+        return CollectionUtils.collect(
+            Arrays.asList(olapElements),
+            new Transformer() {
+                public Object transform(Object o) {
+                    return uniqueName ? ((OlapElement)o).getUniqueName()
+                        : ((OlapElement)o).getName();
+                }
+            });
+    }
+
+    /**
+     * Returns true if the Id is something that will potentially translate into
+     * either the All/Default member of a dimension/hierarchy,
+     * or a specific member.
+     * This filters out references that we'd be unlikely to effectively
+     * handle.
+     */
+    private boolean isPossibleMemberRef(Id id) {
+        int size = id.getSegments().size();
+
+        if (size == 1) {
+            return segListMatchInUniqueNames(
+                id.getSegments(), dimensionUniqueNames)
+                || segListMatchInUniqueNames(
+                    id.getSegments(), hierarchyUniqueNames);
+        }
+        if (size == 2) {
+            return segListMatchInUniqueNames(
+                id.getSegments(), hierarchyUniqueNames);
+        }
+        if (segMatchInNames(getLastSegment(id), levelNames)) {
+            // conservative.  false on any match of any level name
+            return false;
+        }
+        // don't support "shortcut" member references references
+        return size > 1;
+    }
+
+    private boolean segListMatchInUniqueNames(
+        List<Id.Segment> segments, Collection<String> names)
+    {
+        String segUniqueName = Util.implode(segments);
+        for (String name : names) {
+           if (Util.equalName(segUniqueName, name)) {
+               return true;
+           }
+        }
+        return false;
+    }
+
+    private boolean segMatchInNames(
+        Id.Segment seg, Collection<String> names)
+    {
+        for (String name : names) {
+            if (seg.matches(name)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Conservative check that returns true if the last segment
+     * matches any formula name.
+     */
+    private boolean segmentIsCalcMember(final List<Id.Segment> checkSegments) {
+        Id.Segment lastSegment = checkSegments.get(checkSegments.size() - 1);
+        for (Formula formula : formulas) {
+            if (lastSegment.matches(formula.getName())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private List<Id> findChildIds(Id parent, SortedSet<Id> identifiers) {
+        List<Id> childIds = new ArrayList<Id>();
+        for (Id id : identifiers) {
+            final List<Id.Segment> idSeg = id.getSegments();
+            final List<Id.Segment> parentSegments = parent.getSegments();
+            final int parentSegSize = parentSegments.size();
+            if (idSeg.size() == parentSegSize + 1
+                && parent.getSegments().equals(
+                    idSeg.subList(0, parentSegSize)))
+            {
+                childIds.add(id);
+            }
+        }
+        return childIds;
+    }
+
+    /**
+     * Adds each parent segment to the set.
+     */
+    private void expandIdentifiers(Set<Id> identifiers) {
+        Set<Id> expandedIdentifiers = new HashSet<Id>();
+        for (Id id : identifiers) {
+            for (int i = 1; i < id.getSegments().size(); i++) {
+                expandedIdentifiers.add(new Id(id.getSegments().subList(0, i)));
+            }
+        }
+        identifiers.addAll(expandedIdentifiers);
+    }
+
+    /**
+     * Sorts shorter segments first, then by string compare.
+     * This allows processing parents first during the lookup loop,
+     * which is required by the algorithm.
+     */
+    private static class IdComparator implements Comparator<Id> {
+        public int compare(Id o1, Id o2) {
+            List<Id.Segment> o1Seg = o1.getSegments();
+            List<Id.Segment> o2Seg = o2.getSegments();
+
+            if (o1Seg.size() > o2Seg.size()) {
+                return 1;
+            } else if (o1Seg.size() < o2Seg.size()) {
+                return -1;
+            } else {
+                return o1Seg.toString()
+                    .compareTo(o2Seg.toString());
+            }
+        }
+    }
+}
+// End IdBatchResolver.java

--- a/src/main/java/mondrian/olap/IdentifierVisitor.java
+++ b/src/main/java/mondrian/olap/IdentifierVisitor.java
@@ -1,0 +1,28 @@
+/*
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (C) 2006-2015 Pentaho and others
+// All Rights Reserved.
+ */
+package mondrian.olap;
+
+import mondrian.mdx.*;
+
+import java.util.*;
+
+public class IdentifierVisitor extends MdxVisitorImpl {
+    private final Set<Id> identifiers;
+
+    public IdentifierVisitor(Set<Id> identifiers) {
+        this.identifiers = identifiers;
+    }
+
+    public Object visit(Id id) {
+        identifiers.add(id);
+        return null;
+    }
+}
+// End IdentifierVisitor.java

--- a/src/main/java/mondrian/olap/SchemaReader.java
+++ b/src/main/java/mondrian/olap/SchemaReader.java
@@ -5,7 +5,7 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2003-2005 Julian Hyde
-// Copyright (C) 2005-2012 Pentaho
+// Copyright (C) 2005-2015 Pentaho
 // All Rights Reserved.
 */
 package mondrian.olap;
@@ -457,13 +457,21 @@ public interface SchemaReader {
         MatchType matchType);
 
     /**
+     * Finds a list of child members with the given names.
+     */
+    List<Member> lookupMemberChildrenByNames(
+        Member parent,
+        List<Id.NameSegment> childNames,
+        MatchType matchType);
+
+    /**
      * Returns an object which can evaluate an expression in native SQL, or
      * null if this is not possible.
      *
      * @param fun Function
      * @param args Arguments to the function
      * @param evaluator Evaluator, provides context
-     * @param calc
+     * @param calc the calc to be natively evaluated
      */
     NativeEvaluator getNativeSetEvaluator(
         FunDef fun,

--- a/src/main/java/mondrian/olap/Util.java
+++ b/src/main/java/mondrian/olap/Util.java
@@ -5,7 +5,7 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2001-2005 Julian Hyde
-// Copyright (C) 2005-2014 Pentaho and others
+// Copyright (C) 2005-2015 Pentaho and others
 // All Rights Reserved.
 */
 package mondrian.olap;
@@ -656,7 +656,10 @@ public class Util extends XOMUtil {
         } else if (k1 instanceof List) {
             return compareLists((List) k1, (List) k2);
         }
-        return ((Comparable) k1).compareTo(k2);
+        return SqlNullSafeComparator
+            .instance.compare((Comparable) k1, (Comparable) k2);
+
+        //return ((Comparable) k1).compareTo(k2);
     }
 
     private static int compareLists(List list0, List list1) {
@@ -2076,6 +2079,38 @@ public class Util extends XOMUtil {
             throw unexpected(segment.getQuoting());
         }
     }
+
+    public static boolean matches(
+        Member member, List<Id.Segment> nameParts)
+    {
+        if (Util.equalName(Util.implode(nameParts),
+            member.getUniqueName()))
+        {
+            // exact match
+            return true;
+        }
+        Id.Segment segment = nameParts.get(nameParts.size() - 1);
+        while (member.getParentMember() != null) {
+            if (!segment.matches(member.getName())) {
+                return false;
+            }
+            member = member.getParentMember();
+            nameParts = nameParts.subList(0, nameParts.size() - 1);
+            segment = nameParts.get(nameParts.size() - 1);
+        }
+        if (segment.matches(member.getName())) {
+            return Util.equalName(
+                member.getHierarchy().getUniqueName(),
+                Util.implode(nameParts.subList(0, nameParts.size() - 1)));
+        } else if (member.isAll()) {
+            return Util.equalName(
+                member.getHierarchy().getUniqueName(),
+                Util.implode(nameParts));
+        } else {
+            return false;
+        }
+    }
+
 
     public static RuntimeException newElementNotFoundException(
         int category,

--- a/src/main/java/mondrian/olap/ValidatorImpl.java
+++ b/src/main/java/mondrian/olap/ValidatorImpl.java
@@ -4,7 +4,7 @@
 // http://www.eclipse.org/legal/epl-v10.html.
 // You must accept the terms of that agreement to use this software.
 //
-// Copyright (C) 2009-2009 Pentaho
+// Copyright (C) 2002-2015 Pentaho
 // All Rights Reserved.
 */
 package mondrian.olap;
@@ -50,11 +50,15 @@ abstract class ValidatorImpl implements Validator {
      *
      * @param funTable Function table
      *
+     * @param resolvedIdentifiers map of already resolved Ids
      * @pre funTable != null
      */
-    protected ValidatorImpl(FunTable funTable) {
+    protected ValidatorImpl(
+        FunTable funTable, Map<QueryPart, QueryPart> resolvedIdentifiers)
+    {
         Util.assertPrecondition(funTable != null, "funTable != null");
         this.funTable = funTable;
+        resolvedNodes.putAll(resolvedIdentifiers);
     }
 
     public Exp validate(Exp exp, boolean scalar) {

--- a/src/main/java/mondrian/rolap/ChildByNameConstraint.java
+++ b/src/main/java/mondrian/rolap/ChildByNameConstraint.java
@@ -5,7 +5,7 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2004-2005 TONBELLER AG
-// Copyright (C) 2006-2014 Pentaho
+// Copyright (C) 2006-2015 Pentaho
 // All Rights Reserved.
 */
 package mondrian.rolap;
@@ -14,6 +14,7 @@ import mondrian.olap.Id;
 import mondrian.rolap.sql.SqlQuery;
 
 import java.util.Arrays;
+import java.util.List;
 
 /**
  * Constraint which optimizes the search for a child by name. This is used
@@ -24,7 +25,7 @@ import java.util.Arrays;
  * @author avix
  */
 class ChildByNameConstraint extends DefaultMemberChildrenConstraint {
-    final String childName;
+    private final String[] childNames;
     private final Object cacheKey;
 
     /**
@@ -33,8 +34,18 @@ class ChildByNameConstraint extends DefaultMemberChildrenConstraint {
      * @param childName Name of child
      */
     public ChildByNameConstraint(Id.NameSegment childName) {
-        this.childName = childName.name;
+        this.childNames = new String[]{childName.name};
         this.cacheKey = Arrays.asList(ChildByNameConstraint.class, childName);
+    }
+
+    public ChildByNameConstraint(List<Id.NameSegment> childNames) {
+        this.childNames = new String[childNames.size()];
+        int i = 0;
+        for (Id.NameSegment name : childNames) {
+            this.childNames[i++] = name.name;
+        }
+        this.cacheKey = Arrays.asList(
+            ChildByNameConstraint.class, this.childNames);
     }
 
     @Override
@@ -57,16 +68,20 @@ class ChildByNameConstraint extends DefaultMemberChildrenConstraint {
         super.addLevelConstraint(query, starSet, level);
         query.addWhere(
             SqlConstraintUtils.constrainLevel(
-                level.attribute.getNameExp(), query.getDialect(), childName,
+                level.attribute.getNameExp(), query.getDialect(), childNames,
                 true));
     }
 
     public String toString() {
-        return "ChildByNameConstraint(" + childName + ")";
+        return "ChildByNameConstraint(" + Arrays.toString(childNames) + ")";
     }
 
     public Object getCacheKey() {
         return cacheKey;
+    }
+
+    public List<String> getChildNames() {
+        return Arrays.asList(childNames);
     }
 
 }

--- a/src/main/java/mondrian/rolap/MemberCacheHelper.java
+++ b/src/main/java/mondrian/rolap/MemberCacheHelper.java
@@ -6,7 +6,7 @@
 //
 // Copyright (C) 2001-2005 Julian Hyde
 // Copyright (C) 2004-2005 TONBELLER AG
-// Copyright (C) 2005-2013 Pentaho and others
+// Copyright (C) 2005-2015 Pentaho and others
 // All Rights Reserved.
 */
 package mondrian.rolap;
@@ -18,8 +18,12 @@ import mondrian.rolap.sql.MemberChildrenConstraint;
 import mondrian.rolap.sql.TupleConstraint;
 import mondrian.util.Pair;
 
+import org.apache.commons.collections.Predicate;
+
 import java.util.*;
 import java.util.Map.Entry;
+
+import static org.apache.commons.collections.CollectionUtils.filter;
 
 /**
  * Encapsulation of member caching.
@@ -31,9 +35,16 @@ public class MemberCacheHelper implements MemberCache {
     private final SqlConstraintFactory sqlConstraintFactory =
         SqlConstraintFactory.instance();
 
-    /** maps a parent member to a list of its children */
+    /** maps a parent member and constraint to a list of its children */
     final SmartMemberListCache<RolapMember, List<RolapMember>>
         mapMemberToChildren;
+
+    /** maps a parent member to the collection of named children that have
+     * been cached.  The collection can grow over time as new children are
+     * loaded.
+     */
+    final SmartIncrementalCache<RolapMember, Collection<RolapMember>>
+        mapParentToNamedChildren;
 
     /** a cache for all members to ensure uniqueness */
     SmartCache<Pair<RolapCubeLevel, Object>, RolapMember> mapKeyToMember;
@@ -56,6 +67,8 @@ public class MemberCacheHelper implements MemberCache {
             new SoftSmartCache<Pair<RolapCubeLevel, Object>, RolapMember>();
         this.mapMemberToChildren =
             new SmartMemberListCache<RolapMember, List<RolapMember>>();
+        this.mapParentToNamedChildren =
+            new SmartIncrementalCache<RolapMember, Collection<RolapMember>>();
     }
 
     // implement MemberCache
@@ -105,8 +118,51 @@ public class MemberCacheHelper implements MemberCache {
             constraint =
                 sqlConstraintFactory.getMemberChildrenConstraint(null);
         }
+        if (constraint instanceof ChildByNameConstraint) {
+            return findNamedChildrenInCache(
+                member, ((ChildByNameConstraint) constraint).getChildNames());
+        }
         return mapMemberToChildren.get(member, constraint);
     }
+
+    /**
+     * Attempts to find all children requested by the ChildByNameConstraint
+     * in cache.  Returns null if the complete list is not found.
+     */
+    private List<RolapMember> findNamedChildrenInCache(
+        final RolapMember parent, final List<String> childNames)
+    {
+        List<RolapMember> children =
+            checkDefaultAndNamedChildrenCache(parent);
+        if (children == null || childNames == null
+            || childNames.size() > children.size())
+        {
+            return null;
+        }
+        filter(
+            children, new Predicate()
+            {
+                public boolean evaluate(Object member) {
+                    return childNames.contains(
+                        ((RolapMember) member).getName());
+                }
+            });
+        boolean foundAll = children.size() == childNames.size();
+        return !foundAll ? null : children;
+    }
+
+    private List<RolapMember> checkDefaultAndNamedChildrenCache(
+        RolapMember parent)
+    {
+        Collection<RolapMember> children = mapMemberToChildren
+            .get(parent, DefaultMemberChildrenConstraint.instance());
+        if (children == null) {
+            children = mapParentToNamedChildren.get(parent);
+        }
+        return children == null ? Collections.emptyList()
+            : new ArrayList(children);
+    }
+
 
     public void putChildren(
         RolapMember member,
@@ -117,7 +173,29 @@ public class MemberCacheHelper implements MemberCache {
             constraint =
                 sqlConstraintFactory.getMemberChildrenConstraint(null);
         }
-        mapMemberToChildren.put(member, constraint, children);
+        if (constraint instanceof ChildByNameConstraint) {
+            putChildrenInChildNameCache(member, children);
+        } else {
+            mapMemberToChildren.put(member, constraint, children);
+        }
+    }
+
+    private void putChildrenInChildNameCache(
+        final RolapMember parent,
+        final List<RolapMember> children)
+    {
+        if (children == null || children.isEmpty()) {
+            return;
+        }
+        Collection<RolapMember> cachedChildren =
+            mapParentToNamedChildren.get(parent);
+        if (cachedChildren == null) {
+            // initialize with a sorted set
+            mapParentToNamedChildren.put(
+                parent, new TreeSet<RolapMember>(children));
+        } else {
+            mapParentToNamedChildren.addToEntry(parent, children);
+        }
     }
 
     public List<RolapMember> getLevelMembersFromCache(
@@ -135,6 +213,7 @@ public class MemberCacheHelper implements MemberCache {
         mapMemberToChildren.clear();
         mapKeyToMember.clear();
         mapLevelToMembers.clear();
+        mapParentToNamedChildren.clear();
         // We also need to clear the approxRowCount of each level.
         for (RolapCubeLevel level : rolapHierarchy.getLevelList()) {
             level.setApproxRowCount(Integer.MIN_VALUE);
@@ -231,6 +310,25 @@ public class MemberCacheHelper implements MemberCache {
                 }
             });
 
+        mapParentToNamedChildren.getCache().execute(
+            new SmartCache.SmartCacheTask<RolapMember,
+                Collection<RolapMember>>() {
+                public void execute(
+                    Iterator<Entry<RolapMember,
+                        Collection<RolapMember>>> iterator)
+                {
+                    while (iterator.hasNext()) {
+                        Entry<RolapMember, Collection<RolapMember>> entry =
+                            iterator.next();
+                        RolapMember currentMember = entry.getKey();
+                        if (member.equals(currentMember)) {
+                            iterator.remove();
+                        } else if (parent.equals(currentMember)) {
+                            entry.getValue().remove(member);
+                        }
+                    }
+                }
+            });
         // drop it from the lookup-cache
         return mapKeyToMember.put(Pair.of(level, key), null);
     }

--- a/src/main/java/mondrian/rolap/RolapSchemaReader.java
+++ b/src/main/java/mondrian/rolap/RolapSchemaReader.java
@@ -5,7 +5,7 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2003-2005 Julian Hyde
-// Copyright (C) 2005-2014 Pentaho
+// Copyright (C) 2005-2015 Pentaho
 // All Rights Reserved.
 */
 package mondrian.rolap;
@@ -482,6 +482,19 @@ public class RolapSchemaReader
                 + "\", exception: " + e.getMessage());
         }
         return null;
+    }
+
+    public List<Member> lookupMemberChildrenByNames(
+        Member parent, List<Id.NameSegment> childNames, MatchType matchType)
+    {
+        MemberChildrenConstraint constraint = sqlConstraintFactory
+            .getChildrenByNamesConstraint(
+                (RolapMember) parent, childNames);
+        List<RolapMember> children =
+            internalGetMemberChildren((RolapMember) parent, constraint);
+        List<Member> childMembers = new ArrayList<Member>();
+        childMembers.addAll(children);
+        return childMembers;
     }
 
     public Member getCalculatedMember(List<Id.Segment> nameParts) {

--- a/src/main/java/mondrian/rolap/SmartIncrementalCache.java
+++ b/src/main/java/mondrian/rolap/SmartIncrementalCache.java
@@ -1,0 +1,70 @@
+/*
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (C) 2001-2005 Julian Hyde
+// Copyright (C) 2005-2015 Pentaho and others
+// All Rights Reserved.
+*/
+package mondrian.rolap;
+
+import mondrian.rolap.cache.*;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
+
+/**
+ * Uses a SmartCache to store a collection of values.
+ * Supplements put operations with an "addToEntry", which
+ * supports incrementally adding to the collection associated
+ * with key.
+ */
+public class SmartIncrementalCache<K, V extends Collection> {
+    SmartCache<K, V> cache;
+
+    public SmartIncrementalCache() {
+        cache = new SoftSmartCache<K, V>();
+    }
+
+    public V put(final K  key, final V value) {
+        return cache.put(key, value);
+    }
+
+    public V get(K key) {
+        return cache.get(key);
+    }
+
+    public void clear() {
+        cache.clear();
+    }
+
+    public void addToEntry(final K key, final V value) {
+        cache
+            .execute(
+                new SmartCache.SmartCacheTask
+                    <K, V>() {
+                    public void execute(Iterator<Map.Entry<K, V>> iterator) {
+                        // iterator is ignored,
+                        // we're updating a single entry and
+                        // we have the key.
+                        if (cache.get(key) == null) {
+                            cache.put(key, value);
+                        } else {
+                            cache.get(key).addAll(value);
+                        }
+                    } });
+    }
+
+    SmartCache<K, V> getCache() {
+        return cache;
+    }
+
+    void setCache(SmartCache<K, V> cache) {
+        this.cache = cache;
+    }
+
+}
+// End SmartIncrementalCache.java

--- a/src/main/prop/mondrian/olap/MondrianProperties.xml
+++ b/src/main/prop/mondrian/olap/MondrianProperties.xml
@@ -4,7 +4,7 @@
   == http://www.eclipse.org/legal/epl-v10.html.
   == You must accept the terms of that agreement to use this software.
   ==
-  == Copyright (C) 2011-2013 Pentaho
+  == Copyright (C) 2011-2015 Pentaho
   == All Rights Reserved.
   ==
   == Definitions of configuration properties used by Mondrian. From this file,
@@ -1380,6 +1380,29 @@ only if external statistics were not available.</p>
         </Description>
         <Core>true</Core>
         <Type>String</Type>
+    </PropertyDefinition>
+
+    <PropertyDefinition>
+        <Name>LevelPreCacheThreshold</Name>
+        <Path>mondrian.rolap.precache.threshold</Path>
+        <Description>
+            <p>
+                Property which governs whether child members or members of a level are precached
+                when child or level members are requested within a
+                query expression.  For example,
+                if an expression references two child members in the store dimension,
+                like <code>{ [Store].[USA].[CA], [Store].[USA].[OR] }</code>, precaching will
+                load *all* children under [USA] rather than just the 2 requested.
+                The threshold value is
+                compared against the cardinality of the level to determine
+                whether or not precaching should be performed.  If cardinality is
+                lower than the threshold value Mondrian will precache.  Setting
+                this property to 0 effectively disables precaching.
+            </p>
+        </Description>
+        <Core>true</Core>
+        <Type>int</Type>
+        <Default>300</Default>
     </PropertyDefinition>
 
     <PropertyDefinition>

--- a/src/test/java/mondrian/olap/IdBatchResolverTest.java
+++ b/src/test/java/mondrian/olap/IdBatchResolverTest.java
@@ -1,0 +1,395 @@
+/*
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (C) 2006-2015 Pentaho and others
+// All Rights Reserved.
+ */
+package mondrian.olap;
+
+import mondrian.parser.*;
+import mondrian.rolap.*;
+import mondrian.server.*;
+
+import org.apache.commons.collections.*;
+
+import org.mockito.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.mockito.Mockito.*;
+
+public class IdBatchResolverTest extends BatchTestCase {
+
+    private Query query;
+
+    @Captor
+    private ArgumentCaptor<List<Id.NameSegment>> childNames;
+
+    @Captor
+    private ArgumentCaptor<Member> parentMember;
+
+    @Captor
+    private ArgumentCaptor<MatchType> matchType;
+
+    @Override
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    public void testSimpleEnum() {
+        assertContains(
+            "Resolved map omitted one or more members",
+            batchResolve(
+                "SELECT "
+                + "{[Product].[Products].[Food].[Dairy],"
+                + "[Product].[Products].[Food].[Deli],"
+                + "[Product].[Products].[Food].[Eggs],"
+                + "[Product].[Products].[Food].[Produce],"
+                + "[Product].[Products].[Food].[Starchy Foods]}"
+                + "on 0 FROM SALES"),
+            list(
+                "[Product].[Products].[Food].[Dairy]",
+                "[Product].[Products].[Food].[Deli]",
+                "[Product].[Products].[Food].[Eggs]",
+                "[Product].[Products].[Food].[Produce]",
+                "[Product].[Products].[Food].[Starchy Foods]"));
+
+        // verify lookupMemberChildrenByNames is called as expected with
+        // batched children's names.
+        verify(
+            query.getSchemaReader(true), times(2))
+            .lookupMemberChildrenByNames(
+                parentMember.capture(),
+                childNames.capture(),
+                matchType.capture());
+
+        assertEquals(
+            "[Product].[Products].[All Products]",
+            parentMember.getAllValues().get(0).getUniqueName());
+        assertTrue(childNames.getAllValues().get(0).size() == 1);
+        assertEquals(
+            "Food",
+            childNames.getAllValues().get(0).get(0).getName());
+
+        assertEquals(
+            "[Product].[Products].[Food]",
+            parentMember.getAllValues().get(1).getUniqueName());
+        assertTrue(childNames.getAllValues().get(1).size() == 5);
+
+        assertEquals(
+            "[[Dairy], [Deli], [Eggs], [Produce], [Starchy Foods]]",
+            sortedNames(childNames.getAllValues().get(1)));
+    }
+
+    public void testCalcMemsNotResolved() {
+        assertFalse(
+            "Resolved map should not contain calc members",
+            batchResolve(
+                "with member time.time.foo as '1' member time.time.bar as '2' "
+                + " select "
+                + " {[Time].[foo], [Time].[bar], "
+                + "  [Time].[1997],"
+                + "  [Time].[1997].[Q1], [Time].[1997].[Q2]} "
+                + " on 0 from sales ")
+                .removeAll(list("[Time].[foo]", "[Time].[bar]")));
+        // .removeAll will only return true if the set has changed, i.e. if
+        // one ore more of the members were present.
+    }
+
+    public void testLevelReferenceHandled() {
+        // make sure ["Week", 1997] don't get batched as children of
+        // [Time.Weekly].[All]
+        batchResolve(
+            "with member Gender.levelRef as "
+            + "'Sum(Descendants([Time].[Weekly].CurrentMember, [Time].[Weekly].Week))' "
+            + "select Gender.levelRef on 0 from sales where [Time].[Weekly].[1997]");
+        verify(
+            query.getSchemaReader(true), times(1))
+            .lookupMemberChildrenByNames(
+                parentMember.capture(),
+                childNames.capture(),
+                matchType.capture());
+        assertEquals(
+            "[Time].[Weekly].[All Weeklys]",
+            parentMember.getAllValues().get(0).getUniqueName());
+        assertEquals(
+            "[[1997]]",
+            sortedNames(childNames.getAllValues().get(0)));
+    }
+
+
+    public void testPhysMemsResolvedWhenCalcsMixedIn() {
+        assertContains(
+            "Resolved map omitted one or more members",
+            batchResolve(
+                "with member time.time.foo as '1' member time.time.bar as '2' "
+                + " select "
+                + " {[Time].[Time].[foo], [Time].[Time].[bar], "
+                + "  [Time].[Time].[1997],"
+                + "  [Time].[Time].[1997].[Q1], [Time].[Time].[1997].[Q2]} "
+                + " on 0 from sales "),
+            list(
+                "[Time].[Time].[1997]",
+                "[Time].[Time].[1997].[Q1]",
+                "[Time].[Time].[1997].[Q2]"));
+        verify(
+            query.getSchemaReader(true), times(1))
+            .lookupMemberChildrenByNames(
+                parentMember.capture(),
+                childNames.capture(),
+                matchType.capture());
+        assertEquals(
+            "[Time].[Time].[1997]",
+            parentMember.getAllValues().get(0).getUniqueName());
+        assertTrue(childNames.getAllValues().get(0).size() == 2);
+        assertEquals(
+            "[[Q1], [Q2]]",
+            sortedNames(childNames.getAllValues().get(0)));
+    }
+
+
+    public void testAnalyzerFilterMdx() {
+        assertContains(
+            "Resolved map omitted one or more members",
+            batchResolve(
+                "WITH\n"
+                + "SET [*NATIVE_CJ_SET] AS 'NONEMPTYCROSSJOIN([*BASE_MEMBERS__Promotions_],[*BASE_MEMBERS__Store_])'\n"
+                + "SET [*BASE_MEMBERS__Store_] AS '{[Store].[Stores].[USA].[WA].[Bellingham],[Store].[Stores].[USA].[CA].[Beverly Hills],[Store].[Stores].[USA].[WA].[Bremerton],[Store].[Stores].[USA].[CA].[Los Angeles]}'\n"
+                + "SET [*SORTED_COL_AXIS] AS 'ORDER([*CJ_COL_AXIS],[Promotion].[Promotions].CURRENTMEMBER.ORDERKEY,BASC)'\n"
+                + "SET [*BASE_MEMBERS__Measures_] AS '{[Measures].[*FORMATTED_MEASURE_0]}'\n"
+                + "SET [*CJ_ROW_AXIS] AS 'GENERATE([*NATIVE_CJ_SET], {([Store].[Stores].CURRENTMEMBER)})'\n"
+                + "SET [*BASE_MEMBERS__Promotions_] AS '{[Promotion].[Promotions].[Bag Stuffers],[Promotion].[Promotions].[Best Savings],[Promotion].[Promotions].[Big Promo],[Promotion].[Promotions].[Big Time Discounts],[Promotion].[Promotions].[Big Time Savings],[Promotion].[Promotions].[Bye Bye Baby]}'\n"
+                + "SET [*SORTED_ROW_AXIS] AS 'ORDER([*CJ_ROW_AXIS],[Store].[Stores].CURRENTMEMBER.ORDERKEY,BASC,ANCESTOR([Store].[Stores].CURRENTMEMBER,[Store].[Stores].[Store State]).ORDERKEY,BASC)'\n"
+                + "SET [*CJ_COL_AXIS] AS 'GENERATE([*NATIVE_CJ_SET], {([Promotion].[Promotions].CURRENTMEMBER)})'\n"
+                + "MEMBER [Measures].[*FORMATTED_MEASURE_0] AS '[Measures].[Unit Sales]', FORMAT_STRING = 'Standard', SOLVE_ORDER=500\n"
+                + "SELECT\n"
+                + "CROSSJOIN([*SORTED_COL_AXIS],[*BASE_MEMBERS__Measures_]) ON COLUMNS\n"
+                + ",NON EMPTY\n"
+                + "[*SORTED_ROW_AXIS] ON ROWS\n"
+                + "FROM [Sales]"),
+            list(
+                "[Store].[Stores].[USA].[WA].[Bellingham]",
+                "[Store].[Stores].[USA].[CA].[Beverly Hills]",
+                "[Store].[Stores].[USA].[WA].[Bremerton]",
+                "[Store].[Stores].[USA].[CA].[Los Angeles]",
+                "[Promotion].[Promotions].[Bag Stuffers]",
+                "[Promotion].[Promotions].[Best Savings]",
+                "[Promotion].[Promotions].[Big Promo]",
+                "[Promotion].[Promotions].[Big Time Discounts]",
+                "[Promotion].[Promotions].[Big Time Savings]",
+                "[Promotion].[Promotions].[Bye Bye Baby]"));
+
+        verify(
+            query.getSchemaReader(true), times(6))
+            .lookupMemberChildrenByNames(
+                parentMember.capture(),
+                childNames.capture(),
+                matchType.capture());
+
+        assertEquals(
+            "[Promotion].[Promotions].[All Promotions]",
+            parentMember.getAllValues().get(1).getUniqueName());
+        assertTrue(childNames.getAllValues().get(1).size() == 6);
+        assertEquals(
+            "[[Bag Stuffers], [Best Savings], [Big Promo], "
+            + "[Big Time Discounts], [Big Time Savings], [Bye Bye Baby]]",
+            sortedNames(childNames.getAllValues().get(1)));
+
+        assertEquals(
+            "[Store].[Stores].[USA].[CA]",
+            parentMember.getAllValues().get(4).getUniqueName());
+        assertTrue(childNames.getAllValues().get(4).size() == 2);
+        assertEquals(
+            "[[Beverly Hills], [Los Angeles]]",
+            sortedNames(childNames.getAllValues().get(4)));
+    }
+
+    public void testSetWithNullMember() {
+        assertContains(
+            "Resolved map omitted one or more members",
+            batchResolve(
+                "WITH\n"
+                + "SET [*NATIVE_CJ_SET] AS 'FILTER([*BASE_MEMBERS__Store Size in SQFT_], NOT ISEMPTY ([Measures].[Unit Sales]))'\n"
+                + "SET [*BASE_MEMBERS__Store Size in SQFT_] AS '{[Store].[Store Size in SQFT].[#null],[Store].[Store Size in SQFT].[20319],[Store].[Store Size in SQFT].[21215],[Store].[Store Size in SQFT].[22478],[Store].[Store Size in SQFT].[23598]}'\n"
+                + "SET [*BASE_MEMBERS__Measures_] AS '{[Measures].[*FORMATTED_MEASURE_0]}'\n"
+                + "SET [*CJ_SLICER_AXIS] AS 'GENERATE([*NATIVE_CJ_SET], {([Store].[Store Size in SQFT].CURRENTMEMBER)})'\n"
+                + "MEMBER [Measures].[*FORMATTED_MEASURE_0] AS '[Measures].[Unit Sales]', FORMAT_STRING = 'Standard', SOLVE_ORDER=500\n"
+                + "SELECT\n"
+                + "[*BASE_MEMBERS__Measures_] ON COLUMNS\n"
+                + "FROM [Sales]\n"
+                + "WHERE ([*CJ_SLICER_AXIS])"),
+            list(
+                "[Store].[Store Size in SQFT].[#null]",
+                "[Store].[Store Size in SQFT].[20319]",
+                "[Store].[Store Size in SQFT].[21215]",
+                "[Store].[Store Size in SQFT].[22478]",
+                "[Store].[Store Size in SQFT].[23598]"));
+
+        verify(
+            query.getSchemaReader(true), times(2))
+            .lookupMemberChildrenByNames(
+                parentMember.capture(),
+                childNames.capture(),
+                matchType.capture());
+
+        assertEquals(
+            "[Store].[Store Size in SQFT].[All Store Size in SQFTs]",
+            parentMember.getAllValues().get(1).getUniqueName());
+        assertTrue(childNames.getAllValues().get(1).size() == 5);
+        assertEquals(
+            "[[#null], [20319], [21215], [22478], [23598]]",
+            sortedNames(childNames.getAllValues().get(1)));
+    }
+
+
+    public void testMultiHierarchySSAS() {
+        assertContains(
+            "Resolved map omitted one or more members",
+            batchResolve(
+                "WITH\n"
+                + "SET [*NATIVE_CJ_SET] AS 'FILTER([*BASE_MEMBERS__Time.Weekly_], NOT ISEMPTY ([Measures].[Unit Sales]))'\n"
+                + "SET [*BASE_MEMBERS__Time.Weekly_] AS '{[Time].[Weekly].[1997].[4],[Time].[Weekly].[1997].[5],[Time].[Weekly].[1997].[6]}'\n"
+                + "SET [*BASE_MEMBERS__Measures_] AS '{[Measures].[*FORMATTED_MEASURE_0]}'\n"
+                + "SET [*CJ_SLICER_AXIS] AS 'GENERATE([*NATIVE_CJ_SET], {([Time].[Weekly].CURRENTMEMBER)})'\n"
+                + "MEMBER [Measures].[*FORMATTED_MEASURE_0] AS '[Measures].[Unit Sales]', FORMAT_STRING = 'Standard', SOLVE_ORDER=500\n"
+                + "SELECT\n"
+                + "[*BASE_MEMBERS__Measures_] ON COLUMNS\n"
+                + "FROM [Sales]\n"
+                + "WHERE ([*CJ_SLICER_AXIS])"),
+            list(
+                "[Time].[Weekly].[1997].[4]",
+                "[Time].[Weekly].[1997].[5]",
+                "[Time].[Weekly].[1997].[6]"));
+
+        verify(
+            query.getSchemaReader(true), times(2))
+            .lookupMemberChildrenByNames(
+                parentMember.capture(),
+                childNames.capture(),
+                matchType.capture());
+        assertEquals(
+            "[Time].[Weekly].[All Weeklys]",
+            parentMember.getAllValues().get(0).getUniqueName());
+        assertTrue(
+            childNames.getAllValues().get(0).size() == 1);
+        assertEquals(
+            "1997",
+            childNames.getAllValues().get(0).get(0).getName());
+        assertEquals(
+            "[[4], [5], [6]]",
+            sortedNames(childNames.getAllValues().get(1)));
+    }
+
+    public void testParentChild() {
+        // P-C resolution will not result in consolidated SQL, but it should
+        // still correctly identify children and attempt to resolve them
+        // together.
+        assertContains(
+            "Resolved map omitted one or more members",
+            batchResolve(
+                "WITH\n"
+                + "SET [*NATIVE_CJ_SET] AS 'FILTER([*BASE_MEMBERS__Employees_], NOT ISEMPTY ([Measures].[Number of Employees]))'\n"
+                + "SET [*BASE_MEMBERS__Employees_] AS '{[Employee].[Employees].[Sheri Nowmer].[Derrick Whelply],[Employee].[Employees].[Sheri Nowmer].[Michael Spence]}'\n"
+                + "SET [*BASE_MEMBERS__Measures_] AS '{[Measures].[*FORMATTED_MEASURE_0]}'\n"
+                + "SET [*CJ_SLICER_AXIS] AS 'GENERATE([*NATIVE_CJ_SET], {([Employee].[Employees].CURRENTMEMBER)})'\n"
+                + "MEMBER [Measures].[*FORMATTED_MEASURE_0] AS '[Measures].[Number of Employees]', FORMAT_STRING = '#,#', SOLVE_ORDER=500\n"
+                + "SELECT\n"
+                + "[*BASE_MEMBERS__Measures_] ON COLUMNS\n"
+                + "FROM [HR]\n"
+                + "WHERE ([*CJ_SLICER_AXIS])"),
+            list(
+                "[Employee].[Employees].[Sheri Nowmer].[Derrick Whelply]",
+                "[Employee].[Employees].[Sheri Nowmer].[Michael Spence]"));
+
+        verify(
+            query.getSchemaReader(true), times(2))
+            .lookupMemberChildrenByNames(
+                parentMember.capture(),
+                childNames.capture(),
+                matchType.capture());
+        assertEquals(
+            "[Employee].[Employees].[Sheri Nowmer]",
+            parentMember.getAllValues().get(1).getUniqueName());
+        assertTrue(childNames.getAllValues().get(1).size() == 2);
+    }
+
+
+    private void assertContains(
+        String msg, Collection<String> strings, Collection<String> list)
+    {
+        if (!strings.containsAll(list)) {
+            List<String> copy = new ArrayList<String>(list);
+            copy.removeAll(strings);
+            fail(
+                String.format(
+                    "%s\nMissing: %s", msg,
+                    Arrays.toString(copy.toArray())));
+        }
+    }
+
+    public Set<String> batchResolve(String mdx) {
+        IdBatchResolver batchResolver = makeTestBatchResolver(mdx);
+        Map<QueryPart, QueryPart> resolvedIdents = batchResolver.resolve();
+        Set<String> resolvedNames = getResolvedNames(resolvedIdents);
+        return resolvedNames;
+    }
+
+    private String sortedNames(List<Id.NameSegment> items) {
+        Collections.sort(
+            items, new Comparator<Id.NameSegment>() {
+                public int compare(Id.NameSegment o1, Id.NameSegment o2) {
+                    return o1.getName().compareTo(o2.getName());
+                }
+            });
+        return Arrays.toString(items.toArray());
+    }
+
+    private Collection<String> list(String... items) {
+        return Arrays.asList(items);
+    }
+
+    private Set<String> getResolvedNames(
+        Map<QueryPart, QueryPart> resolvedIdents)
+    {
+        return new HashSet(
+            CollectionUtils
+                .collect(
+                    resolvedIdents.keySet(),
+                    new Transformer() {
+                        public Object transform(Object o) {
+                            return o.toString();
+                        }
+                    }));
+    }
+
+    public IdBatchResolver makeTestBatchResolver(String mdx) {
+        getTestContext().flushSchemaCache();
+        MdxParserValidator parser = new JavaccParserValidatorImpl(
+            new FactoryImplTestWrapper());
+
+        RolapConnection conn = (RolapConnection) spy(
+            getTestContext().withFreshConnection().getConnection());
+        when(conn.createParser()).thenReturn(parser);
+
+        query = conn.parseQuery(mdx);
+        Locus.push(new Locus(new Execution(
+            query.getStatement(), Integer.MAX_VALUE),
+            "batchResolveTest", "batchResolveTest"));
+
+        return new IdBatchResolver(query);
+    }
+
+}
+
+// End IdBatchResolverTest.java

--- a/src/test/java/mondrian/olap/QueryTestWrapper.java
+++ b/src/test/java/mondrian/olap/QueryTestWrapper.java
@@ -1,0 +1,62 @@
+/*
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (C) 2006-2015 Pentaho and others
+// All Rights Reserved.
+ */
+package mondrian.olap;
+
+import mondrian.server.Statement;
+
+import static org.mockito.Mockito.spy;
+
+public class QueryTestWrapper extends Query {
+    private SchemaReader spyReader;
+
+    public QueryTestWrapper(
+        Statement statement,
+        Formula[] formulas,
+        QueryAxis[] axes,
+        String cube,
+        QueryAxis slicerAxis,
+        QueryPart[] cellProps,
+        boolean strictValidation)
+    {
+        super(
+            statement,
+            Util.lookupCube(statement.getSchemaReader(), cube, true),
+            formulas,
+            axes,
+            slicerAxis,
+            cellProps,
+            new Parameter[0],
+            strictValidation);
+    }
+
+    @Override
+    public void resolve() {
+        // for testing purposes we want to defer resolution till after
+        //  Query init (resolve is called w/in constructor).
+        // We do still need formulas to be created, though.
+        if (getFormulas() != null) {
+            for (Formula formula : getFormulas()) {
+                formula.createElement(this);
+            }
+        }
+    }
+
+    @Override
+    public synchronized SchemaReader getSchemaReader(
+        boolean accessControlled)
+    {
+        if (spyReader == null) {
+            spyReader = spy(super.getSchemaReader(accessControlled));
+        }
+        return spyReader;
+    }
+}
+
+// End QueryTestWrapper.java

--- a/src/test/java/mondrian/parser/FactoryImplTestWrapper.java
+++ b/src/test/java/mondrian/parser/FactoryImplTestWrapper.java
@@ -1,0 +1,46 @@
+/*
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (C) 2006-2015 Pentaho and others
+// All Rights Reserved.
+ */
+package mondrian.parser;
+
+import mondrian.olap.*;
+import mondrian.server.Statement;
+
+/**
+ * Helper test class which allows injecting a testable Query
+ * object during parse.
+ *
+ * Can be used by instantiating a ParserValidator passing this
+ * wrapper class to the JavaccParserValidatorImpl constructor.
+ */
+public class FactoryImplTestWrapper extends QueryPartFactoryImpl {
+
+    @Override
+    public Query makeQuery(
+        Statement statement,
+        Formula[] formulae,
+        QueryAxis[] axes,
+        String cube,
+        Exp slicer,
+        QueryPart[] cellProps,
+        boolean strictValidation)
+    {
+        final QueryAxis slicerAxis =
+            slicer == null
+                ? null
+                : new QueryAxis(
+                    false, slicer, AxisOrdinal.StandardAxisOrdinal.SLICER,
+                    QueryAxis.SubtotalVisibility.Undefined, new Id[0]);
+        return new QueryTestWrapper(
+            statement, formulae, axes, cube, slicerAxis, cellProps,
+            strictValidation);
+    }
+}
+
+// End FactoryImplTestWrapper.java

--- a/src/test/java/mondrian/rolap/MemberCacheHelperTest.java
+++ b/src/test/java/mondrian/rolap/MemberCacheHelperTest.java
@@ -1,0 +1,207 @@
+/*
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (C) 2006-2015 Pentaho and others
+// All Rights Reserved.
+ */
+package mondrian.rolap;
+
+import mondrian.rolap.sql.MemberChildrenConstraint;
+
+import junit.framework.TestCase;
+
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class MemberCacheHelperTest extends TestCase {
+
+    @Mock
+    private RolapMember parentMember;
+
+    @Mock
+    private ChildByNameConstraint childByNameConstraint;
+
+    @Mock
+    private MemberKey memberKey;
+
+    @Mock
+    RolapCubeHierarchy rolapHierarchy;
+
+    private MemberChildrenConstraint defMemChildrenConstraint =
+        DefaultMemberChildrenConstraint.instance();
+
+    private List<RolapMember> children = new ArrayList<RolapMember>();
+
+    private MemberCacheHelper cacheHelper;
+
+    @Override
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        cacheHelper = new MemberCacheHelper(rolapHierarchy);
+    }
+
+    public void testRoundtripChildrenUsingChildByNameConstraint() {
+        List<String> childNames = fillChildren(children, 3);
+        when(childByNameConstraint.getChildNames()).thenReturn(childNames);
+
+        cacheHelper.putChildren(parentMember, childByNameConstraint, children);
+
+        List<RolapMember> retrievedChildren =
+            cacheHelper.getChildrenFromCache(
+                parentMember, childByNameConstraint);
+
+        assertEquals(children, retrievedChildren);
+    }
+
+    public void testCachedByDefaultConstraint() {
+        List<String> childNames = fillChildren(children, 5);
+        when(childByNameConstraint.getChildNames()).thenReturn(childNames);
+
+        // cached under default constraint, but subsequent
+        // retrieval with childByName should work since all children present.
+        cacheHelper.putChildren(
+            parentMember,
+            defMemChildrenConstraint, children);
+
+        List<RolapMember> retrievedChildren =
+            cacheHelper.getChildrenFromCache(
+                parentMember,
+                childByNameConstraint);
+
+        assertEquals(children, retrievedChildren);
+    }
+
+    public void testOnlyRequestedChildrenRetrieved() {
+        // tests retrieval of a subset of children from
+        // the cache with keyed with DefaultMemberChildrenConstraint
+        List<String> childNames = fillChildren(children, 5);
+
+        int FROM = 2;
+        int TO = 5;
+        // childByName constraint defined with member names in sublist
+        when(childByNameConstraint.getChildNames()).thenReturn(
+            childNames.subList(FROM, TO));
+
+        // cached under default constraint, but subsequent
+        // retrieval with childByName should work since all children present.
+        cacheHelper.putChildren(
+            parentMember,
+            defMemChildrenConstraint, children);
+
+        List<RolapMember> retrievedChildren =
+            cacheHelper.getChildrenFromCache(
+                parentMember,
+                childByNameConstraint);
+
+        assertEquals(
+            "Expected children were not retrieved from cache.",
+            children.subList(FROM, TO), retrievedChildren);
+    }
+
+    public void testMissingChildrenNotRetrievedDefaultConst() {
+        runMissingChildrenNotRetrievedTest(defMemChildrenConstraint);
+    }
+
+    public void testMissingChildrenNotRetrievedChildByName() {
+        runMissingChildrenNotRetrievedTest(childByNameConstraint);
+    }
+
+    public void runMissingChildrenNotRetrievedTest(
+        MemberChildrenConstraint constraint)
+    {
+        fillChildren(children, 5);
+        when(childByNameConstraint.getChildNames()).thenReturn(
+            Arrays.asList("Other Name", "Other Name2"));
+
+        cacheHelper.putChildren(
+            parentMember, constraint, children);
+
+        List<RolapMember> retrievedChildren =
+            cacheHelper.getChildrenFromCache(
+                parentMember, childByNameConstraint);
+
+        assertEquals(
+            "Not expecting to retrieve anything from cache",
+            null, retrievedChildren);
+    }
+
+
+    public void testRemoveChildMemberPresentInNamedChildrenMap() {
+        List<String> childNames = fillChildren(children, 3);
+        when(childByNameConstraint.getChildNames()).thenReturn(
+            childNames.subList(1, 3));
+        List<MemberKey> childKeys = new ArrayList<MemberKey>();
+
+        for (RolapMember member : children) {
+            when(member.getParentMember()).thenReturn(parentMember);
+            MemberKey key = mockMemberKey();
+            childKeys.add(key);
+            cacheHelper.putMember(member.getLevel(), key, member);
+        }
+        cacheHelper.putMember(memberKey.getLevel(), memberKey, parentMember);
+        cacheHelper.putChildren(parentMember, childByNameConstraint, children);
+
+        cacheHelper.removeMember(mock(RolapCubeLevel.class), childKeys.get(0));
+
+        List<RolapMember> members =
+            cacheHelper.getChildrenFromCache(
+                parentMember, childByNameConstraint);
+
+        assertEquals(
+            "Retrieved children should not include the removed member",
+            children.subList(1, 3), members);
+    }
+
+    private MemberKey mockMemberKey() {
+        MemberKey mock = mock(MemberKey.class);
+        RolapCubeLevel mockedLevel = mock(RolapCubeLevel.class);
+        when(mock.getLevel()).thenReturn(mockedLevel);
+        return mock;
+    }
+
+    private List<String> fillChildren(List<RolapMember> children, int count) {
+        List<String> names = new ArrayList<String>();
+        for (int i = 0; i < count; i++) {
+            RolapMember member = mock(RolapMember.class);
+            String name = "Member-" + i;
+            names.add(name);
+            when(member.getName()).thenReturn(name);
+            // there's a bug in mockito which causes mock objects
+            // .compareTo to always return 1
+            // https://code.google.com/p/mockito/issues/detail?id=467
+            // here's a workaround.
+            when(member.compareTo(any(RolapMember.class))).thenAnswer(
+                new Answer<Object>() {
+                    public Object answer(InvocationOnMock invocation)
+                        throws Throwable
+                    {
+                        return ((RolapMember) invocation.getMock()).getName()
+                            .compareTo(
+                                ((RolapMember) invocation.getArguments()[0])
+                                    .getName());
+                    }
+                }
+            );
+            children.add(member);
+        }
+        return names;
+    }
+}
+
+// End MemberCacheHelperTest.java

--- a/src/test/java/mondrian/rolap/VirtualCubeTest.java
+++ b/src/test/java/mondrian/rolap/VirtualCubeTest.java
@@ -5,7 +5,7 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2003-2005 Julian Hyde
-// Copyright (C) 2005-2013 Pentaho
+// Copyright (C) 2005-2015 Pentaho
 // All Rights Reserved.
 */
 package mondrian.rolap;
@@ -1340,6 +1340,9 @@ public class VirtualCubeTest extends BatchTestCase {
      * cube is correct.  The joins shouldn't be cartesian product.
      */
     public void testNonEmptyConstraintOnVirtualCubeWithCalcMeasure() {
+        // we want to make sure a SqlConstraint is used for retrieving
+        // [Product Family].members
+        propSaver.set(propSaver.props.LevelPreCacheThreshold, 0);
         if (!MondrianProperties.instance().EnableNativeNonEmpty.get()) {
             // Generated SQL is different if NON EMPTY is evaluated in memory.
             return;

--- a/src/test/java/mondrian/rolap/sql/EffectiveMemberCacheTest.java
+++ b/src/test/java/mondrian/rolap/sql/EffectiveMemberCacheTest.java
@@ -1,0 +1,196 @@
+/*
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (C) 2006-2015 Pentaho and others
+// All Rights Reserved.
+ */
+package mondrian.rolap.sql;
+
+import mondrian.rolap.*;
+import mondrian.spi.Dialect;
+import mondrian.test.*;
+
+public class EffectiveMemberCacheTest extends BatchTestCase {
+
+    TestContext testContext;
+
+    @Override
+    public void setUp() {
+        clearCache();
+        propSaver.set(propSaver.props.GenerateFormattedSql, true);
+    }
+
+    public void _testCachedLevelMembers() {
+        // Disabled pending MONDRIAN-2341
+
+        // verify query for specific members can be fulfilled by members cached
+        // from a level members query.
+        testWithAndWithoutCachedMembers(
+            "select Product.[Product Name].members on 0 from sales",
+            "select "
+            + " { [Product].[Food].[Produce].[Fruit].[Fresh Fruit].[Hermanos].[Hermanos Fancy Plums], "
+            + "[Product].[Food].[Produce].[Fruit].[Fresh Fruit].[Hermanos].[Hermanos Lemons],"
+            + "[Product].[Food].[Produce].[Fruit].[Fresh Fruit].[Hermanos].[Hermanos Plums] }"
+            + " on 0 from sales",
+            new SqlPattern[]{
+                new SqlPattern(
+                    Dialect.DatabaseProduct.MYSQL,
+                    "select\n"
+                    + "    `product`.`product_name` as `c0`\n"
+                    + "from\n"
+                    + "    `product` as `product`,\n"
+                    + "    `product_class` as `product_class`\n"
+                    + "where\n"
+                    + "    (`product_class`.`product_family` = 'Food' and `product_class`.`product_department` = 'Produce' and `product_class`.`product_category` = 'Fruit' and `product_class`.`product_subcategory` = 'Fresh Fruit' and `product`.`brand_name` = 'Hermanos')\n"
+                    + "and\n"
+                    + "    ( UPPER(`product`.`product_name`) IN (UPPER('Hermanos Fancy Plums'),UPPER('Hermanos Lemons'),UPPER('Hermanos Plums')))\n"
+                    + "and\n"
+                    + "    `product`.`product_class_id` = `product_class`.`product_class_id`\n"
+                    + "group by\n"
+                    + "    `product`.`product_name`\n"
+                    + "order by\n"
+                    + "    `product`.`product_name` ASC", null)}
+        );
+    }
+
+    public void testCachedChildMembers() {
+        // verify query for specific members can be fulfilled by members cached
+        // from a child members query.
+        testWithAndWithoutCachedMembers(
+            "select [Product].[Food].[Produce].[Fruit].[Fresh Fruit].[Hermanos].Children on 0 from sales",
+            "select "
+            + " { [Product].[Food].[Produce].[Fruit].[Fresh Fruit].[Hermanos].[Hermanos Fancy Plums], "
+            + "[Product].[Food].[Produce].[Fruit].[Fresh Fruit].[Hermanos].[Hermanos Lemons],"
+            + "[Product].[Food].[Produce].[Fruit].[Fresh Fruit].[Hermanos].[Hermanos Plums] }"
+            + " on 0 from sales",
+            new SqlPattern[]{
+                new SqlPattern(
+                    Dialect.DatabaseProduct.MYSQL,
+                    "select\n"
+                    + "    `product`.`product_name` as `c0`\n"
+                    + "from\n"
+                    + "    `product` as `product`,\n"
+                    + "    `product_class` as `product_class`\n"
+                    + "where\n"
+                    + "    (`product_class`.`product_family` = 'Food' and `product_class`.`product_department` = 'Produce' and `product_class`.`product_category` = 'Fruit' and `product_class`.`product_subcategory` = 'Fresh Fruit' and `product`.`brand_name` = 'Hermanos')\n"
+                    + "and\n"
+                    + "    ( UPPER(`product`.`product_name`) IN (UPPER('Hermanos Fancy Plums'),UPPER('Hermanos Lemons'),UPPER('Hermanos Plums')))\n"
+                    + "and\n"
+                    + "    `product`.`product_class_id` = `product_class`.`product_class_id`\n"
+                    + "group by\n"
+                    + "    `product`.`product_name`\n"
+                    + "order by\n"
+                    + "    `product`.`product_name` ASC", null) }
+        );
+    }
+
+    public void testLevelPreCacheThreshold() {
+        // [Store Type] members cardinality falls well below
+        // LevelPreCacheThreshold.  All members should be loaded, not
+        // just the 2 referenced.
+        propSaver.set(propSaver.props.LevelPreCacheThreshold, 300);
+
+        assertQuerySql(
+            testContext,
+            "select {[Store Type].[Gourmet Supermarket], "
+            + "[Store Type].[HeadQuarters]} on 0 from sales",
+            new SqlPattern[] {
+                new SqlPattern(
+                    Dialect.DatabaseProduct.MYSQL,
+                    "select\n"
+                    + "    `store`.`store_type` as `c0`\n"
+                    + "from\n"
+                    + "    `store` as `store`\n"
+                    + "group by\n"
+                    + "    `store`.`store_type`\n"
+                    + "order by\n"
+                    + "    `store`.`store_type` ASC", null)
+            });
+    }
+
+    public void testLevelPreCacheThresholdDisabled() {
+        propSaver.set(propSaver.props.LevelPreCacheThreshold, 0);
+
+        // with LevelPreCacheThreshold set to 0, we should not load
+        // all [store type] members, we should only retrieve the 2
+        // specified.
+        assertQuerySql(
+            testContext.legacy(),
+            "select {[Store Type].[Store Type].[Gourmet Supermarket], "
+            + "[Store Type].[Store Type].[HeadQuarters]} on 0 from sales",
+            new SqlPattern[] {
+                new SqlPattern(
+                    Dialect.DatabaseProduct.MYSQL,
+                    "select\n"
+                    + "    `store`.`store_type` as `c0`\n"
+                    + "from\n"
+                    + "    `store` as `store`\n"
+                    + "where\n"
+                    + "    ( UPPER(`store`.`store_type`) IN (UPPER('Gourmet Supermarket'),UPPER('HeadQuarters')))\n"
+                    + "group by\n"
+                    + "    `store`.`store_type`\n"
+                    + "order by\n"
+                    + "    `store`.`store_type` ASC", null)
+            });
+    }
+
+    public void testLevelPreCacheThresholdParentDegenerate() {
+        // we should avoid pulling all deg members, regardless of cardinality.
+        // The cost of doing full scans of the fact table is assumed
+        // to be too high.
+        propSaver.set(propSaver.props.LevelPreCacheThreshold, 1000);
+        assertQuerySql(
+            testContext,
+            "select {[Store Type].[Store Type].[Deluxe Supermarket]} on 0 from Store",
+            new SqlPattern[]{
+                new SqlPattern(
+                    Dialect.DatabaseProduct.MYSQL,
+                    "select\n"
+                    + "    `store`.`store_type` as `c0`\n"
+                    + "from\n"
+                    + "    `store` as `store`\n"
+                    + "where\n"
+                    + "    UPPER(`store`.`store_type`) = UPPER('Deluxe Supermarket')\n"
+                    + "group by\n"
+                    + "    `store`.`store_type`\n"
+                    + "order by\n"
+                    + "    `store`.`store_type` ASC", null)});
+    }
+
+
+    /**
+     * Execute testMdx both with and without running the cacheMdx first,
+     * validating that sqlToLoadTestMdxMembers either fires or doesn't fire,
+     * as appropriate.
+     *
+     * Assumption is that if the cacheMdx has fired, then members shoould
+     * already be in cache and there is no need to load them.  If cacheMedx
+     * is not fired we should see the sqlToLoadTestMdxMembers.
+     */
+    private void testWithAndWithoutCachedMembers(
+        String cacheMdx, String testMdx, SqlPattern[] sqlToLoadTestMdxMembers)
+    {
+        for (boolean membersCached : new boolean[] {false, true}) {
+            clearCache();
+            if (membersCached) {
+                testContext.executeQuery(cacheMdx);
+            }
+            assertQuerySqlOrNot(
+                testContext,
+                testMdx,
+                sqlToLoadTestMdxMembers,
+                membersCached, false, false);
+        }
+    }
+
+    private void clearCache() {
+        getTestContext().flushSchemaCache();
+        testContext = getTestContext().legacy().withFreshConnection();
+    }
+
+}
+
+// End EffectiveMemberCacheTest.java

--- a/src/test/java/mondrian/test/AccessControlTest.java
+++ b/src/test/java/mondrian/test/AccessControlTest.java
@@ -5,7 +5,7 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2003-2005 Julian Hyde
-// Copyright (C) 2005-2014 Pentaho
+// Copyright (C) 2005-2015 Pentaho
 // All Rights Reserved.
 */
 package mondrian.test;
@@ -1184,13 +1184,13 @@ public class AccessControlTest extends FoodMartTestCase {
         // Role1 can see [Promotion].[Media Type], Role2 cannot
         // Neither can see [Marital Status]
         assertHierarchyAccess(
-            connection, Access.CUSTOM, "Sales", "[Customers]");
+            connection, Access.CUSTOM, "Sales", "[Customer].[Customers]");
         assertHierarchyAccess(
             connection, Access.ALL, "Sales", "[Stores]");
         assertHierarchyAccess(
             connection, Access.ALL, "Sales", "[Promotion].[Media Type]");
         assertHierarchyAccess(
-            connection, Access.NONE, "Sales", "[Marital Status]");
+            connection, Access.NONE, "Sales", "[Customer].[Marital Status]");
 
         // Rollup policy is the greater of Role1's partian and Role2's hidden
         final Role.HierarchyAccess hierarchyAccess =

--- a/src/test/java/mondrian/test/Main.java
+++ b/src/test/java/mondrian/test/Main.java
@@ -5,7 +5,7 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 1998-2005 Julian Hyde
-// Copyright (C) 2005-2014 Pentaho and others
+// Copyright (C) 2005-2015 Pentaho and others
 // All Rights Reserved.
 //
 // jhyde, 21 January, 1999
@@ -21,6 +21,7 @@ import mondrian.olap.type.TypeTest;
 import mondrian.rolap.*;
 import mondrian.rolap.agg.*;
 import mondrian.rolap.aggmatcher.*;
+import mondrian.rolap.sql.EffectiveMemberCacheTest;
 import mondrian.rolap.sql.SelectNotInGroupByTest;
 import mondrian.rolap.sql.SqlQueryTest;
 import mondrian.test.build.CodeComplianceTest;
@@ -321,6 +322,9 @@ public class Main extends TestSuite {
             addTest(suite, DynamicSchemaProcessorTest.class);
             addTest(suite, MonitorTest.class);
             addTest(suite, BlockingHashMapTest.class);
+            addTest(suite, IdBatchResolverTest.class);
+            addTest(suite, MemberCacheHelperTest.class);
+            addTest(suite, EffectiveMemberCacheTest.class);
             addTest(suite, CodeComplianceTest.class);
 
             boolean testNonEmpty = isRunOnce();

--- a/src/test/java/mondrian/test/ParameterTest.java
+++ b/src/test/java/mondrian/test/ParameterTest.java
@@ -5,7 +5,7 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2003-2005 Julian Hyde
-// Copyright (C) 2005-2014 Pentaho
+// Copyright (C) 2005-2015 Pentaho
 // All Rights Reserved.
 */
 package mondrian.test;
@@ -558,7 +558,7 @@ public class ParameterTest extends FoodMartTestCase {
         Assert.assertEquals("Q", parameters[3].getName());
         final Member member =
             query.getSchemaReader(true).getMemberByUniqueName(
-                Id.Segment.toList("Gender", "M"), true);
+                Id.Segment.toList("Customer", "Gender", "M"), true);
         parameters[2].setValue(member);
         TestContext.assertEqualsVerbose(
             "with member [Measures].[A string] as 'Parameter(\"S\", STRING, (\"x\" || \"y\"), \"A string parameter\")'\n"

--- a/src/test/java/mondrian/xmla/XmlaBaseTestCase.java
+++ b/src/test/java/mondrian/xmla/XmlaBaseTestCase.java
@@ -4,7 +4,7 @@
 // http://www.eclipse.org/legal/epl-v10.html.
 // You must accept the terms of that agreement to use this software.
 //
-// Copyright (C) 2006-2013 Pentaho and others
+// Copyright (C) 2006-2015 Pentaho and others
 // All Rights Reserved.
 */
 package mondrian.xmla;
@@ -132,7 +132,7 @@ System.out.println("requestText=" + requestText);
         }
 
         Document gotDoc = XmlUtil.parse(bytes);
-        gotDoc = replaceLastSchemaUpdateDate(gotDoc);
+        gotDoc = cleanseOutput(gotDoc);
         String gotStr = XmlUtil.toString(gotDoc, true);
         gotStr = maskVersion(gotStr);
         gotStr = testContext.upgradeActual(gotStr);
@@ -142,7 +142,7 @@ System.out.println("requestText=" + requestText);
             }
             return;
         }
-        expectedDoc = replaceLastSchemaUpdateDate(expectedDoc);
+        expectedDoc = cleanseOutput(expectedDoc);
         String expectedStr = XmlUtil.toString(expectedDoc, true);
         try {
             XMLAssert.assertXMLEqual(expectedStr, gotStr);
@@ -164,6 +164,11 @@ System.out.println("requestText=" + requestText);
                 throw e;
             }
         }
+    }
+
+    private Document cleanseOutput(Document gotDoc) {
+        return replaceMemberOrdinal(
+            replaceLastSchemaUpdateDate(gotDoc));
     }
 
     public void doTest(Properties props) throws Exception {
@@ -319,6 +324,23 @@ System.out.println("Got CONTINUE");
             Node node = elements.item(i);
             node.getFirstChild().setNodeValue(
                 LAST_SCHEMA_UPDATE_DATE);
+        }
+        return doc;
+    }
+
+    /**
+     * The MEMBER_ORDINAL property is unreliable since it's dependent
+     * on the sequence in which members are loaded, which is inconsistent
+     * unless the complete dimension is loaded.  The property has been
+     * deprecated.
+     * @return doc with MEMBER_ORDINAL set to -1
+     */
+    protected Document replaceMemberOrdinal(Document doc) {
+        NodeList elements =
+            doc.getElementsByTagName(Property.MEMBER_ORDINAL.getCaption());
+        for (int i = 0; i < elements.getLength(); i++) {
+            Node node = elements.item(i);
+            node.getFirstChild().setNodeValue("-1");
         }
         return doc;
     }


### PR DESCRIPTION

1) Introduces a "batch resolution" phase prior to final expression
resolution which collects child name references and loads them at the
same time.  This avoids the one-at-a-time SQL queries for each child
member reference within an expression.  IdBatchResolver is the
relevant class.

2) To better suppport (1), this change also introduces a new caching
mechanism for ChildByNameConstraints.  If the child members { [Bob],
[Joe], [Bill] } have already been cached, MemberCacheHelper is now
smart enough to retrieve any subset of what has formerly been loaded.
This new functionanlity only works with ChildByNameConstraint checks,
since it depends on lookups by name.

3) To better handle small levels (under 300 members), this change also
adds a check for level cardinality when constructing a constraint in
SqlConstraintFactory.  In general, any level with fewer than 300
members will be loaded with a default constraint to avoid repeat
queries to the dimension table.  There are some exceptions to this,
for example degenerate dimensions are assumed to be too expensive for
full table scans, so a Sql constraint is preferred.  This is governed by
a new property called "LevelPreCacheThreshold", which can be set to
0 to disable the new behavior.

manual merge from 3x future-dev branch (cf2eceabd1)