### PR TITLE
[MONDRIAN-1495] Allow Aggregate levels to use more attributes from

### DIFF
--- a/src/main/mondrian/olap/Mondrian.xml
+++ b/src/main/mondrian/olap/Mondrian.xml
@@ -1875,9 +1875,25 @@ Revision is $Id$
                 The name of the column mapping to the level name.
             </Doc>
         </Attribute>
+        <Attribute name="ordinalColumn" required="false">
+            <Doc>
+                The ordinal column for this level.
+            </Doc>
+        </Attribute>
+        <Attribute name="captionColumn" required="false">
+            <Doc>
+                The caption column for this level.
+            </Doc>
+        </Attribute>
         <Attribute name="name" required="true">
             <Doc>
                 The name of the Dimension Hierarchy level.
+            </Doc>
+        </Attribute>
+        <Attribute name="nameColumn" required="false">
+            <Doc>
+                The name of the column which holds the user identifier of
+                this level.
             </Doc>
         </Attribute>
         <Attribute name="collapsed" required="false" type="Boolean" default="true">
@@ -1886,6 +1902,7 @@ Revision is $Id$
                 are also present in the aggregation table.
             </Doc>
         </Attribute>
+        <Array name="properties" type="AggLevelProperty" min="0"/>
         <Code>
             public String getNameAttribute() {
                 return name;
@@ -1897,6 +1914,13 @@ Revision is $Id$
                 return collapsed;
             }
         </Code>
+    </Element>
+    <Element type="AggLevelProperty">
+    <Doc>
+        Member property.
+    </Doc>
+        <Attribute name="name"><Doc></Doc></Attribute>
+        <Attribute name="column"><Doc></Doc></Attribute>
     </Element>
 
     <Element type="AggMeasure">

--- a/src/main/mondrian/rolap/RolapLevel.java
+++ b/src/main/mondrian/rolap/RolapLevel.java
@@ -5,10 +5,9 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2001-2005 Julian Hyde
-// Copyright (C) 2005-2013 Pentaho and others
+// Copyright (C) 2005-2015 Pentaho and others
 // All Rights Reserved.
 */
-
 package mondrian.rolap;
 
 import mondrian.olap.*;
@@ -255,7 +254,7 @@ public class RolapLevel extends LevelBase {
         return keyExp;
     }
 
