### PR TITLE
Backport of MONDRIAN-2366 - CacheControl.flush(MemberSet) does not flush NativeSet member caches. (5.4 Suite)

### DIFF
--- a/src/main/mondrian/rolap/CacheControlImpl.java
+++ b/src/main/mondrian/rolap/CacheControlImpl.java
@@ -1,12 +1,11 @@
 /*
-* This software is subject to the terms of the Eclipse Public License v1.0
-* Agreement, available at the following URL:
-* http://www.eclipse.org/legal/epl-v10.html.
-* You must accept the terms of that agreement to use this software.
-*
-* Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
 */
-
 package mondrian.rolap;
 
 import mondrian.olap.*;
@@ -623,6 +622,8 @@ public class CacheControlImpl implements CacheControl {
     public void flush(MemberSet memberSet) {
         // REVIEW How is flush(s) different to executing createDeleteCommand(s)?
         synchronized (MEMBER_CACHE_LOCK) {
+            // firstly clear all cache associated with native sets
+            connection.getSchema().getNativeRegistry().flushAllNativeSetCache();
             final List<CellRegion> cellRegionList = new ArrayList<CellRegion>();
             ((MemberSetPlus) memberSet).accept(
                 new MemberSetVisitorImpl() {

--- a/src/main/mondrian/rolap/RolapNativeRegistry.java
+++ b/src/main/mondrian/rolap/RolapNativeRegistry.java
@@ -5,15 +5,15 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2004-2005 TONBELLER AG
-// Copyright (C) 2006-2009 Pentaho and others
+// Copyright (C) 2006-2015 Pentaho and others
 // All Rights Reserved.
 */
-
 package mondrian.rolap;
 
 import mondrian.olap.*;
 
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 
 /**
@@ -27,10 +27,7 @@ public class RolapNativeRegistry extends RolapNative {
 
     public RolapNativeRegistry() {
         super.setEnabled(true);
-
-        /*
-         * Mondrian functions which might be evaluated natively.
-         */
+        // Mondrian functions which might be evaluated natively.
         register("NonEmptyCrossJoin".toUpperCase(), new RolapNativeCrossJoin());
         register("CrossJoin".toUpperCase(), new RolapNativeCrossJoin());
         register("TopCount".toUpperCase(), new RolapNativeTopCount());
@@ -81,6 +78,19 @@ public class RolapNativeRegistry extends RolapNative {
     void useHardCache(boolean hard) {
         for (RolapNative rn : nativeEvaluatorMap.values()) {
             rn.useHardCache(hard);
+        }
+    }
+
+    void flushAllNativeSetCache() {
+        for (String key : nativeEvaluatorMap.keySet()) {
+            RolapNative currentRolapNative = nativeEvaluatorMap.get(key);
+            if (currentRolapNative instanceof RolapNativeSet
+                && currentRolapNative != null)
+            {
+                RolapNativeSet currentRolapNativeSet =
+                    (RolapNativeSet) currentRolapNative;
+                currentRolapNativeSet.flushCache();
+            }
         }
     }
 }

--- a/src/main/mondrian/rolap/RolapNativeSet.java
+++ b/src/main/mondrian/rolap/RolapNativeSet.java
@@ -6,7 +6,7 @@
 //
 // Copyright (C) 2004-2005 TONBELLER AG
 // Copyright (C) 2005-2005 Julian Hyde
-// Copyright (C) 2005-2014 Pentaho and others
+// Copyright (C) 2005-2015 Pentaho and others
 // All Rights Reserved.
 */
 package mondrian.rolap;
@@ -503,6 +503,12 @@ public abstract class RolapNativeSet extends RolapNative {
                 hierarchyReaders.put(hierarchy, memberReader);
             }
             return memberReader;
+        }
+    }
+
+    public void flushCache() {
+        if (cache.size() != 0) {
+            cache.clear();
         }
     }
 }

--- a/src/main/mondrian/rolap/RolapNativeSet.java
+++ b/src/main/mondrian/rolap/RolapNativeSet.java
@@ -507,9 +507,7 @@ public abstract class RolapNativeSet extends RolapNative {
     }
 
     public void flushCache() {
-        if (cache.size() != 0) {
-            cache.clear();
-        }
+        cache.clear();
     }
 }
 

--- a/testsrc/main/mondrian/rolap/CacheControlTest.java
+++ b/testsrc/main/mondrian/rolap/CacheControlTest.java
@@ -1,12 +1,11 @@
 /*
-* This software is subject to the terms of the Eclipse Public License v1.0
-* Agreement, available at the following URL:
-* http://www.eclipse.org/legal/epl-v10.html.
-* You must accept the terms of that agreement to use this software.
-*
-* Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
 */
-
 package mondrian.rolap;
 
 import mondrian.olap.*;
@@ -1308,6 +1307,23 @@ public class CacheControlTest extends FoodMartTestCase {
     // todo: test which tries to constraint on calc member. Should get error.
 
     // todo: test which tries to constrain on member of parent-child hierarchy
+
+    public void testMondrian2366() {
+        String mdx =
+            "select filter( gender.gender.members, measures.[Unit Sales] > 0) on 0 from sales ";
+        mondrian.olap.Result rest = executeQuery(mdx);
+        RolapCube cube = (RolapCube) rest.getQuery().getCube();
+        RolapConnection con = (RolapConnection) rest.getQuery().getConnection();
+        CacheControl cacheControl = con.getCacheControl(null);
+
+        for (RolapHierarchy hier : cube.getHierarchies()) {
+            if (hier.hasAll()) {
+                cacheControl.flush(
+                    cacheControl.createMemberSet(hier.getAllMember(), true));
+            }
+        }
+        executeQuery(mdx);
+    }
 }
 
 // End CacheControlTest.java


### PR DESCRIPTION
@mkambol, here is backport of http://jira.pentaho.com/browse/MONDRIAN-2366 to 3.10.0. Thanks 