### PR TITLE
[ANALYZER-3017]  Drillthrough in Analyzer against a Virtual cube fails

### DIFF
--- a/src/main/mondrian/olap4j/MondrianOlap4jCell.java
+++ b/src/main/mondrian/olap4j/MondrianOlap4jCell.java
@@ -1,27 +1,25 @@
 /*
-* This software is subject to the terms of the Eclipse Public License v1.0
-* Agreement, available at the following URL:
-* http://www.eclipse.org/legal/epl-v10.html.
-* You must accept the terms of that agreement to use this software.
-*
-* Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
 */
-
 package mondrian.olap4j;
 
-import mondrian.olap.Exp;
-import mondrian.olap.Util;
+import mondrian.olap.*;
 import mondrian.rolap.RolapCell;
 import mondrian.rolap.SqlStatement;
 
 import org.apache.log4j.Logger;
 
 import org.olap4j.*;
+import org.olap4j.Cell;
 import org.olap4j.metadata.Property;
 
 import java.sql.ResultSet;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -123,7 +121,7 @@ class MondrianOlap4jCell implements Cell {
         return drillThroughInternal(
             -1,
             -1,
-            new ArrayList<Exp>(),
+            new ArrayList<OlapElement>(),
             false,
             null,
             null);
@@ -152,7 +150,7 @@ class MondrianOlap4jCell implements Cell {
     ResultSet drillThroughInternal(
         int maxRowCount,
         int firstRowOrdinal,
-        List<Exp> fields,
+        List<OlapElement> fields,
         boolean extendedContext,
         Logger logger,
         int[] rowCountSlot)

--- a/src/main/mondrian/rolap/RolapCell.java
+++ b/src/main/mondrian/rolap/RolapCell.java
@@ -5,10 +5,9 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2005-2005 Julian Hyde
-// Copyright (C) 2005-2013 Pentaho
+// Copyright (C) 2005-2015 Pentaho
 // All Rights Reserved.
 */
-
 package mondrian.rolap;
 
 import mondrian.mdx.*;
@@ -97,11 +96,11 @@ public class RolapCell implements Cell {
         boolean extendedContext)
     {
         return getDrillThroughSQL(
-            new ArrayList<Exp>(), extendedContext);
+            new ArrayList<OlapElement>(), extendedContext);
     }
 
     public String getDrillThroughSQL(
-        List<Exp> fields,
+        List<OlapElement> fields,
         boolean extendedContext)
     {
         if (!MondrianProperties.instance()
@@ -154,7 +153,8 @@ public class RolapCell implements Cell {
                 result.getSlicerAxis());
         DrillThroughCellRequest cellRequest =
             RolapAggregationManager.makeDrillThroughRequest(
-                currentMembers, false, result.getCube(), null);
+                currentMembers, false, result.getCube(),
+                Collections.<OlapElement>emptyList());
         if (cellRequest == null) {
             return -1;
         }
@@ -167,7 +167,7 @@ public class RolapCell implements Cell {
             aggMgr.getDrillThroughSql(
                 cellRequest,
                 starPredicateSlicer,
-                new ArrayList<Exp>(),
+                new ArrayList<OlapElement>(),
                 true);
 
         final SqlStatement stmt =
@@ -452,7 +452,7 @@ public class RolapCell implements Cell {
     public SqlStatement drillThroughInternal(
         int maxRowCount,
         int firstRowOrdinal,
-        List<Exp> fields,
+        List<OlapElement> fields,
         boolean extendedContext,
         Logger logger)
     {

--- a/src/main/mondrian/rolap/agg/AggregationManager.java
+++ b/src/main/mondrian/rolap/agg/AggregationManager.java
@@ -5,18 +5,14 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2001-2005 Julian Hyde
-// Copyright (C) 2005-2014 Pentaho and others
+// Copyright (C) 2005-2015 Pentaho and others
 // All Rights Reserved.
 //
 // jhyde, 30 August, 2001
 */
 package mondrian.rolap.agg;
 
-import mondrian.olap.CacheControl;
-import mondrian.olap.Exp;
-import mondrian.olap.MondrianProperties;
-import mondrian.olap.MondrianServer;
-import mondrian.olap.Util;
+import mondrian.olap.*;
 import mondrian.rolap.*;
 import mondrian.rolap.SqlStatement.Type;
 import mondrian.rolap.aggmatcher.AggStar;
@@ -196,13 +192,14 @@ public class AggregationManager extends RolapAggregationManager {
     public String getDrillThroughSql(
         final DrillThroughCellRequest request,
         final StarPredicate starPredicateSlicer,
-        List<Exp> fields,
+        List<OlapElement> fields,
         final boolean countOnly)
     {
         DrillThroughQuerySpec spec =
             new DrillThroughQuerySpec(
                 request,
                 starPredicateSlicer,
+                fields,
                 countOnly);
         Pair<String, List<SqlStatement.Type>> pair = spec.generateSqlQuery();
 

--- a/src/main/mondrian/rolap/agg/DrillThroughCellRequest.java
+++ b/src/main/mondrian/rolap/agg/DrillThroughCellRequest.java
@@ -1,14 +1,14 @@
 /*
-* This software is subject to the terms of the Eclipse Public License v1.0
-* Agreement, available at the following URL:
-* http://www.eclipse.org/legal/epl-v10.html.
-* You must accept the terms of that agreement to use this software.
-*
-* Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
 */
-
 package mondrian.rolap.agg;
 
+import mondrian.olap.OlapElement;
 import mondrian.rolap.RolapStar;
 
 import java.util.ArrayList;
@@ -27,12 +27,14 @@ public class DrillThroughCellRequest extends CellRequest {
 
     private final List<RolapStar.Measure> drillThroughMeasures =
         new ArrayList<RolapStar.Measure>();
+    private final List<OlapElement> nonApplicableMembers;
 
     public DrillThroughCellRequest(
         RolapStar.Measure measure,
-        boolean extendedContext)
+        boolean extendedContext, List<OlapElement> nonApplicableFields)
     {
         super(measure, extendedContext, true);
+        this.nonApplicableMembers = nonApplicableFields;
     }
 
     public void addDrillThroughColumn(RolapStar.Column column) {
@@ -63,6 +65,10 @@ public class DrillThroughCellRequest extends CellRequest {
 
     public List<RolapStar.Measure> getDrillThroughMeasures() {
         return Collections.unmodifiableList(drillThroughMeasures);
+    }
+
+    public List<OlapElement> getNonApplicableMembers() {
+        return nonApplicableMembers;
     }
 }
 


### PR DESCRIPTION
When Analyzer issues a DT, it includes (by default) a RETURNS clause
including all available members.  In a virtual cube this may include
some non-conforming, inapplicable members.  To address this case,
we now capture the list of inapplicable members so they can be
specially handled.  All inapplicable members result in a placeholder
field in the DT resultset with a value of NULL.