### PR TITLE
[BACKLOG-5370]  "Pentaho Data Services" database type not in list

### DIFF
--- a/src/main/mondrian/gui/Workbench.java
+++ b/src/main/mondrian/gui/Workbench.java
@@ -110,6 +110,7 @@ public class Workbench extends javax.swing.JFrame {
     private int windowMenuMapIndex = 1;
 
     private static final String KETTLE_PLUGIN_BASE_FOLDERS = "kettle-plugins,"
+            + "plugins,"
             + Const.getKettleDirectory() + Const.FILE_SEPARATOR + "plugins";
     private XulDialog connectionDialog = null;
     private DataHandler connectionDialogController = null;


### PR DESCRIPTION
Updating KETTLE_PLUGIN_BASE_FOLDERS to include the plugin dir
 to make sure the dataservices plugin is found and loaded.
(cherry picked from commit 9057afe)

@dkincade 