### PR TITLE
[MONDRIAN-2403] Severe performance issue with reports containing count

### DIFF
--- a/src/main/mondrian/rolap/CompoundPredicateInfo.java
+++ b/src/main/mondrian/rolap/CompoundPredicateInfo.java
@@ -1,0 +1,353 @@
+/*
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (C) 2005-2015 Pentaho and others
+// All Rights Reserved.
+//
+*/
+package mondrian.rolap;
+
+import mondrian.olap.Member;
+import mondrian.olap.fun.VisualTotalsFunDef;
+import mondrian.rolap.agg.OrPredicate;
+import mondrian.rolap.agg.ValueColumnPredicate;
+import mondrian.rolap.sql.SqlQuery;
+import mondrian.util.Pair;
+
+import java.util.*;
+
+
+/**
+ * Constructs a Pair<BitKey, StarPredicate> based on an tuple list and
+ * measure, along with the string representation of the predicate.
+ * Also sets the isSatisfiable flag based on whether a predicate
+ * is compatible with the measure.
+ *
+ * This logic was extracted from RolapAggregationManager and AggregationKey.
+ */
+public class CompoundPredicateInfo {
+
+    private final Pair<BitKey, StarPredicate> predicate;
+    private final String predicateString;
+    private final RolapMeasure measure;
+    private boolean satisfiable = true;
+
+    public CompoundPredicateInfo(
+        List<List<Member>> tupleList, RolapMeasure measure)
+    {
+        this.predicate = predicateFromTupleList(tupleList, measure);
+        this.predicateString = getPredicateString(
+            getStar(measure), getPredicate());
+        this.measure = measure;
+    }
+
+    public StarPredicate getPredicate() {
+        return predicate == null ? null : predicate.right;
+    }
+
+    public BitKey getBitKey() {
+        return predicate == null ? null : predicate.left;
+    }
+
+    public String getPredicateString() {
+        return predicateString;
+    }
+
+    public boolean isSatisfiable() {
+        return satisfiable;
+    }
+
+    public RolapCube getCube() {
+        return measure.isCalculated() ? null
+            : ((RolapStoredMeasure)measure).getCube();
+    }
+    /**
+     * Returns a string representation of the predicate
+     */
+    public static String getPredicateString(
+        RolapStar star, StarPredicate predicate)
+    {
+        if (star == null || predicate == null) {
+            return null;
+        }
+        final StringBuilder buf = new StringBuilder();
+        SqlQuery query =
+            new SqlQuery(
+                star.getSqlQueryDialect());
+        buf.setLength(0);
+        predicate.toSql(query, buf);
+        return buf.toString();
+    }
+
+    private static RolapStar getStar(RolapMeasure measure) {
+        if (measure.isCalculated()) {
+            return null;
+        }
+        final RolapStoredMeasure storedMeasure =
+            (RolapStoredMeasure) measure;
+        final RolapStar.Measure starMeasure =
+            (RolapStar.Measure) storedMeasure.getStarMeasure();
+        assert starMeasure != null;
+        return starMeasure.getStar();
+    }
+
+    private Pair<BitKey, StarPredicate> predicateFromTupleList(
+        List<List<Member>> tupleList, RolapMeasure measure)
+    {
+        if (measure.isCalculated()) {
+            // need a base measure to build predicates
+            return null;
+        }
+        RolapCube cube = ((RolapStoredMeasure)measure).getCube();
+
+        BitKey compoundBitKey;
+        StarPredicate compoundPredicate;
+        Map<BitKey, List<RolapCubeMember[]>> compoundGroupMap;
+        boolean unsatisfiable;
+        int starColumnCount = getStar(measure).getColumnCount();
+
+        compoundBitKey = BitKey.Factory.makeBitKey(starColumnCount);
+        compoundBitKey.clear();
+        compoundGroupMap =
+            new LinkedHashMap<BitKey, List<RolapCubeMember[]>>();
+        unsatisfiable =
+            makeCompoundGroup(
+                starColumnCount,
+                cube,
+                tupleList,
+                compoundGroupMap);
+
+        if (unsatisfiable) {
+            satisfiable = false;
+            return null;
+        }
+        compoundPredicate =
+            makeCompoundPredicate(compoundGroupMap, cube);
+        if (compoundPredicate != null) {
+            for (BitKey bitKey : compoundGroupMap.keySet()) {
+                compoundBitKey = compoundBitKey.or(bitKey);
+            }
+        }
+        return  Pair.of(compoundBitKey, compoundPredicate);
+    }
+
+    /**
+     * Groups members (or tuples) from the same compound (i.e. hierarchy) into
+     * groups that are constrained by the same set of columns.
+     *
+     * <p>E.g.
+     *
+     * <pre>Members
+     *     [USA].[CA],
+     *     [Canada].[BC],
+     *     [USA].[CA].[San Francisco],
+     *     [USA].[OR].[Portland]</pre>
+     *
+     * will be grouped into
+     *
+     * <pre>Group 1:
+     *     {[USA].[CA], [Canada].[BC]}
+     * Group 2:
+     *     {[USA].[CA].[San Francisco], [USA].[OR].[Portland]}</pre>
+     *
+     * <p>This helps with generating optimal form of sql.
+     *
+     * <p>In case of aggregating over a list of tuples, similar logic also
+     * applies.
+     *
+     * <p>For example:
+     *
+     * <pre>Tuples:
+     *     ([Gender].[M], [Store].[USA].[CA])
+     *     ([Gender].[F], [Store].[USA].[CA])
+     *     ([Gender].[M], [Store].[USA])
+     *     ([Gender].[F], [Store].[Canada])</pre>
+     *
+     * will be grouped into
+     *
+     * <pre>Group 1:
+     *     {([Gender].[M], [Store].[USA].[CA]),
+     *      ([Gender].[F], [Store].[USA].[CA])}
+     * Group 2:
+     *     {([Gender].[M], [Store].[USA]),
+     *      ([Gender].[F], [Store].[Canada])}</pre>
+     *
+     * <p>This function returns a boolean value indicating if any constraint
+     * can be created from the aggregationList. It is possible that only part
+     * of the aggregationList can be applied, which still leads to a (partial)
+     * constraint that is represented by the compoundGroupMap.
+     */
+    private boolean makeCompoundGroup(
+        int starColumnCount,
+        RolapCube baseCube,
+        List<List<Member>> aggregationList,
+        Map<BitKey, List<RolapCubeMember[]>> compoundGroupMap)
+    {
+        // The more generalized aggregation as aggregating over tuples.
+        // The special case is a tuple defined by only one member.
+        int unsatisfiableTupleCount = 0;
+        for (List<Member> aggregation : aggregationList) {
+            if (!(aggregation.size() > 0
+                && (aggregation.get(0) instanceof RolapCubeMember
+                || aggregation.get(0) instanceof
+                VisualTotalsFunDef.VisualTotalMember)))
+            {
+                ++unsatisfiableTupleCount;
+                continue;
+            }
+
+            BitKey bitKey = BitKey.Factory.makeBitKey(starColumnCount);
+            RolapCubeMember[] tuple;
+
+            tuple = new RolapCubeMember[aggregation.size()];
+            int i = 0;
+            for (Member member : aggregation) {
+                if (member instanceof VisualTotalsFunDef.VisualTotalMember) {
+                    tuple[i] = (RolapCubeMember)
+                        ((VisualTotalsFunDef.VisualTotalMember) member)
+                            .getMember();
+                } else {
+                    tuple[i] = (RolapCubeMember)member;
+                }
+                i++;
+            }
+
+            boolean tupleUnsatisfiable = false;
+            for (RolapCubeMember member : tuple) {
+                // Tuple cannot be constrained if any of the member cannot be.
+                tupleUnsatisfiable =
+                    makeCompoundGroupForMember(member, baseCube, bitKey);
+                if (tupleUnsatisfiable) {
+                    // If this tuple is unsatisfiable, skip it and try to
+                    // constrain the next tuple.
+                    unsatisfiableTupleCount ++;
+                    break;
+                }
+            }
+
+            if (!tupleUnsatisfiable && !bitKey.isEmpty()) {
+                // Found tuple(columns) to constrain,
+                // now add it to the compoundGroupMap
+                addTupleToCompoundGroupMap(tuple, bitKey, compoundGroupMap);
+            }
+        }
+        return (unsatisfiableTupleCount == aggregationList.size());
+    }
+
+    private void addTupleToCompoundGroupMap(
+        RolapCubeMember[] tuple,
+        BitKey bitKey,
+        Map<BitKey, List<RolapCubeMember[]>> compoundGroupMap)
+    {
+        List<RolapCubeMember[]> compoundGroup = compoundGroupMap.get(bitKey);
+        if (compoundGroup == null) {
+            compoundGroup = new ArrayList<RolapCubeMember[]>();
+            compoundGroupMap.put(bitKey, compoundGroup);
+        }
+        compoundGroup.add(tuple);
+    }
+
+    private boolean makeCompoundGroupForMember(
+        RolapCubeMember member,
+        RolapCube baseCube,
+        BitKey bitKey)
+    {
+        RolapCubeMember levelMember = member;
+        boolean memberUnsatisfiable = false;
+        while (levelMember != null) {
+            RolapCubeLevel level = levelMember.getLevel();
+            // Only need to constrain the nonAll levels
+            if (!level.isAll()) {
+                RolapStar.Column column = level.getBaseStarKeyColumn(baseCube);
+                if (column != null) {
+                    bitKey.set(column.getBitPosition());
+                } else {
+                    // One level in a member causes the member to be
+                    // unsatisfiable.
+                    memberUnsatisfiable = true;
+                    break;
+                }
+            }
+
+            levelMember = levelMember.getParentMember();
+        }
+        return memberUnsatisfiable;
+    }
+
+    private StarPredicate makeCompoundPredicate(
+        Map<BitKey, List<RolapCubeMember[]>> compoundGroupMap,
+        RolapCube baseCube)
+    {
+        List<StarPredicate> compoundPredicateList =
+            new ArrayList<StarPredicate> ();
+        for (List<RolapCubeMember[]> group : compoundGroupMap.values()) {
+            // e.g {[USA].[CA], [Canada].[BC]}
+            StarPredicate compoundGroupPredicate = null;
+            for (RolapCubeMember[] tuple : group) {
+                // [USA].[CA]
+                StarPredicate tuplePredicate = null;
+
+                for (RolapCubeMember member : tuple) {
+                    tuplePredicate = makeCompoundPredicateForMember(
+                        member, baseCube, tuplePredicate);
+                }
+                if (tuplePredicate != null) {
+                    if (compoundGroupPredicate == null) {
+                        compoundGroupPredicate = tuplePredicate;
+                    } else {
+                        compoundGroupPredicate =
+                            compoundGroupPredicate.or(tuplePredicate);
+                    }
+                }
+            }
+
+            if (compoundGroupPredicate != null) {
+                // Sometimes the compound member list does not constrain any
+                // columns; for example, if only AllLevel is present.
+                compoundPredicateList.add(compoundGroupPredicate);
+            }
+        }
+
+        StarPredicate compoundPredicate = null;
+
+        if (compoundPredicateList.size() > 1) {
+            compoundPredicate = new OrPredicate(compoundPredicateList);
+        } else if (compoundPredicateList.size() == 1) {
+            compoundPredicate = compoundPredicateList.get(0);
+        }
+
+        return compoundPredicate;
+    }
+
+    private StarPredicate makeCompoundPredicateForMember(
+        RolapCubeMember member,
+        RolapCube baseCube,
+        StarPredicate memberPredicate)
+    {
+        while (member != null) {
+            RolapCubeLevel level = member.getLevel();
+            if (!level.isAll()) {
+                RolapStar.Column column = level.getBaseStarKeyColumn(baseCube);
+                if (memberPredicate == null) {
+                    memberPredicate =
+                        new ValueColumnPredicate(column, member.getKey());
+                } else {
+                    memberPredicate =
+                        memberPredicate.and(
+                            new ValueColumnPredicate(column, member.getKey()));
+                }
+            }
+            // Don't need to constrain USA if CA is unique
+            if (member.getLevel().isUnique()) {
+                break;
+            }
+            member = member.getParentMember();
+        }
+        return memberPredicate;
+    }
+}
+
+// End CompoundPredicateInfo.java

