### PR TITLE
SP-1945 - Backport of MONDRIAN-2251 - Exceeding CellBatchSize when evaluating a UDF causes an error. (5.4 Suite)

### DIFF
--- a/src/main/mondrian/olap/fun/UdfResolver.java
+++ b/src/main/mondrian/olap/fun/UdfResolver.java
@@ -5,10 +5,9 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2005-2005 Julian Hyde
-// Copyright (C) 2005-2012 Pentaho
+// Copyright (C) 2005-2015 Pentaho
 // All Rights Reserved.
 */
-
 package mondrian.olap.fun;
 
 import mondrian.calc.*;
@@ -16,6 +15,7 @@ import mondrian.calc.impl.*;
 import mondrian.mdx.ResolvedFunCall;
 import mondrian.olap.*;
 import mondrian.olap.type.*;
+import mondrian.rolap.agg.CellRequestQuantumExceededException;
 import mondrian.spi.UserDefinedFunction;
 
 import java.util.*;
@@ -196,6 +196,9 @@ public class UdfResolver implements Resolver {
         public Object evaluate(Evaluator evaluator) {
             try {
                 return udf.execute(evaluator, args);
+            } catch (CellRequestQuantumExceededException e) {
+                // Is assumed will be processed in mondrian.rolap.RolapResult
+                throw e;
             } catch (Exception e) {
                 return FunUtil.newEvalException(
                     "Exception while executing function " + udf.getName(),

--- a/testsrc/main/mondrian/rolap/FastBatchingCellReaderTest.java
+++ b/testsrc/main/mondrian/rolap/FastBatchingCellReaderTest.java
@@ -2462,7 +2462,7 @@ public class FastBatchingCellReaderTest extends BatchTestCase {
      *      issue</a>
      */
     public void testCellBatchSizeWithUdf() {
-        propSaver.properties.CellBatchSize.set(1);
+        propSaver.set(MondrianProperties.instance().CellBatchSize, 1);
         assertQueryReturns(
             "select lastnonempty([education level].members, measures.[unit sales]) on 0 from sales",
             "Axis #0:\n" + "{}\n" + "Axis #1:\n"

--- a/testsrc/main/mondrian/rolap/FastBatchingCellReaderTest.java
+++ b/testsrc/main/mondrian/rolap/FastBatchingCellReaderTest.java
@@ -4,7 +4,7 @@
 // http://www.eclipse.org/legal/epl-v10.html.
 // You must accept the terms of that agreement to use this software.
 //
-// Copyright (c) 2002-2014 Pentaho Corporation..  All rights reserved.
+// Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
 */
 package mondrian.rolap;
 
@@ -2451,6 +2451,23 @@ public class FastBatchingCellReaderTest extends BatchTestCase {
             RolapAggregator.Max.aggregate(
                 Arrays.asList(intSet4),
                 Dialect.Datatype.Integer));
+    }
+
+    /**
+     * Tests if UdfResolver processes CellRequestQuantumExceededException.
+     * It should be catch in {@mondrian.rolap.RolapResult}.
+     * No exceptions should be throw outside
+     *
+     * @see <a href="http://jira.pentaho.com/browse/MONDRIAN-2251">Jira
+     *      issue</a>
+     */
+    public void testCellBatchSizeWithUdf() {
+        propSaver.properties.CellBatchSize.set(1);
+        assertQueryReturns(
+            "select lastnonempty([education level].members, measures.[unit sales]) on 0 from sales",
+            "Axis #0:\n" + "{}\n" + "Axis #1:\n"
+            + "{[Education Level].[Partial High School]}\n"
+            + "Row #0: 79,155\n");
     }
 }
 


### PR DESCRIPTION
@mkambol, @lucboudreau, here is backport of https://github.com/pentaho/mondrian/commit/f6875377f8685517575b6a82850b26dd97da798b, https://github.com/pentaho/mondrian/commit/ba0830d35c87de0c42061b9567463b5cde993462 and https://github.com/pentaho/mondrian/commit/d0fc2f09fd2513518d09b03e084eec4c9cac5dc3 to 5.4 branch, thanks  