### PR TITLE
[MONDRIAN-2296] - Invalid query results after executing crossjoin() q…

### DIFF
--- a/src/main/mondrian/rolap/agg/AbstractSegmentBody.java
+++ b/src/main/mondrian/rolap/agg/AbstractSegmentBody.java
@@ -4,7 +4,7 @@
 // http://www.eclipse.org/legal/epl-v10.html.
 // You must accept the terms of that agreement to use this software.
 //
-// Copyright (c) 2002-2014 Pentaho Corporation..  All rights reserved.
+// Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
 */
 package mondrian.rolap.agg;
 
@@ -56,7 +56,7 @@ abstract class AbstractSegmentBody implements SegmentBody {
                     }
 
                     public int size() {
-                        return getSize();
+                        return getEffectiveSize();
                     }
                 };
             }
@@ -74,7 +74,23 @@ abstract class AbstractSegmentBody implements SegmentBody {
             + "of native values");
     }
 
+    /**
+     * Returns the overall amount of stored elements, including those,
+     * that are considered to be <tt>null</tt>.
+     * @return      the size of stored data
+     */
     protected abstract int getSize();
+
+    /**
+     * Returns the amount of non-null elements. This amount is equal to
+     * number of elements that
+     * <code>getValueMap().entrySet().iterator()</code> is returned.
+     * By default the method executes <code>getSize()</code>.
+     * @return      the effective size of stored data
+     */
+    protected int getEffectiveSize() {
+      return getSize();
+    }
 
     protected abstract Object getObject(int i);
 

--- a/src/main/mondrian/rolap/agg/DenseDoubleSegmentBody.java
+++ b/src/main/mondrian/rolap/agg/DenseDoubleSegmentBody.java
@@ -1,12 +1,11 @@
 /*
-* This software is subject to the terms of the Eclipse Public License v1.0
-* Agreement, available at the following URL:
-* http://www.eclipse.org/legal/epl-v10.html.
-* You must accept the terms of that agreement to use this software.
-*
-* Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
 */
-
 package mondrian.rolap.agg;
 
 import mondrian.util.Pair;