-    MondrianDef.Expression getOrdinalExp() {
+    public MondrianDef.Expression getOrdinalExp() {
         return ordinalExp;
     }
 

--- a/src/main/mondrian/rolap/aggmatcher/DefaultRecognizer.java
+++ b/src/main/mondrian/rolap/aggmatcher/DefaultRecognizer.java
@@ -5,10 +5,9 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2005-2005 Julian Hyde
-// Copyright (C) 2005-2009 Pentaho and others
+// Copyright (C) 2005-2015 Pentaho and others
 // All Rights Reserved.
 */
-
 package mondrian.rolap.aggmatcher;
 
 import mondrian.olap.Hierarchy;
@@ -293,7 +292,7 @@ class DefaultRecognizer extends Recognizer {
                 {
                     collapsed = false;
                 }
-                makeLevel(
+                makeLevelColumnUsage(
                     pair.right,
                     hierarchy,
                     hierarchyUsage,
@@ -301,7 +300,7 @@ class DefaultRecognizer extends Recognizer {
                     getColumnName(pair.left.getKeyExp()),
                     pair.left.getName(),
                     collapsed,
-                    pair.left);
+                    pair.left, null, null, null);
             }
         } finally {
             msgRecorder.popContextName();

--- a/src/main/mondrian/rolap/aggmatcher/JdbcSchema.java
+++ b/src/main/mondrian/rolap/aggmatcher/JdbcSchema.java
@@ -5,10 +5,9 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2005-2005 Julian Hyde
-// Copyright (C) 2005-2013 Pentaho and others
+// Copyright (C) 2005-2015 Pentaho and others
 // All Rights Reserved.
 */
-
 package mondrian.rolap.aggmatcher;
 
 import mondrian.olap.MondrianDef;
@@ -234,6 +233,7 @@ public class JdbcSchema {
         FOREIGN_KEY,
         MEASURE,
         LEVEL,
+        LEVEL_EXTRA,
         FACT_COUNT,
         IGNORE
     }
@@ -361,8 +361,11 @@ public class JdbcSchema {
                 public MondrianDef.Expression joinExp;
                 public String levelColumnName;
 
-                // level
+                // level stuff
                 public RolapStar.Column rColumn;
+                public Column ordinalColumn;
+                public Column captionColumn;
+                public Map<String, Column> properties;
 
                 // agg stuff
                 public boolean collapsed = false;
@@ -377,6 +380,7 @@ public class JdbcSchema {
                  * generation (See AggGen).
                  */
                 public String usagePrefix;
+
 
                 /**
                  * Creates a Usage.
@@ -418,6 +422,44 @@ public class JdbcSchema {
                  */
                 public String getSymbolicName() {
                     return symbolicName;
+                }
+
+                public MondrianDef.Expression getOrdinalExp() {
+                    MondrianDef.Expression ordinalExp = null;
+                    if (ordinalColumn != null) {
+                        ordinalExp =
+                            new MondrianDef.Column(
+                                getTable().getName(), ordinalColumn.getName());
+                    }
+                    return ordinalExp;
+                }
+
+                public MondrianDef.Expression getCaptionExp() {
+                    MondrianDef.Expression captionExp = null;
+                    if (captionColumn != null) {
+                        captionExp =
+                            new MondrianDef.Column(
+                                getTable().getName(), captionColumn.getName());
+                    }
+                    return captionExp;
+                }
+
+                public Map<String, MondrianDef.Expression> getProperties() {
+                    Map<String, MondrianDef.Expression> map =
+                        new HashMap<String, MondrianDef.Expression>();
+                    if (properties == null) {
+                        return map;
+                    }
+                    for (Map.Entry<String, Column> entry
+                        : properties.entrySet())
+                    {
+                        map.put(
+                            entry.getKey(),
+                            new MondrianDef.Column(
+                                getTable().getName(),
+                                entry.getValue().getName()));
+                    }
+                    return Collections.unmodifiableMap(map);
                 }
 
                 /**
@@ -1067,7 +1109,7 @@ public class JdbcSchema {
             }
         }
 
-        private Map<String, Column> getColumnMap() {
+        public Map<String, Column> getColumnMap() {
             if (columnMap == null) {
                 columnMap = new HashMap<String, Column>();
             }

--- a/testsrc/main/mondrian/rolap/aggmatcher/ExplicitRecognizerTest.java
+++ b/testsrc/main/mondrian/rolap/aggmatcher/ExplicitRecognizerTest.java
@@ -1,0 +1,487 @@
+/*
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (C) 2006-2015 Pentaho
+// All Rights Reserved.
+*/
+package mondrian.rolap.aggmatcher;
+
+import mondrian.spi.Dialect;
+import mondrian.test.*;
+
+import java.sql.*;
+
+public class ExplicitRecognizerTest extends AggTableTestCase {
+
+    protected void setUp() throws Exception {
+        super.setUp(); // parent setUp enabled agg
+        propSaver.set(propSaver.properties.EnableNativeCrossJoin, true);
+        propSaver.set(propSaver.properties.EnableNativeNonEmpty, true);
+        propSaver.set(propSaver.properties.GenerateFormattedSql, true);
+        TestContext.instance().flushSchemaCache();
+    }
+
+    @Override
+    protected String getFileName() {
+        return "explicit_aggs.csv";
+    }
+
+    @Override
+    protected TestContext createTestContext() {
+        return getTestContext();
+    }
+
+    public void testExplicitAggExtraColsRequiringJoin() throws SQLException {
+        TestContext testContext = setupMultiColDimCube(
+            "    <AggName name=\"agg_g_ms_pcat_sales_fact_1997\">\n"
+            + "        <AggFactCount column=\"FACT_COUNT\"/>\n"
+            + "        <AggMeasure name=\"[Measures].[Unit Sales]\" column=\"UNIT_SALES\" />\n"
+            + "        <AggLevel name=\"[Gender].[Gender]\" column=\"gender\" />\n"
+            + "        <AggLevel name=\"[TimeExtra].[Year]\" column=\"the_year\" />\n"
+            + "        <AggLevel name=\"[TimeExtra].[Quarter]\" column=\"quarter\" />\n"
+            + "        <AggLevel name=\"[TimeExtra].[Month]\" column=\"month_of_year\" />\n"
+            + "    </AggName>\n",
+            "column=\"the_year\"",
+            "column=\"quarter\"",
+            "column=\"month_of_year\" captionColumn=\"the_month\" ordinalColumn=\"month_of_year\"",
+            "");
+
+        String query =
+            "select {[Measures].[Unit Sales]} on columns, "
+            + "non empty CrossJoin({[TimeExtra].[Month].members},{[Gender].[M]}) on rows "
+            + "from [ExtraCol] ";
+        assertQuerySql(
+            testContext,
+            query,
+            sqlPattern(
+                "select\n"
+                + "    `agg_g_ms_pcat_sales_fact_1997`.`the_year` as `c0`,\n"
+                + "    `agg_g_ms_pcat_sales_fact_1997`.`quarter` as `c1`,\n"
+                + "    `agg_g_ms_pcat_sales_fact_1997`.`month_of_year` as `c2`,\n"
+                + "    `time_by_day`.`the_month` as `c3`,\n"
+                + "    `agg_g_ms_pcat_sales_fact_1997`.`gender` as `c4`\n"
+                + "from\n"
+                + "    `agg_g_ms_pcat_sales_fact_1997` as `agg_g_ms_pcat_sales_fact_1997`,\n"
+                + "    `time_by_day` as `time_by_day`\n"
+                + "where\n"
+                + "    `time_by_day`.`month_of_year` = `agg_g_ms_pcat_sales_fact_1997`.`month_of_year`\n"
+                + "and\n"
+                + "    (`agg_g_ms_pcat_sales_fact_1997`.`gender` = 'M')\n"
+                + "group by\n"
+                + "    `agg_g_ms_pcat_sales_fact_1997`.`the_year`,\n"
+                + "    `agg_g_ms_pcat_sales_fact_1997`.`quarter`,\n"
+                + "    `agg_g_ms_pcat_sales_fact_1997`.`month_of_year`,\n"
+                + "    `time_by_day`.`the_month`,\n"
+                + "    `agg_g_ms_pcat_sales_fact_1997`.`gender`\n"
+                + "order by\n"
+                + "    ISNULL(`agg_g_ms_pcat_sales_fact_1997`.`the_year`) ASC, `agg_g_ms_pcat_sales_fact_1997`.`the_year` ASC,\n"
+                + "    ISNULL(`agg_g_ms_pcat_sales_fact_1997`.`quarter`) ASC, `agg_g_ms_pcat_sales_fact_1997`.`quarter` ASC,\n"
+                + "    ISNULL(`agg_g_ms_pcat_sales_fact_1997`.`month_of_year`) ASC, `agg_g_ms_pcat_sales_fact_1997`.`month_of_year` ASC,\n"
+                + "    ISNULL(`agg_g_ms_pcat_sales_fact_1997`.`gender`) ASC, `agg_g_ms_pcat_sales_fact_1997`.`gender` ASC"));
+        assertQuerySql(
+            testContext,
+            query,
+            sqlPattern(
+                "select\n"
+                + "    `agg_g_ms_pcat_sales_fact_1997`.`the_year` as `c0`,\n"
+                + "    `agg_g_ms_pcat_sales_fact_1997`.`quarter` as `c1`,\n"
+                + "    `agg_g_ms_pcat_sales_fact_1997`.`month_of_year` as `c2`,\n"
+                + "    `agg_g_ms_pcat_sales_fact_1997`.`gender` as `c3`,\n"
+                + "    sum(`agg_g_ms_pcat_sales_fact_1997`.`unit_sales`) as `m0`\n"
+                + "from\n"
+                + "    `agg_g_ms_pcat_sales_fact_1997` as `agg_g_ms_pcat_sales_fact_1997`\n"
+                + "where\n"
+                + "    `agg_g_ms_pcat_sales_fact_1997`.`the_year` = 1997\n"
+                + "and\n"
+                + "    `agg_g_ms_pcat_sales_fact_1997`.`gender` = 'M'\n"
+                + "group by\n"
+                + "    `agg_g_ms_pcat_sales_fact_1997`.`the_year`,\n"
+                + "    `agg_g_ms_pcat_sales_fact_1997`.`quarter`,\n"
+                + "    `agg_g_ms_pcat_sales_fact_1997`.`month_of_year`,\n"
+                + "    `agg_g_ms_pcat_sales_fact_1997`.`gender`"));
+    }
+
+    public void testExplicitForeignKey() {
+        TestContext testContext = setupMultiColDimCube(
+            "    <AggName name=\"agg_c_14_sales_fact_1997\">\n"
+            + "        <AggFactCount column=\"FACT_COUNT\"/>\n"
+            + "        <AggForeignKey factColumn=\"store_id\" aggColumn=\"store_id\" />"
+            + "        <AggMeasure name=\"[Measures].[Unit Sales]\" column=\"unit_sales\" />\n"
+            + "        <AggMeasure name=\"[Measures].[Store Cost]\" column=\"store_cost\" />\n"
+            + "        <AggLevel name=\"[Gender].[Gender]\" column=\"gender\" />\n"
+            + "        <AggLevel name=\"[TimeExtra].[Year]\" column=\"the_year\" />\n"
+            + "        <AggLevel name=\"[TimeExtra].[Quarter]\" column=\"quarter\" />\n"
+            + "        <AggLevel name=\"[TimeExtra].[Month]\" column=\"month_of_year\" />\n"
+            + "    </AggName>\n",
+            "column=\"the_year\"",
+            "column=\"quarter\"",
+            "column=\"month_of_year\" captionColumn=\"the_month\" ordinalColumn=\"month_of_year\"",
+            "");
+
+
+        String query =
+            "select {[Measures].[Unit Sales]} on columns, "
+            + "non empty CrossJoin({[TimeExtra].[Month].members},{[Store].[Store Name].members}) on rows "
+            + "from [ExtraCol] ";
+        // Run the query twice, verifying both the SqlTupleReader and
+        // Segment load queries.
+        assertQuerySql(
+            testContext,
+            query,
+            sqlPattern(
+                "select\n"
+                + "    `agg_c_14_sales_fact_1997`.`the_year` as `c0`,\n"
+                + "    `agg_c_14_sales_fact_1997`.`quarter` as `c1`,\n"
+                + "    `agg_c_14_sales_fact_1997`.`month_of_year` as `c2`,\n"
+                + "    `time_by_day`.`the_month` as `c3`,\n"
+                + "    `store`.`store_country` as `c4`,\n"
+                + "    `store`.`store_state` as `c5`,\n"
+                + "    `store`.`store_city` as `c6`,\n"
+                + "    `store`.`store_name` as `c7`,\n"
+                + "    `store`.`store_street_address` as `c8`\n"
+                + "from\n"
+                + "    `agg_c_14_sales_fact_1997` as `agg_c_14_sales_fact_1997`,\n"
+                + "    `time_by_day` as `time_by_day`,\n"
+                + "    `store` as `store`\n"
+                + "where\n"
+                + "    `time_by_day`.`month_of_year` = `agg_c_14_sales_fact_1997`.`month_of_year`\n"
+                + "and\n"
+                + "    `agg_c_14_sales_fact_1997`.`store_id` = `store`.`store_id`\n"
+                + "group by\n"
+                + "    `agg_c_14_sales_fact_1997`.`the_year`,\n"
+                + "    `agg_c_14_sales_fact_1997`.`quarter`,\n"
+                + "    `agg_c_14_sales_fact_1997`.`month_of_year`,\n"
+                + "    `time_by_day`.`the_month`,\n"
+                + "    `store`.`store_country`,\n"
+                + "    `store`.`store_state`,\n"
+                + "    `store`.`store_city`,\n"
+                + "    `store`.`store_name`,\n"
+                + "    `store`.`store_street_address`\n"
+                + "order by\n"
+                + "    ISNULL(`agg_c_14_sales_fact_1997`.`the_year`) ASC, `agg_c_14_sales_fact_1997`.`the_year` ASC,\n"
+                + "    ISNULL(`agg_c_14_sales_fact_1997`.`quarter`) ASC, `agg_c_14_sales_fact_1997`.`quarter` ASC,\n"
+                + "    ISNULL(`agg_c_14_sales_fact_1997`.`month_of_year`) ASC, `agg_c_14_sales_fact_1997`.`month_of_year` ASC,\n"
+                + "    ISNULL(`store`.`store_country`) ASC, `store`.`store_country` ASC,\n"
+                + "    ISNULL(`store`.`store_state`) ASC, `store`.`store_state` ASC,\n"
+                + "    ISNULL(`store`.`store_city`) ASC, `store`.`store_city` ASC,\n"
+                + "    ISNULL(`store`.`store_name`) ASC, `store`.`store_name` ASC"));
+
+        assertQuerySql(
+            testContext,
+            query,
+            sqlPattern(
+                "select\n"
+                + "    `agg_c_14_sales_fact_1997`.`the_year` as `c0`,\n"
+                + "    `agg_c_14_sales_fact_1997`.`quarter` as `c1`,\n"
+                + "    `agg_c_14_sales_fact_1997`.`month_of_year` as `c2`,\n"
+                + "    `store`.`store_name` as `c3`,\n"
+                + "    sum(`agg_c_14_sales_fact_1997`.`unit_sales`) as `m0`\n"
+                + "from\n"
+                + "    `agg_c_14_sales_fact_1997` as `agg_c_14_sales_fact_1997`,\n"
+                + "    `store` as `store`\n"
+                + "where\n"
+                + "    `agg_c_14_sales_fact_1997`.`the_year` = 1997\n"
+                + "and\n"
+                + "    `agg_c_14_sales_fact_1997`.`store_id` = `store`.`store_id`\n"
+                + "group by\n"
+                + "    `agg_c_14_sales_fact_1997`.`the_year`,\n"
+                + "    `agg_c_14_sales_fact_1997`.`quarter`,\n"
+                + "    `agg_c_14_sales_fact_1997`.`month_of_year`,\n"
+                + "    `store`.`store_name`"));
+    }
+
+
+    public void testExplicitAggOrdinalOnAggTable() throws SQLException {
+        TestContext testContext = setupMultiColDimCube(
+            "    <AggName name=\"exp_agg_test\">\n"
+            + "        <AggFactCount column=\"FACT_COUNT\"/>\n"
+            + "        <AggMeasure name=\"[Measures].[Unit Sales]\" column=\"test_unit_sales\" />\n"
+            + "        <AggLevel name=\"[Gender].[Gender]\" column=\"gender\" />\n"
+            + "        <AggLevel name=\"[TimeExtra].[Year]\" column=\"testyear\" />\n"
+            + "        <AggLevel name=\"[TimeExtra].[Quarter]\" column=\"testqtr\" />\n"
+            + "        <AggLevel name=\"[TimeExtra].[Month]\" column=\"testmonthname\"  ordinalColumn=\"testmonthord\"/>\n"
+            + "    </AggName>\n",
+            "column=\"the_year\"",
+            "column=\"quarter\"",
+            "column=\"the_month\"  ordinalColumn=\"month_of_year\"",
+            "");
+
+        String query =
+            "select {[Measures].[Unit Sales]} on columns, "
+            + "non empty CrossJoin({[TimeExtra].[Month].members},{[Gender].[M]}) on rows "
+            + "from [ExtraCol] ";
+
+        assertQuerySql(
+            testContext,
+            query,
+            sqlPattern(
+                "select\n"
+                + "    `exp_agg_test`.`testyear` as `c0`,\n"
+                + "    `exp_agg_test`.`testqtr` as `c1`,\n"
+                + "    `exp_agg_test`.`testmonthname` as `c2`,\n"
+                + "    `exp_agg_test`.`testmonthord` as `c3`,\n"
+                + "    `exp_agg_test`.`gender` as `c4`\n"
+                + "from\n"
+                + "    `exp_agg_test` as `exp_agg_test`\n"
+                + "where\n"
+                + "    (`exp_agg_test`.`gender` = 'M')\n"
+                + "group by\n"
+                + "    `exp_agg_test`.`testyear`,\n"
+                + "    `exp_agg_test`.`testqtr`,\n"
+                + "    `exp_agg_test`.`testmonthname`,\n"
+                + "    `exp_agg_test`.`testmonthord`,\n"
+                + "    `exp_agg_test`.`gender`\n"
+                + "order by\n"
+                + "    ISNULL(`exp_agg_test`.`testyear`) ASC, `exp_agg_test`.`testyear` ASC,\n"
+                + "    ISNULL(`exp_agg_test`.`testqtr`) ASC, `exp_agg_test`.`testqtr` ASC,\n"
+                + "    ISNULL(`exp_agg_test`.`testmonthord`) ASC, `exp_agg_test`.`testmonthord` ASC,\n"
+                + "    ISNULL(`exp_agg_test`.`gender`) ASC, `exp_agg_test`.`gender` ASC"));
+    }
+
+    public void testExplicitAggCaptionOnAggTable() throws SQLException {
+        TestContext testContext = setupMultiColDimCube(
+            "    <AggName name=\"exp_agg_test\">\n"
+            + "        <AggFactCount column=\"FACT_COUNT\"/>\n"
+            + "        <AggMeasure name=\"[Measures].[Unit Sales]\" column=\"test_unit_sales\" />\n"
+            + "        <AggLevel name=\"[Gender].[Gender]\" column=\"gender\" />\n"
+            + "        <AggLevel name=\"[TimeExtra].[Year]\" column=\"testyear\" />\n"
+            + "        <AggLevel name=\"[TimeExtra].[Quarter]\" column=\"testqtr\" />\n"
+            + "        <AggLevel name=\"[TimeExtra].[Month]\" column=\"testmonthname\"  captionColumn=\"testmonthcap\"/>\n"
+            + "    </AggName>\n",
+            "column=\"the_year\"",
+            "column=\"quarter\"",
+            "column=\"the_month\"  captionColumn=\"month_of_year\"",
+            "");
+
+        String query =
+            "select {[Measures].[Unit Sales]} on columns, "
+            + "non empty CrossJoin({[TimeExtra].[Month].members},{[Gender].[M]}) on rows "
+            + "from [ExtraCol] ";
+
+        assertQuerySql(
+            testContext,
+            query,
+            sqlPattern(
+                "select\n"
+                + "    `exp_agg_test`.`testyear` as `c0`,\n"
+                + "    `exp_agg_test`.`testqtr` as `c1`,\n"
+                + "    `exp_agg_test`.`testmonthname` as `c2`,\n"
+                + "    `exp_agg_test`.`testmonthcap` as `c3`,\n"
+                + "    `exp_agg_test`.`gender` as `c4`\n"
+                + "from\n"
+                + "    `exp_agg_test` as `exp_agg_test`\n"
+                + "where\n"
+                + "    (`exp_agg_test`.`gender` = 'M')\n"
+                + "group by\n"
+                + "    `exp_agg_test`.`testyear`,\n"
+                + "    `exp_agg_test`.`testqtr`,\n"
+                + "    `exp_agg_test`.`testmonthname`,\n"
+                + "    `exp_agg_test`.`testmonthcap`,\n"
+                + "    `exp_agg_test`.`gender`\n"
+                + "order by\n"
+                + "    ISNULL(`exp_agg_test`.`testyear`) ASC, `exp_agg_test`.`testyear` ASC,\n"
+                + "    ISNULL(`exp_agg_test`.`testqtr`) ASC, `exp_agg_test`.`testqtr` ASC,\n"
+                + "    ISNULL(`exp_agg_test`.`testmonthname`) ASC, `exp_agg_test`.`testmonthname` ASC,\n"
+                + "    ISNULL(`exp_agg_test`.`gender`) ASC, `exp_agg_test`.`gender` ASC"));
+    }
+
+    public void testExplicitAggNameColumnOnAggTable() throws SQLException {
+        TestContext testContext = setupMultiColDimCube(
+            "    <AggName name=\"exp_agg_test\">\n"
+            + "        <AggFactCount column=\"FACT_COUNT\"/>\n"
+            + "        <AggMeasure name=\"[Measures].[Unit Sales]\" column=\"test_unit_sales\" />\n"
+            + "        <AggLevel name=\"[Gender].[Gender]\" column=\"gender\" />\n"
+            + "        <AggLevel name=\"[TimeExtra].[Year]\" column=\"testyear\" />\n"
+            + "        <AggLevel name=\"[TimeExtra].[Quarter]\" column=\"testqtr\" />\n"
+            + "        <AggLevel name=\"[TimeExtra].[Month]\" column=\"testmonthname\"  nameColumn=\"testmonthcap\">\n"
+            + "             <AggLevelProperty name='aProperty' column='testmonprop1'  />"
+            + "          </AggLevel>"
+            + "    </AggName>\n",
+            "column=\"the_year\"",
+            "column=\"quarter\"",
+            "column=\"the_month\"  nameColumn=\"month_of_year\"",
+            "<Property name='aProperty' column='fiscal_period' /> ");
+
+        String query =
+            "select {[Measures].[Unit Sales]} on columns, "
+            + "non empty CrossJoin({[TimeExtra].[Month].members},{[Gender].[M]}) on rows "
+            + "from [ExtraCol] ";
+
+        assertQuerySql(
+            testContext,
+            query,
+            sqlPattern(
+                "select\n"
+                + "    `exp_agg_test`.`testyear` as `c0`,\n"
+                + "    `exp_agg_test`.`testqtr` as `c1`,\n"
+                + "    `exp_agg_test`.`testmonthname` as `c2`,\n"
+                + "    `exp_agg_test`.`testmonthcap` as `c3`,\n"
+                + "    `exp_agg_test`.`testmonprop1` as `c4`,\n"
+                + "    `exp_agg_test`.`gender` as `c5`\n"
+                + "from\n"
+                + "    `exp_agg_test` as `exp_agg_test`\n"
+                + "where\n"
+                + "    (`exp_agg_test`.`gender` = 'M')\n"
+                + "group by\n"
+                + "    `exp_agg_test`.`testyear`,\n"
+                + "    `exp_agg_test`.`testqtr`,\n"
+                + "    `exp_agg_test`.`testmonthname`,\n"
+                + "    `exp_agg_test`.`testmonthcap`,\n"
+                + "    `exp_agg_test`.`testmonprop1`,\n"
+                + "    `exp_agg_test`.`gender`\n"
+                + "order by\n"
+                + "    ISNULL(`exp_agg_test`.`testyear`) ASC, `exp_agg_test`.`testyear` ASC,\n"
+                + "    ISNULL(`exp_agg_test`.`testqtr`) ASC, `exp_agg_test`.`testqtr` ASC,\n"
+                + "    ISNULL(`exp_agg_test`.`testmonthname`) ASC, `exp_agg_test`.`testmonthname` ASC,\n"
+                + "    ISNULL(`exp_agg_test`.`gender`) ASC, `exp_agg_test`.`gender` ASC"));
+    }
+
+
+    public void testExplicitAggPropertiesOnAggTable() throws SQLException {
+        TestContext testContext = setupMultiColDimCube(
+            "    <AggName name=\"exp_agg_test_distinct_count\">\n"
+            + "        <AggFactCount column=\"FACT_COUNT\"/>\n"
+            + "        <AggMeasure name=\"[Measures].[Unit Sales]\" column=\"unit_s\" />\n"
+            + "        <AggMeasure name=\"[Measures].[Customer Count]\" column=\"cust_cnt\" />\n"
+            + "        <AggLevel name=\"[TimeExtra].[Year]\" column=\"testyear\" />\n"
+            + "        <AggLevel name=\"[Gender].[Gender]\" column=\"gender\" />\n"
+            + "        <AggLevel name=\"[Store].[Store Country]\" column=\"store_country\" />\n"
+            + "        <AggLevel name=\"[Store].[Store State]\" column=\"store_st\" />\n"
+            + "        <AggLevel name=\"[Store].[Store City]\" column=\"store_cty\" />\n"
+            + "        <AggLevel name=\"[Store].[Store Name]\" column=\"store_name\" >\n"
+            + "           <AggLevelProperty name='Street address' column='store_add' />"
+            + "        </AggLevel>\n"
+            + "    </AggName>\n",
+            "column=\"the_year\"",
+            "column=\"quarter\"",
+            "column=\"month_of_year\" captionColumn=\"the_month\" ordinalColumn=\"month_of_year\"",
+            "");
+
+        String query =
+            "with member measures.propVal as 'Store.CurrentMember.Properties(\"Street Address\")'"
+            + "select { measures.[propVal], measures.[Customer Count], [Measures].[Unit Sales]} on columns, "
+            + "non empty CrossJoin({[Gender].Gender.members},{[Store].[USA].[WA].[Spokane].[Store 16]}) on rows "
+            + "from [ExtraCol]";
+        assertQuerySql(
+            testContext,
+            query,
+            sqlPattern(
+                "select\n"
+                + "    `exp_agg_test_distinct_count`.`gender` as `c0`,\n"
+                + "    `exp_agg_test_distinct_count`.`store_country` as `c1`,\n"
+                + "    `exp_agg_test_distinct_count`.`store_st` as `c2`,\n"
+                + "    `exp_agg_test_distinct_count`.`store_cty` as `c3`,\n"
+                + "    `exp_agg_test_distinct_count`.`store_name` as `c4`,\n"
+                + "    `exp_agg_test_distinct_count`.`store_add` as `c5`\n"
+                + "from\n"
+                + "    `exp_agg_test_distinct_count` as `exp_agg_test_distinct_count`\n"
+                + "where\n"
+                + "    (`exp_agg_test_distinct_count`.`store_name` = 'Store 16')\n"
+                + "group by\n"
+                + "    `exp_agg_test_distinct_count`.`gender`,\n"
+                + "    `exp_agg_test_distinct_count`.`store_country`,\n"
+                + "    `exp_agg_test_distinct_count`.`store_st`,\n"
+                + "    `exp_agg_test_distinct_count`.`store_cty`,\n"
+                + "    `exp_agg_test_distinct_count`.`store_name`,\n"
+                + "    `exp_agg_test_distinct_count`.`store_add`\n"
+                + "order by\n"
+                + "    ISNULL(`exp_agg_test_distinct_count`.`gender`) ASC, `exp_agg_test_distinct_count`.`gender` ASC,\n"
+                + "    ISNULL(`exp_agg_test_distinct_count`.`store_country`) ASC, `exp_agg_test_distinct_count`.`store_country` ASC,\n"
+                + "    ISNULL(`exp_agg_test_distinct_count`.`store_st`) ASC, `exp_agg_test_distinct_count`.`store_st` ASC,\n"
+                + "    ISNULL(`exp_agg_test_distinct_count`.`store_cty`) ASC, `exp_agg_test_distinct_count`.`store_cty` ASC,\n"
+                + "    ISNULL(`exp_agg_test_distinct_count`.`store_name`) ASC, `exp_agg_test_distinct_count`.`store_name` ASC"));
+
+        testContext.assertQueryReturns(
+            "Store Address Property should be '5922 La Salle Ct'",
+            query,
+            "Axis #0:\n"
+            + "{}\n"
+            + "Axis #1:\n"
+            + "{[Measures].[propVal]}\n"
+            + "{[Measures].[Customer Count]}\n"
+            + "{[Measures].[Unit Sales]}\n"
+            + "Axis #2:\n"
+            + "{[Gender].[F], [Store].[USA].[WA].[Spokane].[Store 16]}\n"
+            + "{[Gender].[M], [Store].[USA].[WA].[Spokane].[Store 16]}\n"
+            + "Row #0: 5922 La Salle Ct\n"
+            + "Row #0: 45\n"
+            + "Row #0: 12,068\n"
+            + "Row #1: 5922 La Salle Ct\n"
+            + "Row #1: 39\n"
+            + "Row #1: 11,523\n");
+    }
+
+    private SqlPattern[] sqlPattern(String sql) {
+        return new SqlPattern[]{
+            new SqlPattern(
+                Dialect.DatabaseProduct.MYSQL,
+                sql,
+                sql.length())};
+    }
+
+    private TestContext setupMultiColDimCube(
+        String aggName, String yearCols, String qtrCols, String monthCols,
+        String monthProp)
+    {
+        String cube =
+            "<?xml version=\"1.0\"?>\n"
+            + "<Schema name=\"FoodMart\">\n"
+            + "  <Dimension name=\"Store\">\n"
+            + "    <Hierarchy hasAll=\"true\" primaryKey=\"store_id\">\n"
+            + "      <Table name=\"store\"/>\n"
+            + "      <Level name=\"Store Country\" column=\"store_country\" uniqueMembers=\"true\"/>\n"
+            + "      <Level name=\"Store State\" column=\"store_state\" uniqueMembers=\"true\"/>\n"
+            + "      <Level name=\"Store City\" column=\"store_city\" uniqueMembers=\"false\"/>\n"
+            + "      <Level name=\"Store Name\" column=\"store_name\" uniqueMembers=\"true\">\n"
+            + "        <Property name=\"Street address\" column=\"store_street_address\" type=\"String\"/>\n"
+            + "      </Level>\n"
+            + "    </Hierarchy>\n"
+            + "  </Dimension>\n"
+            + "<Cube name=\"ExtraCol\">\n"
+            + "  <Table name=\"sales_fact_1997\">\n"
+            + "           #AGGNAME# "
+            + "  </Table>"
+            + "  <Dimension name=\"TimeExtra\" foreignKey=\"time_id\">\n"
+            + "    <Hierarchy hasAll=\"false\" primaryKey=\"time_id\">\n"
+            + "      <Table name=\"time_by_day\"/>\n"
+            + "      <Level name=\"Year\" #YEARCOLS#  type=\"Numeric\" uniqueMembers=\"true\""
+            + "          levelType=\"TimeYears\">\n"
+            + "      </Level>\n"
+            + "      <Level name=\"Quarter\" #QTRCOLS#  uniqueMembers=\"false\""
+            + "          levelType=\"TimeQuarters\">\n"
+            + "      </Level>\n"
+            + "      <Level name=\"Month\" #MONTHCOLS# uniqueMembers=\"false\" type=\"Numeric\""
+            + "          levelType=\"TimeMonths\">\n"
+            + "           #MONTHPROP# "
+            + "      </Level>\n"
+            + "    </Hierarchy>\n"
+            + "  </Dimension>\n"
+            + "  <Dimension name=\"Gender\" foreignKey=\"customer_id\">\n"
+            + "    <Hierarchy hasAll=\"true\" primaryKey=\"customer_id\">\n"
+            + "    <Table name=\"customer\"/>\n"
+            + "      <Level name=\"Gender\" column=\"gender\" uniqueMembers=\"true\"/>\n"
+            + "    </Hierarchy>\n"
+            + "  </Dimension>  "
+            + "  <DimensionUsage name=\"Store\" source=\"Store\" foreignKey=\"store_id\"/>"
+            + "<Measure name=\"Unit Sales\" column=\"unit_sales\" aggregator=\"sum\"\n"
+            + "      formatString=\"Standard\" visible=\"false\"/>\n"
+            + "  <Measure name=\"Store Cost\" column=\"store_cost\" aggregator=\"sum\"\n"
+            + "      formatString=\"#,###.00\"/>\n"
+            + "<Measure name=\"Customer Count\" column=\"customer_id\" aggregator=\"distinct-count\" formatString=\"#,###\"/>"
+            + "</Cube>\n"
+            + "</Schema>";
+        cube = cube
+            .replace("#AGGNAME#", aggName)
+            .replace("#YEARCOLS#", yearCols)
+            .replace("#QTRCOLS#", qtrCols)
+            .replace("#MONTHCOLS#", monthCols)
+            .replace("#MONTHPROP#", monthProp);
+        return TestContext.instance().withSchema(cube);
+    }
+
+}
+
+// End ExplicitRecognizerTest.java

--- a/testsrc/main/mondrian/rolap/aggmatcher/explicit_aggs.csv
+++ b/testsrc/main/mondrian/rolap/aggmatcher/explicit_aggs.csv
@@ -1,0 +1,48 @@
+# explicit_aggs.csv
+# @version  $Id:$
+## TableName: exp_agg_test
+## ColumnNames:  testyear,testqtr,testmonthord,testmonthname,testmonthcap,testmonprop1,testmonprop2,gender,test_unit_sales,test_store_cost,fact_count
+## ColumnTypes: INTEGER,VARCHAR(30),INTEGER,VARCHAR(30),VARCHAR(30),VARCHAR(30),VARCHAR(30),VARCHAR(30),INTEGER,DECIMAL(10,4),INTEGER
+## NosOfRows: 12
+1997,Q1,1,January,January-,January-prop1,January-prop2,M,663152,549965.3518,217372
+1997,Q1,2,February,February-,February-prop1,February-prop2,M,598696,500406.3176,196224
+1997,Q1,3,March,March-,March-prop1,March-prop2,M,743628,627702.6878,241676
+1997,Q2,4,April,April-,April-prop1,April-prop2,M,611340,518570.178,200340
+1997,Q2,5,May,May-,May-prop1,May-prop2,M,653790,553017.7482,212536
+1997,Q2,6,June,June-,June-prop1,June-prop2,M,653040,545530.242,211440
+1997,Q3,7,July,July-,July-prop1,July-prop2,M,738854,614466.6922,240002
+1997,Q3,8,August,August-,August-prop1,August-prop2,M,699174,592095.0338,226610
+1997,Q3,9,September,September-,September-prop1,September-prop2,M,603300,514856.136,195720
+1997,Q4,10,October,October-,October-prop1,October-prop2,M,648024,545237.9386,210552
+1997,Q4,11,November,November-,November-prop1,November-prop2,M,777000,653573.166,253140
+1997,Q4,12,December,December-,December-prop1,December-prop2,M,841030,715230.6732,273048
+## TableName:  exp_agg_test_distinct_count
+## ColumnNames:  fact_count,testyear,gender,store_name,store_country,store_st,store_cty,store_add,unit_s,cust_cnt
+## ColumnTypes: INTEGER,INTEGER,VARCHAR(30),VARCHAR(30),VARCHAR(30),VARCHAR(30),VARCHAR(30),VARCHAR(30),INTEGER,INTEGER
+## NosOfRows:  26
+3957,1997,F,Store 11,USA,OR,Portland,5371 Holland Circle,12488,269
+6580,1997,F,Store 13,USA,OR,Salem,5179 Valley Ave,20548,232
+653,1997,F,Store 14,USA,CA,San Francisco,4365 Indigo Ct,1064,146
+4301,1997,F,Store 15,USA,WA,Seattle,5006 Highland Drive,13513,470
+3797,1997,F,Store 16,USA,WA,Spokane,5922 La Salle Ct,12068,45
+5538,1997,F,Store 17,USA,WA,Tacoma,490 Risdon Road,17420,139
+676,1997,F,Store 2,USA,WA,Bellingham,5203 Catanzaro Way,1096,100
+641,1997,F,Store 22,USA,WA,Walla Walla,9606 Julpum Loop,1019,44
+1597,1997,F,Store 23,USA,WA,Yakima,3920 Noah Court,5007,42
+4048,1997,F,Store 24,USA,CA,San Diego,2342 Waltham St.,12835,474
+3753,1997,F,Store 3,USA,WA,Bremerton,1501 Ramsey Circle,11640,87
+3426,1997,F,Store 6,USA,CA,Beverly Hills,5495 Mitchell Canyon Road,10771,519
+3864,1997,F,Store 7,USA,CA,Los Angeles,1077 Wharf Drive,12089,551
+4307,1997,M,Store 11,USA,OR,Portland,5371 Holland Circle,13591,294
+6767,1997,M,Store 13,USA,OR,Salem,5179 Valley Ave,21032,242
+672,1997,M,Store 14,USA,CA,San Francisco,4365 Indigo Ct,1053,150
+3655,1997,M,Store 15,USA,WA,Seattle,5006 Highland Drive,11498,436
+3600,1997,M,Store 16,USA,WA,Spokane,5922 La Salle Ct,11523,39
+5646,1997,M,Store 17,USA,WA,Tacoma,490 Risdon Road,17837,139
+704,1997,M,Store 2,USA,WA,Bellingham,5203 Catanzaro Way,1141,90
+698,1997,M,Store 22,USA,WA,Walla Walla,9606 Julpum Loop,1184,52
+2055,1997,M,Store 23,USA,WA,Yakima,3920 Noah Court,6484,53
+4047,1997,M,Store 24,USA,CA,San Diego,2342 Waltham St.,12800,488
+4123,1997,M,Store 3,USA,WA,Bremerton,1501 Ramsey Circle,12936,92
+3389,1997,M,Store 6,USA,CA,Beverly Hills,5495 Mitchell Canyon Road,10562,540
+4343,1997,M,Store 7,USA,CA,Los Angeles,1077 Wharf Drive,13574,596

--- a/testsrc/main/mondrian/test/Main.java
+++ b/testsrc/main/mondrian/test/Main.java
@@ -365,6 +365,7 @@ public class Main extends TestSuite {
             addTest(suite, FastBatchingCellReaderTest.class);
             addTest(suite, SqlQueryTest.class);
             addTest(suite, CodeSetTest.class);
+            addTest(suite, ExplicitRecognizerTest.class);
 
             if (MondrianProperties.instance().EnableNativeCrossJoin.get()) {
                 addTest(suite, BatchedFillTest.class, "suite");


### PR DESCRIPTION
hierarchy's levels so to avoid joins to the dimension tables

This change introduces support for extra level columns when using an
explicitly defined aggregate level.  These columns can be defined by
adding ordinalColumn and captionColumn attributes on an <AggLevel>, as
well as nesting <AggLevelProperties> under an <AggLevel>.  When
constructing SqlTupleReader queries to pull level metadata we'll now
check whether any "extra" columns have a mapping to the aggregate
table.  If not, the old behavior of joining agg table to dimension
table will be used as a fall back.