### PR TITLE
[TEST]  Removing invalid assertion that can get hit with nested named sets.

### DIFF
--- a/src/main/mondrian/calc/impl/AbstractEndToEndTupleList.java
+++ b/src/main/mondrian/calc/impl/AbstractEndToEndTupleList.java
@@ -97,7 +97,6 @@ abstract class AbstractEndToEndTupleList extends AbstractTupleList {
     public TupleList withPositionCallback(
         final PositionCallback positionCallback)
     {
-        assert !(backingList() instanceof PositionSensingList);
         return new ListTupleList(
             arity, new PositionSensingList(positionCallback));
     }


### PR DESCRIPTION
 The following query could trip it:

WITH
SET [parentNamedSet] AS '[childNamedSet]'
SET [childNamedSet] AS 'HEAD({[Product].[All Products]})'
SELECT
[parentNamedSet] ON 0
FROM [Sales]

[childNamedSet] is evaluated during evaluation of the parent named
set, which results in a tupleList with position callback.  The
assertion checks that the backing tupleList isn’t one of these
“position callback supporting” tuplelists, but that can happen with
this sort of nesting.