@@ -60,7 +59,12 @@ class DenseDoubleSegmentBody extends AbstractSegmentBody {
 
     @Override
     protected int getSize() {
-        return values.length; // - nullValues.cardinality();
+        return values.length;
+    }
+
+    @Override
+    protected int getEffectiveSize() {
+        return values.length - nullValues.cardinality();
     }
 
     @Override

--- a/src/main/mondrian/rolap/agg/DenseIntSegmentBody.java
+++ b/src/main/mondrian/rolap/agg/DenseIntSegmentBody.java
@@ -1,12 +1,11 @@
 /*
-* This software is subject to the terms of the Eclipse Public License v1.0
-* Agreement, available at the following URL:
-* http://www.eclipse.org/legal/epl-v10.html.
-* You must accept the terms of that agreement to use this software.
-*
-* Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
 */
-
 package mondrian.rolap.agg;
 
 import mondrian.util.Pair;
@@ -59,6 +58,11 @@ class DenseIntSegmentBody extends AbstractSegmentBody {
     }
 
     protected int getSize() {
+        return values.length;
+    }
+
+    @Override
+    protected int getEffectiveSize() {
         return values.length - nullValues.cardinality();
     }
 

--- a/src/main/mondrian/rolap/agg/DenseObjectSegmentBody.java
+++ b/src/main/mondrian/rolap/agg/DenseObjectSegmentBody.java
@@ -1,12 +1,11 @@
 /*
-* This software is subject to the terms of the Eclipse Public License v1.0
-* Agreement, available at the following URL:
-* http://www.eclipse.org/legal/epl-v10.html.
-* You must accept the terms of that agreement to use this software.
-*
-* Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
 */
-
 package mondrian.rolap.agg;
 
 import mondrian.util.Pair;
@@ -53,7 +52,7 @@ class DenseObjectSegmentBody extends AbstractSegmentBody {
 
     @Override
     protected int getSize() {
-        return values.length; // TODO: subtract number of nulls?
+        return values.length;
     }
 }
 

--- a/testsrc/main/mondrian/rolap/agg/DenseDoubleSegmentBodyTest.java
+++ b/testsrc/main/mondrian/rolap/agg/DenseDoubleSegmentBodyTest.java
@@ -1,0 +1,54 @@
+/*
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (c) 2015-2015 Pentaho Corporation..  All rights reserved.
+*/
+package mondrian.rolap.agg;
+
+import mondrian.util.Pair;
+
+import java.util.BitSet;
+import java.util.List;
+import java.util.SortedSet;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+public class DenseDoubleSegmentBodyTest extends
+  DenseSegmentBodyTestBase<DenseDoubleSegmentBody, Double>
+{
+
+  @Override
+  Double createNullValue() {
+    return 0d;
+  }
+
+  @Override
+  Double createNonNullValue() {
+    return 1d;
+  }
+
+  @Override
+  boolean isNull(Double value) {
+    return (value == null) || (value == 0);
+  }
+
+  @Override
+  DenseDoubleSegmentBody createSegmentBody(
+      BitSet nullValues,
+      Object array,
+      List<Pair<SortedSet<Comparable>, Boolean>> axes)
+  {
+    Object[] doubles = (Object[]) array;
+    double[] values = new double[doubles.length];
+    for (int i = 0; i < doubles.length; i++) {
+      values[i] = (Double)doubles[i];
+    }
+    return new DenseDoubleSegmentBody(nullValues, values, axes);
+  }
+}
+
+// End DenseDoubleSegmentBodyTest.java

--- a/testsrc/main/mondrian/rolap/agg/DenseIntSegmentBodyTest.java
+++ b/testsrc/main/mondrian/rolap/agg/DenseIntSegmentBodyTest.java
@@ -1,0 +1,54 @@
+/*
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (c) 2015-2015 Pentaho Corporation..  All rights reserved.
+*/
+package mondrian.rolap.agg;
+
+import mondrian.util.Pair;
+
+import java.util.BitSet;
+import java.util.List;
+import java.util.SortedSet;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+public class DenseIntSegmentBodyTest extends
+  DenseSegmentBodyTestBase<DenseIntSegmentBody, Integer>
+{
+
+  @Override
+  Integer createNullValue() {
+    return 0;
+  }
+
+  @Override
+  Integer createNonNullValue() {
+    return 1;
+  }
+
+  @Override
+  boolean isNull(Integer value) {
+    return (value == null) || (value == 0);
+  }
+
+  @Override
+  DenseIntSegmentBody createSegmentBody(
+      BitSet nullValues,
+      Object array,
+      List<Pair<SortedSet<Comparable>, Boolean>> axes)
+  {
+    Object[] integers = (Object[]) array;
+    int[] values = new int[integers.length];
+    for (int i = 0; i < integers.length; i++) {
+      values[i] = (Integer)integers[i];
+    }
+    return new DenseIntSegmentBody(nullValues, values, axes);
+  }
+}
+
+// End DenseIntSegmentBodyTest.java

--- a/testsrc/main/mondrian/rolap/agg/DenseSegmentBodyTestBase.java
+++ b/testsrc/main/mondrian/rolap/agg/DenseSegmentBodyTestBase.java
@@ -1,0 +1,166 @@
+/*
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (c) 2015-2015 Pentaho Corporation..  All rights reserved.
+*/
+package mondrian.rolap.agg;
+
+import mondrian.rolap.CellKey;
+import mondrian.util.Pair;
+
+import junit.framework.TestCase;
+
+import java.util.BitSet;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import static java.util.Arrays.asList;
+import static mondrian.util.Pair.of;
+
+/**
+ * This is a base class for two heirs. It provides several template methods
+ * for testing
+ * @author Andrey Khayrutdinov
+ */
+abstract class DenseSegmentBodyTestBase<T extends AbstractSegmentBody, V>
+  extends TestCase
+{
+
+  final V nonNull = createNonNullValue();
+  final V nullValue = createNullValue();
+
+  public void testGetObject_NonNull() {
+    T body = withOutAxes(nonNull);
+    assertEquals(nonNull, body.getObject(0));
+  }
+
+  public void testGetObject_Null() {
+    T body = withOutAxes(nullValue);
+    assertNull(body.getObject(0));
+  }
+
+
+  public void testGetSize_NoNulls() {
+    T body = withOutAxes(nonNull, nonNull, nonNull);
+    assertEquals(body.getSize(), body.getEffectiveSize());
+  }
+
+  public void testGetSize_HasNulls() {
+    T body = withOutAxes(nonNull, nullValue, nonNull);
+    assertEquals(3, body.getSize());
+    assertEquals(2, body.getEffectiveSize());
+  }
+
+  public void testGetSize_OnlyNulls() {
+    T body = withOutAxes(nullValue, nullValue, nullValue);
+    assertEquals(3, body.getSize());
+    assertEquals(0, body.getEffectiveSize());
+  }
+
+
+  public void testGetValueMap_NoNullCells_NoNullAxes() {
+    SortedSet<Comparable> axis1 = new TreeSet<Comparable>(asList(1, 2));
+    SortedSet<Comparable> axis2 = new TreeSet<Comparable>(asList(3));
+    List<Pair<SortedSet<Comparable>, Boolean>> axes = asList(
+        of(axis1, false), of(axis2, false));
+    T body = withAxes(axes, nonNull, nonNull, nonNull);
+    assertValuesMapIsCorrect(body, 3);
+  }
+
+  public void testGetValueMap_NoNullCells_HasNullAxes() {
+    SortedSet<Comparable> axis1 = new TreeSet<Comparable>(asList(1, 2));
+    SortedSet<Comparable> axis2 = new TreeSet<Comparable>(asList(3));
+    List<Pair<SortedSet<Comparable>, Boolean>> axes = asList(
+        of(axis1, false), of(axis2, true));
+    T body = withAxes(axes, nonNull, nonNull, nonNull, nonNull);
+    assertValuesMapIsCorrect(body, 4);
+  }
+
+  public void testGetValueMap_HasNullCells_NoNullAxes() {
+    SortedSet<Comparable> axis1 = new TreeSet<Comparable>(asList(1, 2));
+    SortedSet<Comparable> axis2 = new TreeSet<Comparable>(asList(3));
+    List<Pair<SortedSet<Comparable>, Boolean>> axes = asList(
+        of(axis1, false), of(axis2, false));
+    T body = withAxes(axes, nonNull, nullValue, nonNull, nullValue, nonNull);
+    assertValuesMapIsCorrect(body, 3);
+  }
+
+  public void testGetValueMap_HasNullCells_HasNullAxes() {
+    SortedSet<Comparable> axis1 = new TreeSet<Comparable>(asList(1, 2));
+    SortedSet<Comparable> axis2 = new TreeSet<Comparable>(asList(3));
+    List<Pair<SortedSet<Comparable>, Boolean>> axes = asList(
+        of(axis1, false), of(axis2, true));
+    T body = withAxes(
+        axes, nonNull, nullValue, nonNull, nullValue, nonNull, nonNull);
+    assertValuesMapIsCorrect(body, 4);
+  }
+
+  public void testGetValueMap_OnlyNullCells_NoNullAxes() {
+    SortedSet<Comparable> axis1 = new TreeSet<Comparable>(asList(1, 2));
+    SortedSet<Comparable> axis2 = new TreeSet<Comparable>(asList(3));
+    List<Pair<SortedSet<Comparable>, Boolean>> axes = asList(
+        of(axis1, false), of(axis2, false));
+    T body = withAxes(axes, nullValue, nullValue);
+    assertValuesMapIsCorrect(body, 0);
+  }
+
+  public void testGetValueMap_OnlyNullCells_HasNullAxes() {
+    SortedSet<Comparable> axis1 = new TreeSet<Comparable>(asList(1, 2));
+    SortedSet<Comparable> axis2 = new TreeSet<Comparable>(asList(3));
+    List<Pair<SortedSet<Comparable>, Boolean>> axes = asList(
+        of(axis1, false), of(axis2, true));
+    T body = withAxes(axes, nullValue, nullValue);
+    assertValuesMapIsCorrect(body, 0);
+  }
+
+  private void assertValuesMapIsCorrect(T body, int expectedSize) {
+    Map<CellKey, Object> valueMap = body.getValueMap();
+
+    assertEquals(expectedSize, valueMap.size());
+    assertEquals(expectedSize, valueMap.keySet().size());
+    assertEquals(expectedSize, valueMap.values().size());
+    assertEquals(expectedSize, valueMap.entrySet().size());
+
+    int i = 0;
+    Iterator<Map.Entry<CellKey, Object>> it = valueMap.entrySet().iterator();
+    while (i < expectedSize) {
+      assertTrue(Integer.toString(i), it.hasNext());
+      assertNotNull(it.next());
+      i++;
+    }
+    assertFalse(it.hasNext());
+  }
+
+  abstract V createNullValue();
+  abstract V createNonNullValue();
+  abstract boolean isNull(V value);
+
+  abstract T createSegmentBody(
+      BitSet nullValues, Object array,
+      List<Pair<SortedSet<Comparable>, Boolean>> axes);
+
+  T withOutAxes(V... values) {
+    return withAxes(
+        Collections.<Pair<SortedSet<Comparable>, Boolean>>emptyList(),
+        values);
+  }
+
+  T withAxes(List<Pair<SortedSet<Comparable>, Boolean>> axes, V... values) {
+    BitSet nullValues = new BitSet();
+    for (int i = 0; i < values.length; i++) {
+      if (isNull(values[i])) {
+        nullValues.set(i);
+      }
+    }
+    return createSegmentBody(nullValues, values, axes);
+  }
+}
+
+// End DenseSegmentBodyTestBase.java

--- a/testsrc/main/mondrian/test/Main.java
+++ b/testsrc/main/mondrian/test/Main.java
@@ -5,7 +5,7 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 1998-2005 Julian Hyde
-// Copyright (C) 2005-2014 Pentaho and others
+// Copyright (C) 2005-2015 Pentaho and others
 // All Rights Reserved.
 //
 // jhyde, 21 January, 1999
@@ -211,6 +211,8 @@ public class Main extends TestSuite {
                 return suite;
             }
             addTest(suite, SegmentBuilderTest.class);
+            addTest(suite, DenseDoubleSegmentBodyTest.class);
+            addTest(suite, DenseIntSegmentBodyTest.class);
             addTest(suite, NativeFilterMatchingTest.class);
             addTest(suite, RolapConnectionTest.class);
             addTest(suite, FilteredIterableTest.class);


### PR DESCRIPTION
…uery

- remove subtraction in DenseIntSegmentBody.getSize() to make it consistent with DenseDoubleSegmentBody
- introduce getEffectiveSize() method to be delegated from getValueMap().size()
- add tests for DenseIntSegmentBody and DenseDoubleSegmentBody to guarantee their similarity in behaviour
- add a test case for SegmentBuilder.rollup() where an instance of DenseIntSegmentBody with non-empty null set is passed
- do some cosmetic changes to make affected class follow the checkstyle

@mkambol, @lucboudreau, review it please   