### PR TITLE
[MONDRIAN-2319] - Calculating Date difference produce wrong result

### DIFF
--- a/doc/vba_functions.html
+++ b/doc/vba_functions.html
@@ -500,7 +500,7 @@ functions implemented, is described in the <a href="mdx.html">MDX specification<
 	q Quarter <br>
 	m Month <br>
 	y Day of year <br>
-	d Day of year<br>
+	d Day <br>
 	w Weekday <br>
 	ww Week <br>
 	h Hour <br>
@@ -513,7 +513,7 @@ functions implemented, is described in the <a href="mdx.html">MDX specification<
 	interval from a date. For example, you can use DateAdd to calculate a date 
 	30 days from today or a time 45 minutes from now.<br>
 	<br>
-	To add days to date, you can use Day of Year (&quot;y&quot;, &quot;d&quot;), or Weekday
+	To add days to date, you can use Day of Year (&quot;y&quot;), Day (&quot;d&quot;), or Weekday 
 	(&quot;w&quot;).<br>
 	<br>
 	The DateAdd function won't return an invalid date. The following example 

--- a/src/main/mondrian/olap/fun/vba/Vba.java
+++ b/src/main/mondrian/olap/fun/vba/Vba.java
@@ -425,6 +425,10 @@ public class Vba {
         int firstDayOfWeek, FirstWeekOfYear firstWeekOfYear)
     {
         Interval interval = Interval.valueOf(intervalName);
+        if (interval == Interval.d) {
+            // MONDRIAN-2319
+            interval = Interval.y;
+        }
         Calendar calendar1 = Calendar.getInstance();
         firstWeekOfYear.apply(calendar1);
         calendar1.setTime(date1);
@@ -2427,7 +2431,7 @@ public class Vba {
         q("Quarter", -1),
         m("Month", Calendar.MONTH),
         y("Day of year", Calendar.DAY_OF_YEAR),
-        d("Day", Calendar.DAY_OF_YEAR),
+        d("Day", Calendar.DAY_OF_MONTH),
         w("Weekday", Calendar.DAY_OF_WEEK),
         ww("Week", Calendar.WEEK_OF_YEAR),
         h("Hour", Calendar.HOUR_OF_DAY),
@@ -2519,7 +2523,6 @@ public class Vba {
             case q:
                 return m.diff(calendar1, calendar2, firstDayOfWeek) / 3;
             case y:
-            case d:
                 return computeDiffInDays(calendar1, calendar2);
             default:
                 return floor(calendar1).get(dateField)

--- a/testsrc/main/mondrian/olap/fun/vba/VbaTest.java
+++ b/testsrc/main/mondrian/olap/fun/vba/VbaTest.java
@@ -316,6 +316,43 @@ public class VbaTest extends TestCase {
         assertEquals("2008/04/24 19:10:36", Vba.dateAdd("s", -9, SAMPLE_DATE));
     }
 
+    public void testAddDate_Days_NextYear() throws Exception {
+        Date dec31 = toDate("2001/12/31");
+        for (String i : new String[] {"y", "d"}) {
+            assertEquals("2002/01/01 00:00:00", Vba.dateAdd(i, 1, dec31));
+        }
+    }
+
+    public void testAddDate_Days_PreviousMonth() throws Exception {
+        Date dec31 = toDate("2001/12/31");
+        for (String i : new String[] {"y", "d"}) {
+            assertEquals("2001/11/30 00:00:00", Vba.dateAdd(i, -31, dec31));
+        }
+    }
+
+    public void testAddDate_Days_NextMonth() throws Exception {
+        Date jan1 = toDate("2001/01/01");
+        for (String i : new String[] {"y", "d"}) {
+            assertEquals("2001/02/01 00:00:00", Vba.dateAdd(i, 31, jan1));
+        }
+    }
+
+    public void testAddDate_Days_PreviousYear() throws Exception {
+        Date jan1 = toDate("2001/01/01");
+        for (String i : new String[] {"y", "d"}) {
+            assertEquals("2000/12/31 00:00:00", Vba.dateAdd(i, -1, jan1));
+        }
+    }
+
+    public void testAddDate_Days_LeapYear() throws Exception {
+        Date feb28 = toDate("2012/02/28");
+        Date mar1 = toDate("2012/03/01");
+        for (String i : new String[] {"y", "d"}) {
+            assertEquals("2012/02/29 00:00:00", Vba.dateAdd(i, 1, feb28));
+            assertEquals("2012/02/29 00:00:00", Vba.dateAdd(i, -1, mar1));
+        }
+    }
+
     public void testDateDiff() {
         // TODO:
     }
@@ -467,6 +504,12 @@ public class VbaTest extends TestCase {
         }
     }
 
+    public void testDatePart_Y_vs_D() throws Exception {
+        Date dec1 = toDate("2001/12/01");
+        assertEquals(335, Vba.datePart("y", dec1));
+        assertEquals(1, Vba.datePart("d", dec1));
+    }
+
     public void testDate() {
         final Date date = Vba.date();
         assertNotNull(date);
@@ -492,8 +535,13 @@ public class VbaTest extends TestCase {
     }
 
     private static Date toDate(String dateString) throws Exception {
-        SimpleDateFormat dateFormat =
-          new SimpleDateFormat("yyyy/MM/dd HH:mm:ss", Locale.US);
+        String pattern;
+        if (dateString.contains(":")) {
+            pattern = "yyyy/MM/dd HH:mm:ss";
+        } else {
+            pattern = "yyyy/MM/dd";
+        }
+        SimpleDateFormat dateFormat = new SimpleDateFormat(pattern, Locale.US);
         return dateFormat.parse(dateString);
     }
 


### PR DESCRIPTION
- revert changes related to Interval.d from commit 1ee115751dfb9e5520d411a0b37232229728b409
- change the behaviour of dateDiff function, by manually replacing Interval.d with Interval.y
- add a test to verbose the difference between 'd' and 'y' for DatePart function (https://msdn.microsoft.com/en-us/library/20ee97hz(v=vs.90).aspx)

@mkambol, review it please. I hope this will solve the problem.
/cc @lucboudreau  