--- a/src/main/mondrian/rolap/FastBatchingCellReader.java
+++ b/src/main/mondrian/rolap/FastBatchingCellReader.java
@@ -5,7 +5,7 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2004-2005 Julian Hyde
-// Copyright (C) 2005-2014 Pentaho and others
+// Copyright (C) 2005-2015 Pentaho and others
 // All Rights Reserved.
 */
 package mondrian.rolap;
@@ -629,9 +629,7 @@ class BatchLoader {
         final Map<String, Comparable> mappedCellValues =
             request.getMappedCellValues();
         final List<String> compoundPredicates =
-            AggregationKey.getCompoundPredicateStringList(
-                key.getStar(),
-                key.getCompoundPredicateList());
+            request.getCompoundPredicateStrings();
 
         for (SegmentHeader header : cacheHeaders) {
             if (SegmentCacheIndexImpl.matches(
@@ -727,9 +725,7 @@ class BatchLoader {
                     star.getFactTable().getAlias(),
                     request.getConstrainedColumnsBitKey(),
                     mappedCellValues,
-                    AggregationKey.getCompoundPredicateStringList(
-                        star,
-                        key.getCompoundPredicateList()));
+                    request.getCompoundPredicateStrings());
             if (!rollup.isEmpty()) {
                 rollups.add(
                     new RollupInfo(

--- a/src/main/mondrian/rolap/RolapEvaluator.java
+++ b/src/main/mondrian/rolap/RolapEvaluator.java
@@ -17,10 +17,10 @@ import mondrian.calc.ParameterSlot;
 import mondrian.calc.TupleList;
 import mondrian.calc.impl.DelegatingTupleList;
 import mondrian.olap.*;
-import mondrian.olap.fun.FunUtil;
+import mondrian.olap.fun.*;
 import mondrian.server.Statement;
 import mondrian.spi.Dialect;
-import mondrian.util.Format;
+import mondrian.util.*;
 
 import org.apache.log4j.Logger;
 
@@ -94,6 +94,8 @@ public class RolapEvaluator implements Evaluator {
      */
     protected final List<List<List<Member>>> aggregationLists;
 
+    protected CompoundPredicateInfo slicerPredicateInfo;
+
     private final List<Member> slicerMembers;
 
     // slicer tuples and extra info
@@ -114,6 +116,10 @@ public class RolapEvaluator implements Evaluator {
      */
     public Set<Exp> getActiveNativeExpansions() {
         return root.activeNativeExpansions;
+    }
+
+    public CompoundPredicateInfo getSlicerPredicateInfo() {
+        return slicerPredicateInfo;
     }
 
     /**
@@ -157,8 +163,10 @@ public class RolapEvaluator implements Evaluator {
         calculationCount = parent.calculationCount;
         slicerMembers = new ArrayList<Member>(parent.slicerMembers);
         slicerTuples = parent.slicerTuples;
+        slicerPredicateInfo = parent.slicerPredicateInfo;
         disjointSlicerTuple = parent.disjointSlicerTuple;
         multiLevelSlicerTuple = parent.multiLevelSlicerTuple;
+        expandingMember = parent.expandingMember;
 
         commands = new Object[10];
         commands[0] = Command.SAVEPOINT; // sentinel
@@ -171,6 +179,12 @@ public class RolapEvaluator implements Evaluator {
             aggregationLists =
                 new ArrayList<List<List<Member>>>(parent.aggregationLists);
         }
+        //compoundPredicates.addAll(parent.compoundPredicates);
+
+        if (parent.slicerPredicateInfo != null) {
+            this.slicerPredicateInfo = parent.slicerPredicateInfo;
+        }
+
         if (aggregationList != null) {
             if (aggregationLists == null) {
                 aggregationLists = new ArrayList<List<List<Member>>>();
@@ -181,10 +195,11 @@ public class RolapEvaluator implements Evaluator {
                 setContext(member.getHierarchy().getAllMember());
             }
         }
-        this.aggregationLists = aggregationLists;
-
-        expandingMember = parent.expandingMember;
+        this.aggregationLists = aggregationLists == null
+            ? Collections.<List<List<Member>>>emptyList()
+            : Collections.unmodifiableList(aggregationLists);
     }
+
 
     /**
      * Creates a root evaluator.
@@ -199,7 +214,7 @@ public class RolapEvaluator implements Evaluator {
         nonEmpty = false;
         nativeEnabled =
             MondrianProperties.instance().EnableNativeNonEmpty.get()
-            || MondrianProperties.instance().EnableNativeCrossJoin.get();
+                || MondrianProperties.instance().EnableNativeCrossJoin.get();
         evalAxes = false;
         cellReader = null;
         currentMembers = root.defaultMembers.clone();
@@ -515,6 +530,8 @@ public class RolapEvaluator implements Evaluator {
             disjointSlicerTuple = SqlConstraintUtils.isDisjointTuple(tuples);
             multiLevelSlicerTuple =
               SqlConstraintUtils.hasMultipleLevelSlicer(this);
+            slicerPredicateInfo = new CompoundPredicateInfo(
+                tuples, (RolapMeasure)currentMembers[0]);
         } else {
             disjointSlicerTuple = false;
             multiLevelSlicerTuple = false;

--- a/src/main/mondrian/rolap/agg/AggregationKey.java
+++ b/src/main/mondrian/rolap/agg/AggregationKey.java
@@ -5,10 +5,9 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2005-2005 Julian Hyde
-// Copyright (C) 2005-2012 Pentaho and others
+// Copyright (C) 2005-2015 Pentaho and others
 // All Rights Reserved.
 */
-
 package mondrian.rolap.agg;
 
 import mondrian.olap.Util;
@@ -189,33 +188,6 @@ public class AggregationKey
      */
     public List<StarPredicate> getCompoundPredicateList() {
         return compoundPredicateList;
-    }
-
-    /**
-     * Returns a list of compound predicates, expressed as SQL strings.
-     *
-     * @param star Star
-     * @param compoundPredicateList Predicate list
-     * @return list of predicate strings
-     */
-    public static List<String> getCompoundPredicateStringList(
-        RolapStar star,
-        List<StarPredicate> compoundPredicateList)
-    {
-        if (compoundPredicateList.isEmpty()) {
-            return Collections.emptyList();
-        }
-        final List<String> cp = new ArrayList<String>();
-        final StringBuilder buf = new StringBuilder();
-        for (StarPredicate compoundPredicate : compoundPredicateList) {
-            buf.setLength(0);
-            SqlQuery query =
-                new SqlQuery(
-                    star.getSqlQueryDialect());
-            compoundPredicate.toSql(query, buf);
-            cp.add(buf.toString());
-        }
-        return cp;
     }
 }
 

--- a/src/main/mondrian/rolap/agg/CellRequest.java
+++ b/src/main/mondrian/rolap/agg/CellRequest.java
@@ -5,12 +5,11 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2002-2005 Julian Hyde
-// Copyright (C) 2005-2012 Pentaho and others
+// Copyright (C) 2005-2015 Pentaho and others
 // All Rights Reserved.
 //
 // jhyde, 21 March, 2002
 */
-
 package mondrian.rolap.agg;
 
 import mondrian.rolap.*;
@@ -29,14 +28,12 @@ public class CellRequest {
     public final boolean extendedContext;
     public final boolean drillThrough;
 
-    /*
-     * Sparsely populated array of column predicates.  Each predicate will
-     * be located according to the bitPosition of the column to which it
-     * corresponds.  This costs a little memory in terms of unused array
-     * slots, but avoids the need to explicitly sort the column predicates
-     * into a canonical order. There aren't usually a lot of predicates to
-     * sort, but that time adds up quickly.
-     */
+     // Sparsely populated array of column predicates.  Each predicate will
+     // be located according to the bitPosition of the column to which it
+     // corresponds.  This costs a little memory in terms of unused array
+     // slots, but avoids the need to explicitly sort the column predicates
+     // into a canonical order. There aren't usually a lot of predicates to
+     // sort, but that time adds up quickly.
     private StarColumnPredicate[] sparseColumnPredicateList;
 
     /**
@@ -69,10 +66,8 @@ public class CellRequest {
      */
     private RolapStar star = null;
 
-    /*
-     * Array of column values;
-     * Not used to represent the compound members along one or more dimensions.
-     */
+    // Array of column values;
+    // Not used to represent the compound members along one or more dimensions.
     private Object[] singleValues;
 
     /**
@@ -119,6 +114,14 @@ public class CellRequest {
      * comparison with maps of other requests and with existing segments.</p>
      */
     private SortedMap<BitKey, StarPredicate> compoundPredicateMap = null;
+
+
+    /**
+     * List of string representations of the compound predicates contained
+     * in compoundPredicateMap, if present.
+     */
+    private List<String> compoundPredicateStrings = null;
+
 
     /**
      * Whether the request is impossible to satisfy. This is set to 'true' if
@@ -226,6 +229,16 @@ public class CellRequest {
         compoundPredicateMap.put(compoundBitKey, compoundPredicate);
     }
 
+
+    public void addPredicateString(
+        String predicateString)
+    {
+        if (compoundPredicateStrings == null) {
+            compoundPredicateStrings = new ArrayList<String>();
+        }
+        compoundPredicateStrings.add(predicateString);
+    }
+
     /**
      * Returns the measure of this cell request.
      *
@@ -264,6 +277,24 @@ public class CellRequest {
      */
     SortedMap<BitKey, StarPredicate> getCompoundPredicateMap() {
         return compoundPredicateMap;
+    }
+
+    public List<String> getCompoundPredicateStrings() {
+        if (compoundPredicateStrings != null) {
+            return Collections.unmodifiableList(compoundPredicateStrings);
+        }
+        if (compoundPredicateMap != null) {
+            List<String> stringPredicates = new ArrayList<String>();
+            for (StarPredicate predicate : compoundPredicateMap.values()) {
+                stringPredicates.add(
+                    CompoundPredicateInfo.getPredicateString(
+                        measure.getStar(), predicate));
+            }
+            compoundPredicateStrings =
+                Collections.unmodifiableList(stringPredicates);
+            return compoundPredicateStrings;
+        }
+        return Collections.emptyList();
     }
 
     /**

--- a/src/main/mondrian/rolap/agg/SegmentCacheManager.java
+++ b/src/main/mondrian/rolap/agg/SegmentCacheManager.java
@@ -4,7 +4,7 @@
 // http://www.eclipse.org/legal/epl-v10.html.
 // You must accept the terms of that agreement to use this software.
 //
-// Copyright (c) 2002-2014 Pentaho Corporation.
+// Copyright (c) 2002-2015 Pentaho Corporation.
 // All Rights Reserved.
 */
 package mondrian.rolap.agg;
@@ -243,7 +243,7 @@ public class SegmentCacheManager {
      */
     public final ExecutorService sqlExecutor =
         Util.getExecutorService(
-             // We use the same value for coreSize and maxSize
+            // We use the same value for coreSize and maxSize
             // because that's the behavior we want. All extra
             // tasks will be put on an unbounded queue.
             MondrianProperties.instance()
@@ -1450,9 +1450,7 @@ public class SegmentCacheManager {
                         star.getFactTable().getAlias(),
                         request.getConstrainedColumnsBitKey(),
                         request.getMappedCellValues(),
-                        AggregationKey.getCompoundPredicateStringList(
-                            star,
-                            key.getCompoundPredicateList()));
+                        request.getCompoundPredicateStrings());
 
             final Map<SegmentHeader, Future<SegmentBody>> headerMap =
                 new HashMap<SegmentHeader, Future<SegmentBody>>();

--- a/src/main/mondrian/rolap/cache/SegmentCacheIndexImpl.java
+++ b/src/main/mondrian/rolap/cache/SegmentCacheIndexImpl.java
@@ -4,7 +4,7 @@
 // http://www.eclipse.org/legal/epl-v10.html.
 // You must accept the terms of that agreement to use this software.
 //
-// Copyright (c) 2002-2014 Pentaho Corporation.
+// Copyright (c) 2002-2015 Pentaho Corporation.
 // All Rights Reserved.
 */
 package mondrian.rolap.cache;
@@ -96,9 +96,7 @@ public class SegmentCacheIndexImpl implements SegmentCacheIndex {
             request.getMeasure().getCubeName(),
             request.getMeasure().getStar().getFactTable().getAlias(),
             request.getMeasure().getName(),
-            AggregationKey.getCompoundPredicateStringList(
-                key.getStar(),
-                key.getCompoundPredicateList()));
+            request.getCompoundPredicateStrings());
     }
 
     public List<SegmentHeader> locate(

--- a/testsrc/main/mondrian/rolap/BatchTestCase.java
+++ b/testsrc/main/mondrian/rolap/BatchTestCase.java
@@ -681,7 +681,6 @@ public class BatchTestCase extends FoodMartTestCase {
         request.addAggregateList(
             aggConstraint.getBitKey(star),
             aggConstraint.toPredicate(star));
-
         return request;
     }
 

--- a/testsrc/main/mondrian/rolap/FastBatchingCellReaderTest.java
+++ b/testsrc/main/mondrian/rolap/FastBatchingCellReaderTest.java
@@ -1722,6 +1722,9 @@ public class FastBatchingCellReaderTest extends BatchTestCase {
      * loading and using the aggregate function in the slicer.
      */
     public void testAggregateDistinctCount5() {
+        // make sure tuple optimization will be used
+        propSaver.set(propSaver.properties.MaxConstraints, 2);
+
         String query =
             "With "
             + "Set [Products] as "

--- a/testsrc/main/mondrian/rolap/RolapEvaluatorTest.java
+++ b/testsrc/main/mondrian/rolap/RolapEvaluatorTest.java
@@ -1,0 +1,46 @@
+/*
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (c) 2002-2015 Pentaho Corporation.
+// All Rights Reserved.
+*/
+package mondrian.rolap;
+
+import mondrian.test.FoodMartTestCase;
+
+public class RolapEvaluatorTest extends FoodMartTestCase {
+
+    public void testGetSlicerPredicateInfo() throws Exception {
+        RolapResult result = (RolapResult) executeQuery(
+            "select  from sales "
+            + "WHERE {[Time].[1997].Q1, [Time].[1997].Q2} "
+            + "* { Store.[USA].[CA], Store.[USA].[WA]}");
+        RolapEvaluator evalulator = (RolapEvaluator) result.getRootEvaluator();
+        final CompoundPredicateInfo slicerPredicateInfo =
+            evalulator.getSlicerPredicateInfo();
+        assertEquals(
+            "(((`store`.`store_state`, `time_by_day`.`the_year`, `time_by_day`.`quarter`) in "
+            + "(('CA', 1997, 'Q1'), ('WA', 1997, 'Q1'), ('CA', 1997, 'Q2'), ('WA', 1997, 'Q2'))))",
+            slicerPredicateInfo.getPredicateString());
+        assertTrue(slicerPredicateInfo.isSatisfiable());
+    }
+
+    public void testSlicerPredicateUnsatisfiable() {
+        assertQueryReturns(
+            "select measures.[Customer Count] on 0 from [warehouse and sales] "
+            + "WHERE {[Time].[1997].Q1, [Time].[1997].Q2} "
+            + "*{[Warehouse].[USA].[CA], Warehouse.[USA].[WA]}", "");
+        RolapResult result = (RolapResult) executeQuery(
+            "select  from [warehouse and sales] "
+            + "WHERE {[Time].[1997].Q1, [Time].[1997].Q2} "
+            + "* Head([Warehouse].[Country].members, 2)");
+        RolapEvaluator evalulator = (RolapEvaluator) result.getRootEvaluator();
+        assertFalse(evalulator.getSlicerPredicateInfo().isSatisfiable());
+        assertNull(evalulator.getSlicerPredicateInfo().getPredicate());
+    }
+}
+
+// End RolapEvaluatorTest.java

--- a/testsrc/main/mondrian/rolap/agg/AggregationOnDistinctCountMeasuresTest.java
+++ b/testsrc/main/mondrian/rolap/agg/AggregationOnDistinctCountMeasuresTest.java
@@ -4,7 +4,7 @@
 // http://www.eclipse.org/legal/epl-v10.html.
 // You must accept the terms of that agreement to use this software.
 //
-// Copyright (c) 2002-2014 Pentaho Corporation..  All rights reserved.
+// Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
 */
 package mondrian.rolap.agg;
 
@@ -106,6 +106,9 @@ public class AggregationOnDistinctCountMeasuresTest extends BatchTestCase {
     }
 
     public void testCrossJoinMembersWithASingleMember() {
+        // make sure tuple optimization will be used
+        propSaver.set(propSaver.properties.MaxConstraints, 1);
+
         String query =
             "WITH MEMBER GENDER.X AS 'AGGREGATE({[GENDER].[GENDER].members} * "
             + "{[STORE].[ALL STORES].[USA].[CA]})', solve_order=100 "
@@ -122,15 +125,6 @@ public class AggregationOnDistinctCountMeasuresTest extends BatchTestCase {
         assertQueryReturns(query, result);
 
         // Check aggregate loading sql pattern
-        String derbySql =
-            "select \"time_by_day\".\"the_year\" as \"c0\", "
-            + "count(distinct \"sales_fact_1997\".\"customer_id\") as \"m0\" "
-            + "from \"time_by_day\" as \"time_by_day\", \"sales_fact_1997\" as \"sales_fact_1997\", \"store\" as \"store\" "
-            + "where \"sales_fact_1997\".\"time_id\" = \"time_by_day\".\"time_id\" "
-            + "and \"time_by_day\".\"the_year\" = 1997 "
-            + "and \"sales_fact_1997\".\"store_id\" = \"store\".\"store_id\" and \"store\".\"store_state\" = 'CA' "
-            + "group by \"time_by_day\".\"the_year\"";
-
         String mysqlSql =
             "select `time_by_day`.`the_year` as `c0`, "
             + "count(distinct `sales_fact_1997`.`customer_id`) as `m0` "
@@ -149,7 +143,6 @@ public class AggregationOnDistinctCountMeasuresTest extends BatchTestCase {
             + "group by \"time_by_day\".\"the_year\"";
 
         SqlPattern[] patterns = {
-            new SqlPattern(Dialect.DatabaseProduct.DERBY, derbySql, derbySql),
             new SqlPattern(Dialect.DatabaseProduct.MYSQL, mysqlSql, mysqlSql),
             new SqlPattern(
                 Dialect.DatabaseProduct.ORACLE, oraTeraSql, oraTeraSql),
@@ -161,6 +154,9 @@ public class AggregationOnDistinctCountMeasuresTest extends BatchTestCase {
     }
 
     public void testCrossJoinMembersWithSetOfMembers() {
+        // make sure tuple optimization will be used
+        propSaver.set(propSaver.properties.MaxConstraints, 2);
+
         String query =
             "WITH MEMBER GENDER.X AS 'AGGREGATE({[GENDER].[GENDER].members} * "
             + "{[STORE].[ALL STORES].[USA].[CA], [Store].[All Stores].[Canada]})', solve_order=100 "

--- a/testsrc/main/mondrian/test/TestContext.java
+++ b/testsrc/main/mondrian/test/TestContext.java
@@ -5,10 +5,9 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2002-2005 Julian Hyde
-// Copyright (C) 2005-2013 Pentaho and others
+// Copyright (C) 2005-2015 Pentaho and others
 // All Rights Reserved.
 */
-
 package mondrian.test;
 
 import mondrian.calc.*;
@@ -22,6 +21,7 @@ import mondrian.olap.fun.FunUtil;
 import mondrian.olap4j.MondrianInprocProxy;
 import mondrian.resource.MondrianResource;
 import mondrian.rolap.*;
+import mondrian.rolap.aggmatcher.DefaultDef;
 import mondrian.spi.*;
 import mondrian.spi.impl.FilterDynamicSchemaProcessor;
 import mondrian.util.DelegatingInvocationHandler;
@@ -393,7 +393,8 @@ public class TestContext {
         String dimensionDefs,
         String measureDefs,
         String memberDefs,
-        String namedSetDefs)
+        String namedSetDefs,
+        String defaultMeasure)
     {
         String s = rawSchema;
 
@@ -466,6 +467,11 @@ public class TestContext {
             s = s.substring(0, i)
                 + namedSetDefs
                 + s.substring(i);
+        }
+        if (defaultMeasure != null) {
+            s = s.replaceFirst(
+                "(" + cubeName + ".*)defaultMeasure=\"[^\"]*\"",
+                "$1defaultMeasure=\"" + defaultMeasure + "\"");
         }
 
         return s;
@@ -1866,9 +1872,30 @@ public class TestContext {
             substituteSchema(
                 getRawFoodMartSchema(),
                 cubeName, dimensionDefs,
-                measureDefs, memberDefs, namedSetDefs);
+                measureDefs, memberDefs, namedSetDefs, null);
         return withSchema(schema);
     }
+
+    /**
+     * Overload that allows swapping the defaultMeasure.
+     */
+    public final TestContext createSubstitutingCube(
+        final String cubeName,
+        final String dimensionDefs,
+        final String measureDefs,
+        final String memberDefs,
+        final String namedSetDefs,
+        final String defaultMeasure)
+    {
+        final String schema =
+            substituteSchema(
+                getRawFoodMartSchema(),
+                cubeName, dimensionDefs,
+                measureDefs, memberDefs, namedSetDefs,
+                defaultMeasure);
+        return withSchema(schema);
+    }
+
 
     /**
      * Returns a TestContext similar to this one, but using the given role.


### PR DESCRIPTION
distinct measures and compound slicers

This commit includes the following changes to reduce the overhead of
distinct-count measures being evaluated in the context of a compound
slicer:
1)  Compound predicates for the slicer are constructed in the
evaluator.  This allows the slicer predicates to be constructed a
single time in most cases, rather than once per cell request.

2) Similarly, the compound predicate string representation for the slicer
is also constructed in the evaluator.

3) AggregateFunDef updated to avoid unnecessary tuple optimization
when tuplelist is supportable within an IN list.  The tuple
optimization algorithm is expensive and we should avoid it when
unnecessary.

To support 1 and 2, the logic in RolapAggregationManager for
constructing compound predicates has been extracted into a new
CompoundPredicateInfo class.  The logic for constructing predicate
strings (i.e. getCompoundPredicateStringList) was extracted from
AggregationKey and included in CompoundPredicateInfo as well.
(cherry picked from commit 26d7d97)