### PR TITLE
[MONDRIAN-1272] - Native Top Count cannot handle empty members

### DIFF
--- a/src/main/mondrian/rolap/MemberExcludeConstraint.java
+++ b/src/main/mondrian/rolap/MemberExcludeConstraint.java
@@ -1,0 +1,129 @@
+/*
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (C) 2015-2015 Pentaho and others
+// All Rights Reserved.
+*/
+package mondrian.rolap;
+
+import mondrian.olap.Evaluator;
+import mondrian.rolap.aggmatcher.AggStar;
+import mondrian.rolap.sql.CrossJoinArg;
+import mondrian.rolap.sql.MemberChildrenConstraint;
+import mondrian.rolap.sql.SqlQuery;
+import mondrian.rolap.sql.TupleConstraint;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Arrays.asList;
+
+/**
+ * Constraint which excludes the members in the list received in constructor.
+ *
+ * @author Pedro Vale
+ */
+class MemberExcludeConstraint implements TupleConstraint {
+    private final List<RolapMember> excludes;
+    private final Object cacheKey;
+    private final RolapLevel level;
+    private final RolapNativeSet.SetConstraint csc;
+    private final Map<RolapLevel, List<RolapMember>> roles;
+
+    /**
+     * Creates a <code>MemberExcludeConstraint</code>.
+     *
+     */
+    public MemberExcludeConstraint(
+        List<RolapMember> excludes,
+        RolapLevel level,
+        RolapNativeSet.SetConstraint csc)
+    {
+        this.excludes = excludes;
+        this.cacheKey = asList(MemberExcludeConstraint.class, excludes, csc);
+        this.level = level;
+        this.csc = csc;
+
+        roles = (csc == null)
+            ? Collections.<RolapLevel, List<RolapMember>>emptyMap()
+            : SqlConstraintUtils.getRolesConstraints(csc.getEvaluator());
+    }
+
+
+    @Override
+    public int hashCode() {
+        return getCacheKey().hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof MemberExcludeConstraint
+            && getCacheKey()
+                .equals(((MemberExcludeConstraint) obj).getCacheKey());
+    }
+
+    @Override
+    public void addLevelConstraint(
+        SqlQuery query,
+        RolapCube baseCube,
+        AggStar aggStar,
+        RolapLevel level)
+    {
+        if (level.equals(this.level)) {
+            SqlConstraintUtils.addMemberConstraint(
+                query, baseCube, aggStar, excludes, true, false, true);
+        }
+        if (csc != null) {
+            for (CrossJoinArg cja : csc.args) {
+                if (cja.getLevel().equals(level)) {
+                    cja.addConstraint(query, baseCube, aggStar);
+                }
+            }
+        }
+
+        if (roles.containsKey(level)) {
+            List<RolapMember> members = roles.get(level);
+            SqlConstraintUtils.addMemberConstraint(
+                query, baseCube, aggStar, members, true, false, false);
+        }
+    }
+
+    public String toString() {
+        return "MemberExcludeConstraint(" + excludes + ")";
+    }
+
+    @Override
+    public Object getCacheKey() {
+        return cacheKey;
+    }
+
+
+    public MemberChildrenConstraint getMemberChildrenConstraint(
+        RolapMember parent)
+    {
+        return DefaultMemberChildrenConstraint.instance();
+    }
+
+    @Override
+    public void addConstraint(
+        SqlQuery sqlQuery,
+        RolapCube baseCube,
+        AggStar aggStar)
+    {
+    }
+
+    @Override
+    public Evaluator getEvaluator() {
+        if (csc != null) {
+            return csc.getEvaluator();
+        } else {
+            return null;
+        }
+    }
+}
+
+// End MemberExcludeConstraint.java

--- a/src/main/mondrian/rolap/RolapNativeSet.java
+++ b/src/main/mondrian/rolap/RolapNativeSet.java
@@ -157,6 +157,7 @@ public abstract class RolapNativeSet extends RolapNative {
         private final SchemaReaderWithMemberReaderAvailable schemaReader;
         private final TupleConstraint constraint;
         private int maxRows = 0;
+        private boolean completeWithNullValues;
 
         public SetEvaluator(
             CrossJoinArg[] args,
@@ -172,6 +173,10 @@ public abstract class RolapNativeSet extends RolapNative {
                     new SchemaReaderWithMemberReaderCache(schemaReader);
             }
             this.constraint = constraint;
+        }
+
+        public void setCompleteWithNullValues(boolean completeWithNullValues) {
+            this.completeWithNullValues = completeWithNullValues;
         }
 
         public Object execute(ResultStyle desiredResultStyle) {
@@ -258,6 +263,32 @@ public abstract class RolapNativeSet extends RolapNative {
                 result =
                     tr.readTuples(
                         dataSource, partialResult, newPartialResult);
+            }
+
+            // Did not get as many members as expected - try to complete using
+            // less constraints
+            if (completeWithNullValues && result.size() < maxRows) {
+                RolapLevel l = args[0].getLevel();
+                List<RolapMember> list = new ArrayList<RolapMember>();
+                for (List<Member> lm : result) {
+                    for (Member m : lm) {
+                        list.add((RolapMember) m);
+                    }
+                }
+                SqlTupleReader str = new SqlTupleReader(
+                    new MemberExcludeConstraint(
+                        list, l,
+                        constraint instanceof SetConstraint
+                        ? (SetConstraint) constraint : null));
+                str.setAllowHints(false);
+                for (CrossJoinArg arg : args) {
+                    addLevel(str, arg);
+                }
+
+                str.setMaxRows(maxRows - result.size());
+                result.addAll(
+                    str.readMembers(
+                        dataSource, null, new ArrayList<List<RolapMember>>()));
             }
 
             if (!MondrianProperties.instance().DisableCaching.get()) {

--- a/src/main/mondrian/rolap/RolapNativeTopCount.java
+++ b/src/main/mondrian/rolap/RolapNativeTopCount.java
@@ -6,7 +6,7 @@
 //
 // Copyright (C) 2004-2005 TONBELLER AG
 // Copyright (C) 2005-2005 Julian Hyde
-// Copyright (C) 2005-2013 Pentaho and others
+// Copyright (C) 2005-2015 Pentaho and others
 // All Rights Reserved.
 */
 package mondrian.rolap;
@@ -108,6 +108,7 @@ public class RolapNativeTopCount extends RolapNativeSet {
             }
             key.add(ascending);
             key.add(topCount);
+            key.add(this.getEvaluator().isNonEmpty());
 
             if (this.getEvaluator() instanceof RolapEvaluator) {
                 key.add(
@@ -219,6 +220,7 @@ public class RolapNativeTopCount extends RolapNativeSet {
             SetEvaluator sev =
                 new SetEvaluator(cjArgs, schemaReader, constraint);
             sev.setMaxRows(count);
+            sev.setCompleteWithNullValues(!evaluator.isNonEmpty());
             return sev;
         } finally {
             evaluator.restore(savepoint);

--- a/src/main/mondrian/rolap/RolapNativeTopCount.java
+++ b/src/main/mondrian/rolap/RolapNativeTopCount.java
@@ -26,7 +26,7 @@ import javax.sql.DataSource;
  *
  * @author av
  * @since Nov 21, 2005
-  */
+ */
 public class RolapNativeTopCount extends RolapNativeSet {
 
     public RolapNativeTopCount() {
@@ -113,7 +113,7 @@ public class RolapNativeTopCount extends RolapNativeSet {
             if (this.getEvaluator() instanceof RolapEvaluator) {
                 key.add(
                     ((RolapEvaluator)this.getEvaluator())
-                    .getSlicerMembers());
+                        .getSlicerMembers());
             }
             return key;
         }
@@ -128,18 +128,12 @@ public class RolapNativeTopCount extends RolapNativeSet {
         FunDef fun,
         Exp[] args)
     {
-        boolean ascending;
-
-        if (!isEnabled()) {
-            return null;
-        }
-        if (!TopCountConstraint.isValidContext(
-                evaluator, restrictMemberTypes()))
-        {
+        if (!isEnabled() || !isValidContext(evaluator)) {
             return null;
         }
 
         // is this "TopCount(<set>, <count>, [<numeric expr>])"
+        boolean ascending;
         String funName = fun.getName();
         if ("TopCount".equalsIgnoreCase(funName)) {
             ascending = false;
@@ -149,6 +143,11 @@ public class RolapNativeTopCount extends RolapNativeSet {
             return null;
         }
         if (args.length < 2 || args.length > 3) {
+            return null;
+        }
+
+        if (args.length == 2) {
+            // MONDRIAN-2394: for now, prohibit native evaluation
             return null;
         }
 
@@ -210,7 +209,7 @@ public class RolapNativeTopCount extends RolapNativeSet {
                 // Combined the CJ and the additional predicate args
                 // to form the TupleConstraint.
                 combinedArgs =
-                        Util.appendArrays(cjArgs, predicateArgs);
+                    Util.appendArrays(cjArgs, predicateArgs);
             } else {
                 combinedArgs = cjArgs;
             }
@@ -225,6 +224,12 @@ public class RolapNativeTopCount extends RolapNativeSet {
         } finally {
             evaluator.restore(savepoint);
         }
+    }
+
+    // package-local visibility for testing purposes
+    boolean isValidContext(RolapEvaluator evaluator) {
+        return TopCountConstraint.isValidContext(
+            evaluator, restrictMemberTypes());
     }
 }
 

--- a/src/main/mondrian/rolap/SqlTupleReader.java
+++ b/src/main/mondrian/rolap/SqlTupleReader.java
@@ -90,6 +90,16 @@ public class SqlTupleReader implements TupleReader {
     private int missedMemberCount;
     private static final String UNION = "union";
     private int emptySets = 0;
+    // allow hints by default
+    private boolean allowHints = true;
+
+    public boolean isAllowHints() {
+        return allowHints;
+    }
+
+    public void setAllowHints(boolean allowHints) {
+        this.allowHints = allowHints;
+    }
 
     /**
      * Helper class for SqlTupleReader;
@@ -914,7 +924,7 @@ public class SqlTupleReader implements TupleReader {
 
         // Allow query to use optimization hints from the table definition
         SqlQuery sqlQuery = SqlQuery.newQuery(dataSource, s);
-        sqlQuery.setAllowHints(true);
+        sqlQuery.setAllowHints(allowHints);
 
 
         Evaluator evaluator = getEvaluator(constraint);

--- a/testsrc/main/mondrian/rolap/RolapNativeTopCountTest.java
+++ b/testsrc/main/mondrian/rolap/RolapNativeTopCountTest.java
@@ -4,15 +4,18 @@
 // http://www.eclipse.org/legal/epl-v10.html.
 // You must accept the terms of that agreement to use this software.
 //
-// Copyright (C) 2015-2015 Pentaho ant others
+// Copyright (C) 2015-2015 Pentaho and others
 // All Rights Reserved.
 */
 package mondrian.rolap;
 
 import mondrian.test.TestContext;
 
+import static mondrian.rolap.RolapNativeTopCountTestCases.*;
+
 /**
  * @author Andrey Khayrutdinov
+ * @see RolapNativeTopCountTestCases
  */
 public class RolapNativeTopCountTest extends BatchTestCase {
 
@@ -22,102 +25,76 @@ public class RolapNativeTopCountTest extends BatchTestCase {
     }
 
     public void testTopCount_ImplicitCountMeasure() throws Exception {
-        final String query = ""
-            + "SELECT [Measures].[Fact Count] ON COLUMNS, "
-            + "TOPCOUNT([Store Type].[All Store Types].Children, 3, [Measures].[Fact Count]) ON ROWS "
-            + "FROM [Store]";
-
-        final String expectedResult = ""
-            + "Axis #0:\n"
-            + "{}\n"
-            + "Axis #1:\n"
-            + "{[Measures].[Fact Count]}\n"
-            + "Axis #2:\n"
-            + "{[Store Type].[Supermarket]}\n"
-            + "{[Store Type].[Deluxe Supermarket]}\n"
-            + "{[Store Type].[Mid-Size Grocery]}\n"
-            + "Row #0: 8\n"
-            + "Row #1: 6\n"
-            + "Row #2: 4\n";
-
-        TestContext.instance().assertQueryReturns(query, expectedResult);
+        assertQueryReturns(
+            IMPLICIT_COUNT_MEASURE_QUERY, IMPLICIT_COUNT_MEASURE_RESULT);
     }
 
     public void testTopCount_CountMeasure() throws Exception {
-        final String cube = ""
-            + "  <Cube name=\"StoreWithCountM\" visible=\"true\" cache=\"true\" enabled=\"true\">\n"
-            + "    <Table name=\"store\">\n"
-            + "    </Table>\n"
-            + "    <Dimension visible=\"true\" highCardinality=\"false\" name=\"Store Type\">\n"
-            + "      <Hierarchy visible=\"true\" hasAll=\"true\">\n"
-            + "        <Level name=\"Store Type\" visible=\"true\" column=\"store_type\" type=\"String\" uniqueMembers=\"true\" levelType=\"Regular\" hideMemberIf=\"Never\">\n"
-            + "        </Level>\n"
-            + "      </Hierarchy>\n"
-            + "    </Dimension>\n"
-            + "    <DimensionUsage source=\"Store\" name=\"Store\" visible=\"true\" highCardinality=\"false\">\n"
-            + "    </DimensionUsage>\n"
-            + "    <Dimension visible=\"true\" highCardinality=\"false\" name=\"Has coffee bar\">\n"
-            + "      <Hierarchy visible=\"true\" hasAll=\"true\">\n"
-            + "        <Level name=\"Has coffee bar\" visible=\"true\" column=\"coffee_bar\" type=\"Boolean\" uniqueMembers=\"true\" levelType=\"Regular\" hideMemberIf=\"Never\">\n"
-            + "        </Level>\n"
-            + "      </Hierarchy>\n"
-            + "    </Dimension>\n"
-            + "    <Measure name=\"Store Sqft\" column=\"store_sqft\" formatString=\"#,###\" aggregator=\"sum\">\n"
-            + "    </Measure>\n"
-            + "    <Measure name=\"Grocery Sqft\" column=\"grocery_sqft\" formatString=\"#,###\" aggregator=\"sum\">\n"
-            + "    </Measure>\n"
-            + "    <Measure name=\"CountM\" column=\"store_id\" formatString=\"Standard\" aggregator=\"count\" visible=\"true\">\n"
-            + "    </Measure>\n"
-            + "  </Cube>";
-
         final String schema = TestContext.instance()
-            .getSchema(null, cube, null, null, null, null);
+                .getSchema(
+                    null, CUSTOM_COUNT_MEASURE_CUBE,
+                    null, null, null, null);
 
         TestContext ctx = TestContext.instance()
-            .withSchema(schema)
-            .withCube("StoreWithCountM");
+                .withSchema(schema)
+                .withCube(CUSTOM_COUNT_MEASURE_CUBE_NAME);
 
-        final String query = ""
-            + "SELECT [Measures].[CountM] ON COLUMNS, "
-            + "TOPCOUNT([Store Type].[All Store Types].Children, 3, [Measures].[CountM]) ON ROWS "
-            + "FROM [StoreWithCountM]";
-
-        final String expectedResult = ""
-            + "Axis #0:\n"
-            + "{}\n"
-            + "Axis #1:\n"
-            + "{[Measures].[CountM]}\n"
-            + "Axis #2:\n"
-            + "{[Store Type].[Supermarket]}\n"
-            + "{[Store Type].[Deluxe Supermarket]}\n"
-            + "{[Store Type].[Mid-Size Grocery]}\n"
-            + "Row #0: 8\n"
-            + "Row #1: 6\n"
-            + "Row #2: 4\n";
-
-        ctx.assertQueryReturns(query, expectedResult);
+        ctx.assertQueryReturns(
+            CUSTOM_COUNT_MEASURE_QUERY, CUSTOM_COUNT_MEASURE_RESULT);
     }
 
     public void testTopCount_SumMeasure() throws Exception {
-        final String query = ""
-            + "SELECT [Measures].[Store Sqft] ON COLUMNS, "
-            + "TOPCOUNT([Store Type].[All Store Types].Children, 3, [Measures].[Store Sqft]) ON ROWS "
-            + "FROM [Store]";
+        assertQueryReturns(SUM_MEASURE_QUERY, SUM_MEASURE_RESULT);
+    }
 
-        final String expectedResult = ""
-            + "Axis #0:\n"
-            + "{}\n"
-            + "Axis #1:\n"
-            + "{[Measures].[Store Sqft]}\n"
-            + "Axis #2:\n"
-            + "{[Store Type].[Supermarket]}\n"
-            + "{[Store Type].[Deluxe Supermarket]}\n"
-            + "{[Store Type].[Mid-Size Grocery]}\n"
-            + "Row #0: 193,480\n"
-            + "Row #1: 146,045\n"
-            + "Row #2: 109,343\n";
 
-        TestContext.instance().assertQueryReturns(query, expectedResult);
+    public void testEmptyCellsAreShown_Countries() {
+        assertQueryReturns(
+            EMPTY_CELLS_ARE_SHOWN_COUNTRIES_QUERY,
+            EMPTY_CELLS_ARE_SHOWN_COUNTRIES_RESULT);
+    }
+
+    public void testEmptyCellsAreShown_States() {
+        assertQueryReturns(
+            EMPTY_CELLS_ARE_SHOWN_STATES_QUERY,
+            EMPTY_CELLS_ARE_SHOWN_STATES_RESULT);
+    }
+
+    public void testEmptyCellsAreShown_ButNoMoreThanReallyExist() {
+        assertQueryReturns(
+            EMPTY_CELLS_ARE_SHOWN_NOT_MORE_THAN_EXIST_QUERY,
+            EMPTY_CELLS_ARE_SHOWN_NOT_MORE_THAN_EXIST_RESULT);
+    }
+
+    public void testEmptyCellsAreHidden_WhenNonEmptyIsDeclaredExplicitly() {
+        assertQueryReturns(
+            EMPTY_CELLS_ARE_HIDDEN_WHEN_NON_EMPTY_QUERY,
+            EMPTY_CELLS_ARE_HIDDEN_WHEN_NON_EMPTY_RESULT);
+    }
+
+
+    public void testRoleRestrictionWorks_ForRowWithData() throws Exception {
+        TestContext ctx = TestContext.instance()
+            .create(
+                null, null, null, null, null,
+                ROLE_RESTRICTION_WORKS_WA_ROLE_DEF)
+            .withRole(ROLE_RESTRICTION_WORKS_WA_ROLE_NAME);
+
+        ctx.assertQueryReturns(
+            ROLE_RESTRICTION_WORKS_WA_QUERY,
+            ROLE_RESTRICTION_WORKS_WA_RESULT);
+    }
+
+    public void testRoleRestrictionWorks_ForRowWithOutData() throws Exception {
+        TestContext ctx = TestContext.instance()
+            .create(
+                null, null, null, null, null,
+                ROLE_RESTRICTION_WORKS_DF_ROLE_DEF)
+            .withRole(ROLE_RESTRICTION_WORKS_DF_ROLE_NAME);
+
+        ctx.assertQueryReturns(
+            ROLE_RESTRICTION_WORKS_DF_QUERY,
+            ROLE_RESTRICTION_WORKS_DF_RESULT);
     }
 }
 

--- a/testsrc/main/mondrian/rolap/RolapNativeTopCountTest.java
+++ b/testsrc/main/mondrian/rolap/RolapNativeTopCountTest.java
@@ -96,6 +96,31 @@ public class RolapNativeTopCountTest extends BatchTestCase {
             ROLE_RESTRICTION_WORKS_DF_QUERY,
             ROLE_RESTRICTION_WORKS_DF_RESULT);
     }
+
+
+    public void testMimicsHeadWhenTwoParams_States() {
+        assertQueryReturns(
+            TOPCOUNT_MIMICS_HEAD_WHEN_TWO_PARAMS_STATES_QUERY,
+            TOPCOUNT_MIMICS_HEAD_WHEN_TWO_PARAMS_STATES_RESULT);
+    }
+
+    public void testMimicsHeadWhenTwoParams_Cities() {
+        assertQueryReturns(
+            TOPCOUNT_MIMICS_HEAD_WHEN_TWO_PARAMS_CITIES_QUERY,
+            TOPCOUNT_MIMICS_HEAD_WHEN_TWO_PARAMS_CITIES_RESULT);
+    }
+
+    public void testMimicsHeadWhenTwoParams_ShowsNotMoreThanExist() {
+        assertQueryReturns(
+            RESULTS_ARE_SHOWN_NOT_MORE_THAN_EXIST_2_PARAMS_QUERY,
+            RESULTS_ARE_SHOWN_NOT_MORE_THAN_EXIST_2_PARAMS_RESULT);
+    }
+
+    public void testMimicsHeadWhenTwoParams_DoesNotIgnoreNonEmpty() {
+        assertQueryReturns(
+            NON_EMPTY_IS_NOT_IGNORED_WHEN_TWO_PARAMS_QUERY,
+            NON_EMPTY_IS_NOT_IGNORED_WHEN_TWO_PARAMS_RESULT);
+    }
 }
 
 // End RolapNativeTopCountTest.java

--- a/testsrc/main/mondrian/rolap/RolapNativeTopCountTestCases.java
+++ b/testsrc/main/mondrian/rolap/RolapNativeTopCountTestCases.java
@@ -1,0 +1,325 @@
+/*
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (C) 2015-2015 Pentaho and others
+// All Rights Reserved.
+*/
+package mondrian.rolap;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+class RolapNativeTopCountTestCases {
+
+    //
+    // The case for verifying NativeTopCount can handle implicit
+    // count measure, which is created each time.
+    //
+
+    static final String IMPLICIT_COUNT_MEASURE_QUERY = ""
+        + "SELECT [Measures].[Fact Count] ON COLUMNS, "
+        + "TOPCOUNT([Store Type].[All Store Types].Children, 3, [Measures].[Fact Count]) ON ROWS "
+        + "FROM [Store]";
+
+    static final String IMPLICIT_COUNT_MEASURE_RESULT = ""
+        + "Axis #0:\n"
+        + "{}\n"
+        + "Axis #1:\n"
+        + "{[Measures].[Fact Count]}\n"
+        + "Axis #2:\n"
+        + "{[Store Type].[Supermarket]}\n"
+        + "{[Store Type].[Deluxe Supermarket]}\n"
+        + "{[Store Type].[Mid-Size Grocery]}\n"
+        + "Row #0: 8\n"
+        + "Row #1: 6\n"
+        + "Row #2: 4\n";
+
+
+    //
+    // The case for verifying NativeTopCount can handle explicitly defined
+    // count measure.
+    //
+
+    static final String CUSTOM_COUNT_MEASURE_CUBE_NAME = "StoreWithCountM";
+
+    static final String CUSTOM_COUNT_MEASURE_CUBE = ""
+        + "  <Cube name=\"StoreWithCountM\" visible=\"true\" cache=\"true\" enabled=\"true\">\n"
+        + "    <Table name=\"store\">\n"
+        + "    </Table>\n"
+        + "    <Dimension visible=\"true\" highCardinality=\"false\" name=\"Store Type\">\n"
+        + "      <Hierarchy visible=\"true\" hasAll=\"true\">\n"
+        + "        <Level name=\"Store Type\" visible=\"true\" column=\"store_type\" type=\"String\" uniqueMembers=\"true\" levelType=\"Regular\" hideMemberIf=\"Never\">\n"
+        + "        </Level>\n"
+        + "      </Hierarchy>\n"
+        + "    </Dimension>\n"
+        + "    <DimensionUsage source=\"Store\" name=\"Store\" visible=\"true\" highCardinality=\"false\">\n"
+        + "    </DimensionUsage>\n"
+        + "    <Dimension visible=\"true\" highCardinality=\"false\" name=\"Has coffee bar\">\n"
+        + "      <Hierarchy visible=\"true\" hasAll=\"true\">\n"
+        + "        <Level name=\"Has coffee bar\" visible=\"true\" column=\"coffee_bar\" type=\"Boolean\" uniqueMembers=\"true\" levelType=\"Regular\" hideMemberIf=\"Never\">\n"
+        + "        </Level>\n"
+        + "      </Hierarchy>\n"
+        + "    </Dimension>\n"
+        + "    <Measure name=\"Store Sqft\" column=\"store_sqft\" formatString=\"#,###\" aggregator=\"sum\">\n"
+        + "    </Measure>\n"
+        + "    <Measure name=\"Grocery Sqft\" column=\"grocery_sqft\" formatString=\"#,###\" aggregator=\"sum\">\n"
+        + "    </Measure>\n"
+        + "    <Measure name=\"CountM\" column=\"store_id\" formatString=\"Standard\" aggregator=\"count\" visible=\"true\">\n"
+        + "    </Measure>\n"
+        + "  </Cube>";
+
+    static final String CUSTOM_COUNT_MEASURE_QUERY = ""
+        + "SELECT [Measures].[CountM] ON COLUMNS, "
+        + "TOPCOUNT([Store Type].[All Store Types].Children, 3, [Measures].[CountM]) ON ROWS "
+        + "FROM [StoreWithCountM]";
+
+    static final String CUSTOM_COUNT_MEASURE_RESULT = ""
+        + "Axis #0:\n"
+        + "{}\n"
+        + "Axis #1:\n"
+        + "{[Measures].[CountM]}\n"
+        + "Axis #2:\n"
+        + "{[Store Type].[Supermarket]}\n"
+        + "{[Store Type].[Deluxe Supermarket]}\n"
+        + "{[Store Type].[Mid-Size Grocery]}\n"
+        + "Row #0: 8\n"
+        + "Row #1: 6\n"
+        + "Row #2: 4\n";
+
+
+    //
+    // The case for verifying NativeTopCount can handle sum measure.
+    //
+
+    static final String SUM_MEASURE_QUERY = ""
+        + "SELECT [Measures].[Store Sqft] ON COLUMNS, "
+        + "TOPCOUNT([Store Type].[All Store Types].Children, 3, [Measures].[Store Sqft]) ON ROWS "
+        + "FROM [Store]";
+
+    static final String SUM_MEASURE_RESULT = ""
+        + "Axis #0:\n"
+        + "{}\n"
+        + "Axis #1:\n"
+        + "{[Measures].[Store Sqft]}\n"
+        + "Axis #2:\n"
+        + "{[Store Type].[Supermarket]}\n"
+        + "{[Store Type].[Deluxe Supermarket]}\n"
+        + "{[Store Type].[Mid-Size Grocery]}\n"
+        + "Row #0: 193,480\n"
+        + "Row #1: 146,045\n"
+        + "Row #2: 109,343\n";
+
+
+    //
+    // The case for verifying NativeTopCount returns tuples for those members
+    // that have no corresponding records in the fact table.
+    //
+    // This case checks countries level.
+    //
+
+    static final String EMPTY_CELLS_ARE_SHOWN_COUNTRIES_QUERY = ""
+        + "SELECT [Measures].[Unit Sales] ON COLUMNS, "
+        + "TOPCOUNT([Customers].[Country].Members, 2, [Measures].[Unit Sales]) ON ROWS "
+        + "FROM [Sales] "
+        + "WHERE [Time].[1997].[Q3]";
+
+    static final String EMPTY_CELLS_ARE_SHOWN_COUNTRIES_RESULT = ""
+        + "Axis #0:\n"
+        + "{[Time].[1997].[Q3]}\n"
+        + "Axis #1:\n"
+        + "{[Measures].[Unit Sales]}\n"
+        + "Axis #2:\n"
+        + "{[Customers].[USA]}\n"
+        + "{[Customers].[Canada]}\n"
+        + "Row #0: 65,848\n"
+        + "Row #1: \n";
+
+
+    //
+    // The case for verifying NativeTopCount returns tuples for those members
+    // that have no corresponding records in the fact table.
+    //
+    // This case checks states level.
+    //
+
+    static final String EMPTY_CELLS_ARE_SHOWN_STATES_QUERY = ""
+        + "SELECT [Measures].[Unit Sales] ON COLUMNS, "
+        + "TOPCOUNT([Customers].[State Province].Members, 6, [Measures].[Unit Sales]) ON ROWS "
+        + "FROM [Sales] "
+        + "WHERE [Time].[1997].[Q3]";
+
+    static final String EMPTY_CELLS_ARE_SHOWN_STATES_RESULT = ""
+        + "Axis #0:\n"
+        + "{[Time].[1997].[Q3]}\n"
+        + "Axis #1:\n"
+        + "{[Measures].[Unit Sales]}\n"
+        + "Axis #2:\n"
+        + "{[Customers].[USA].[WA]}\n"
+        + "{[Customers].[USA].[CA]}\n"
+        + "{[Customers].[USA].[OR]}\n"
+        + "{[Customers].[Canada].[BC]}\n"
+        + "{[Customers].[Mexico].[DF]}\n"
+        + "{[Customers].[Mexico].[Guerrero]}\n"
+        + "Row #0: 30,538\n"
+        + "Row #1: 18,370\n"
+        + "Row #2: 16,940\n"
+        + "Row #3: \n"
+        + "Row #4: \n"
+        + "Row #5: \n";
+
+
+    //
+    // The case for verifying NativeTopCount returns tuples for those members
+    // that have no corresponding records in the fact table.
+    //
+    // This case checks that no extra lines are returned. For instance,
+    // in the [Sales] cube (year 1997) there are records only for USA, Canada
+    // and Mexico; hence, even if limit parameter is 10
+    // then only 3 rows should be shown.
+    //
+
+    static final String EMPTY_CELLS_ARE_SHOWN_NOT_MORE_THAN_EXIST_QUERY = ""
+        + "SELECT [Measures].[Unit Sales] ON COLUMNS, "
+        + "TOPCOUNT([Customers].[Country].Members, 10, [Measures].[Unit Sales]) ON ROWS "
+        + "FROM [Sales] "
+        + "WHERE [Time].[1997].[Q3]";
+
+    static final String EMPTY_CELLS_ARE_SHOWN_NOT_MORE_THAN_EXIST_RESULT = ""
+        + "Axis #0:\n"
+        + "{[Time].[1997].[Q3]}\n"
+        + "Axis #1:\n"
+        + "{[Measures].[Unit Sales]}\n"
+        + "Axis #2:\n"
+        + "{[Customers].[USA]}\n"
+        + "{[Customers].[Canada]}\n"
+        + "{[Customers].[Mexico]}\n"
+        + "Row #0: 65,848\n"
+        + "Row #1: \n"
+        + "Row #2: \n";
+
+
+    //
+    // The case for verifying NativeTopCount does not return tuples for those
+    // members that have no corresponding records in the fact table if
+    // NON EMPTY modifier is explicitly used.
+    //
+
+    static final String EMPTY_CELLS_ARE_HIDDEN_WHEN_NON_EMPTY_QUERY = ""
+        + "SELECT [Measures].[Unit Sales] ON COLUMNS, "
+        + "NON EMPTY TOPCOUNT([Customers].[Country].Members, 2, [Measures].[Unit Sales]) ON ROWS "
+        + "FROM [Sales] "
+        + "WHERE [Time].[1997].[Q3]";
+
+    static final String EMPTY_CELLS_ARE_HIDDEN_WHEN_NON_EMPTY_RESULT = ""
+        + "Axis #0:\n"
+        + "{[Time].[1997].[Q3]}\n"
+        + "Axis #1:\n"
+        + "{[Measures].[Unit Sales]}\n"
+        + "Axis #2:\n"
+        + "{[Customers].[USA]}\n"
+        + "Row #0: 65,848\n";
+
+
+    //
+    // The case for verifying NativeTopCount respects roles restriction.
+    //
+    // This case checks that restriction works for rows with data
+    // ([USA].[WA] has 30538)
+    //
+
+    static final String ROLE_RESTRICTION_WORKS_WA_ROLE_NAME = "No_WA_State";
+
+    static final String ROLE_RESTRICTION_WORKS_WA_ROLE_DEF = ""
+        + "<Role name=\"No_WA_State\">\n"
+        + "  <SchemaGrant access=\"none\">\n"
+        + "    <CubeGrant cube=\"Sales\" access=\"all\">\n"
+        + "      <HierarchyGrant hierarchy=\"[Customers]\" access=\"custom\" rollupPolicy=\"partial\">\n"
+        + "        <MemberGrant member=\"[Customers].[USA].[WA]\" access=\"none\"/>\n"
+        + "        <MemberGrant member=\"[Customers].[USA].[OR]\" access=\"all\"/>\n"
+        + "        <MemberGrant member=\"[Customers].[USA].[CA]\" access=\"all\"/>\n"
+        + "        <MemberGrant member=\"[Customers].[Canada]\" access=\"all\"/>\n"
+        + "        <MemberGrant member=\"[Customers].[Mexico]\" access=\"all\"/>\n"
+        + "      </HierarchyGrant>\n"
+        + "    </CubeGrant>\n"
+        + "  </SchemaGrant>\n"
+        + "</Role>\n";
+
+    static final String ROLE_RESTRICTION_WORKS_WA_QUERY = ""
+        + "SELECT [Measures].[Unit Sales] ON COLUMNS, "
+        + "TOPCOUNT([Customers].[State Province].Members, 6, [Measures].[Unit Sales]) ON ROWS "
+        + "FROM [Sales] "
+        + "WHERE [Time].[1997].[Q3]";
+
+    static final String ROLE_RESTRICTION_WORKS_WA_RESULT = ""
+        + "Axis #0:\n"
+        + "{[Time].[1997].[Q3]}\n"
+        + "Axis #1:\n"
+        + "{[Measures].[Unit Sales]}\n"
+        + "Axis #2:\n"
+        + "{[Customers].[USA].[CA]}\n"
+        + "{[Customers].[USA].[OR]}\n"
+        + "{[Customers].[Canada].[BC]}\n"
+        + "{[Customers].[Mexico].[DF]}\n"
+        + "{[Customers].[Mexico].[Guerrero]}\n"
+        + "{[Customers].[Mexico].[Jalisco]}\n"
+        + "Row #0: 18,370\n"
+        + "Row #1: 16,940\n"
+        + "Row #2: \n"
+        + "Row #3: \n"
+        + "Row #4: \n"
+        + "Row #5: \n";
+
+
+    //
+    // The case for verifying NativeTopCount respects roles restriction.
+    //
+    // This case checks that restriction works for rows w/o data:
+    // only [Mexico].[DF] is visible among [Mexico].Children.
+    //
+
+    static final String ROLE_RESTRICTION_WORKS_DF_ROLE_NAME = "Only_DF_State";
+
+    static final String ROLE_RESTRICTION_WORKS_DF_ROLE_DEF = ""
+        + "<Role name=\"Only_DF_State\">\n"
+        + "  <SchemaGrant access=\"none\">\n"
+        + "    <CubeGrant cube=\"Sales\" access=\"all\">\n"
+        + "      <HierarchyGrant hierarchy=\"[Customers]\" access=\"custom\" rollupPolicy=\"partial\">\n"
+        + "        <MemberGrant member=\"[Customers].[USA].[WA]\" access=\"all\"/>\n"
+        + "        <MemberGrant member=\"[Customers].[USA].[OR]\" access=\"all\"/>\n"
+        + "        <MemberGrant member=\"[Customers].[USA].[CA]\" access=\"all\"/>\n"
+        + "        <MemberGrant member=\"[Customers].[Canada]\" access=\"all\"/>\n"
+        + "        <MemberGrant member=\"[Customers].[Mexico].[DF]\" access=\"all\"/>\n"
+        + "      </HierarchyGrant>\n"
+        + "    </CubeGrant>\n"
+        + "  </SchemaGrant>\n"
+        + "</Role>\n";
+
+    static final String ROLE_RESTRICTION_WORKS_DF_QUERY = ""
+        + "SELECT [Measures].[Unit Sales] ON COLUMNS, "
+        + "TOPCOUNT([Customers].[State Province].Members, 6, [Measures].[Unit Sales]) ON ROWS "
+        + "FROM [Sales] "
+        + "WHERE [Time].[1997].[Q3]";
+
+    static final String ROLE_RESTRICTION_WORKS_DF_RESULT = ""
+        + "Axis #0:\n"
+        + "{[Time].[1997].[Q3]}\n"
+        + "Axis #1:\n"
+        + "{[Measures].[Unit Sales]}\n"
+        + "Axis #2:\n"
+        + "{[Customers].[USA].[WA]}\n"
+        + "{[Customers].[USA].[CA]}\n"
+        + "{[Customers].[USA].[OR]}\n"
+        + "{[Customers].[Canada].[BC]}\n"
+        + "{[Customers].[Mexico].[DF]}\n"
+        + "Row #0: 30,538\n"
+        + "Row #1: 18,370\n"
+        + "Row #2: 16,940\n"
+        + "Row #3: \n"
+        + "Row #4: \n";
+
+}
+
+// End RolapNativeTopCountTestCases.java

--- a/testsrc/main/mondrian/rolap/RolapNativeTopCountTestCases.java
+++ b/testsrc/main/mondrian/rolap/RolapNativeTopCountTestCases.java
@@ -320,6 +320,144 @@ class RolapNativeTopCountTestCases {
         + "Row #3: \n"
         + "Row #4: \n";
 
+
+
+    //
+    // The case for verifying NativeTopCount mimics HEAD's behaviour.
+    //
+    // This case checks states level.
+    //
+
+    static final String TOPCOUNT_MIMICS_HEAD_WHEN_TWO_PARAMS_STATES_QUERY = ""
+        + "SELECT TOPCOUNT([Customers].[State Province].members, 3) ON COLUMNS "
+        + "FROM [Sales] ";
+
+    static final String TOPCOUNT_MIMICS_HEAD_WHEN_TWO_PARAMS_STATES_RESULT = ""
+        + "Axis #0:\n"
+        + "{}\n" + "Axis #1:\n"
+        + "{[Customers].[Canada].[BC]}\n"
+        + "{[Customers].[Mexico].[DF]}\n"
+        + "{[Customers].[Mexico].[Guerrero]}\n"
+        + "Row #0: \n"
+        + "Row #0: \n"
+        + "Row #0: \n";
+
+
+    //
+    // The case for verifying NativeTopCount mimics HEAD's behaviour.
+    //
+    // This case checks cities level.
+    //
+
+    static final String TOPCOUNT_MIMICS_HEAD_WHEN_TWO_PARAMS_CITIES_QUERY = ""
+        + "SELECT TOPCOUNT([Customers].[City].members, 30) ON COLUMNS "
+        + "FROM [Sales] ";
+
+    static final String TOPCOUNT_MIMICS_HEAD_WHEN_TWO_PARAMS_CITIES_RESULT = ""
+        + "Axis #0:\n"
+        + "{}\n"
+        + "Axis #1:\n"
+        + "{[Customers].[Canada].[BC].[Burnaby]}\n"
+        + "{[Customers].[Canada].[BC].[Cliffside]}\n"
+        + "{[Customers].[Canada].[BC].[Haney]}\n"
+        + "{[Customers].[Canada].[BC].[Ladner]}\n"
+        + "{[Customers].[Canada].[BC].[Langford]}\n"
+        + "{[Customers].[Canada].[BC].[Langley]}\n"
+        + "{[Customers].[Canada].[BC].[Metchosin]}\n"
+        + "{[Customers].[Canada].[BC].[N. Vancouver]}\n"
+        + "{[Customers].[Canada].[BC].[Newton]}\n"
+        + "{[Customers].[Canada].[BC].[Oak Bay]}\n"
+        + "{[Customers].[Canada].[BC].[Port Hammond]}\n"
+        + "{[Customers].[Canada].[BC].[Richmond]}\n"
+        + "{[Customers].[Canada].[BC].[Royal Oak]}\n"
+        + "{[Customers].[Canada].[BC].[Shawnee]}\n"
+        + "{[Customers].[Canada].[BC].[Sooke]}\n"
+        + "{[Customers].[Canada].[BC].[Vancouver]}\n"
+        + "{[Customers].[Canada].[BC].[Victoria]}\n"
+        + "{[Customers].[Canada].[BC].[Westminster]}\n"
+        + "{[Customers].[Mexico].[DF].[San Andres]}\n"
+        + "{[Customers].[Mexico].[DF].[Santa Anita]}\n"
+        + "{[Customers].[Mexico].[DF].[Santa Fe]}\n"
+        + "{[Customers].[Mexico].[DF].[Tixapan]}\n"
+        + "{[Customers].[Mexico].[Guerrero].[Acapulco]}\n"
+        + "{[Customers].[Mexico].[Jalisco].[Guadalajara]}\n"
+        + "{[Customers].[Mexico].[Mexico].[Mexico City]}\n"
+        + "{[Customers].[Mexico].[Oaxaca].[Tlaxiaco]}\n"
+        + "{[Customers].[Mexico].[Sinaloa].[La Cruz]}\n"
+        + "{[Customers].[Mexico].[Veracruz].[Orizaba]}\n"
+        + "{[Customers].[Mexico].[Yucatan].[Merida]}\n"
+        + "{[Customers].[Mexico].[Zacatecas].[Camacho]}\n"
+        + "Row #0: \n"
+        + "Row #0: \n"
+        + "Row #0: \n"
+        + "Row #0: \n"
+        + "Row #0: \n"
+        + "Row #0: \n"
+        + "Row #0: \n"
+        + "Row #0: \n"
+        + "Row #0: \n"
+        + "Row #0: \n"
+        + "Row #0: \n"
+        + "Row #0: \n"
+        + "Row #0: \n"
+        + "Row #0: \n"
+        + "Row #0: \n"
+        + "Row #0: \n"
+        + "Row #0: \n"
+        + "Row #0: \n"
+        + "Row #0: \n"
+        + "Row #0: \n"
+        + "Row #0: \n"
+        + "Row #0: \n"
+        + "Row #0: \n"
+        + "Row #0: \n"
+        + "Row #0: \n"
+        + "Row #0: \n"
+        + "Row #0: \n"
+        + "Row #0: \n"
+        + "Row #0: \n"
+        + "Row #0: \n";
+
+
+    //
+    // The case for verifying NativeTopCount mimics HEAD's behaviour.
+    //
+    // This case checks that no extra lines are returned.
+    //
+
+    static final String RESULTS_ARE_SHOWN_NOT_MORE_THAN_EXIST_2_PARAMS_QUERY =
+        ""
+        + "SELECT TOPCOUNT([Customers].[Country].members, 5) ON COLUMNS "
+        + "FROM [Sales] ";
+
+    static final String RESULTS_ARE_SHOWN_NOT_MORE_THAN_EXIST_2_PARAMS_RESULT =
+        ""
+        + "Axis #0:\n"
+        + "{}\n"
+        + "Axis #1:\n"
+        + "{[Customers].[Canada]}\n"
+        + "{[Customers].[Mexico]}\n"
+        + "{[Customers].[USA]}\n"
+        + "Row #0: \n"
+        + "Row #0: \n"
+        + "Row #0: 266,773\n";
+
+
+    //
+    // The case for verifying NativeTopCount mimics HEAD's behaviour.
+    //
+    // This case checks NON EMPTY modifier is not neglected.
+    //
+
+    static final String NON_EMPTY_IS_NOT_IGNORED_WHEN_TWO_PARAMS_QUERY = ""
+        + "SELECT NON EMPTY TOPCOUNT([Customers].[State Province].members, 3) ON COLUMNS "
+        + "FROM [Sales] ";
+
+    static final String NON_EMPTY_IS_NOT_IGNORED_WHEN_TWO_PARAMS_RESULT = ""
+        + "Axis #0:\n"
+        + "{}\n"
+        + "Axis #1:\n";
+
 }
 
 // End RolapNativeTopCountTestCases.java

--- a/testsrc/main/mondrian/rolap/RolapNativeTopCountVersusNonNativeTest.java
+++ b/testsrc/main/mondrian/rolap/RolapNativeTopCountVersusNonNativeTest.java
@@ -1,0 +1,112 @@
+/*
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (C) 2015-2015 Pentaho and others
+// All Rights Reserved.
+*/
+package mondrian.rolap;
+
+import mondrian.test.TestContext;
+
+import static mondrian.rolap.RolapNativeTopCountTestCases.*;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+public class RolapNativeTopCountVersusNonNativeTest extends BatchTestCase {
+
+    private void assertResultsAreEqual(String testCase, String query) {
+        assertResultsAreEqual(testCase, query, getTestContext());
+    }
+
+    private void assertResultsAreEqual(
+        String testCase,
+        String query,
+        TestContext ctx)
+    {
+        String message = String.format(
+            "[%s]: native and non-native results of the query differ. The query:\n\t\t%s",
+            testCase,
+            query);
+        verifySameNativeAndNot(query, message, ctx);
+    }
+
+
+    public void testTopCount_ImplicitCountMeasure() throws Exception {
+        assertResultsAreEqual(
+            "Implicit Count Measure", IMPLICIT_COUNT_MEASURE_QUERY);
+    }
+
+    public void testTopCount_SumMeasure() throws Exception {
+        assertResultsAreEqual(
+            "Sum Measure", SUM_MEASURE_QUERY);
+    }
+
+    public void testTopCount_CountMeasure() throws Exception {
+        final String schema = TestContext.instance()
+            .getSchema(null, CUSTOM_COUNT_MEASURE_CUBE, null, null, null, null);
+
+        TestContext ctx = TestContext.instance()
+            .withSchema(schema)
+            .withCube(CUSTOM_COUNT_MEASURE_CUBE_NAME);
+
+        assertResultsAreEqual(
+            "Custom Count Measure", CUSTOM_COUNT_MEASURE_QUERY, ctx);
+    }
+
+
+    public void testEmptyCellsAreShown_Countries() throws Exception {
+        assertResultsAreEqual(
+            "Empty Cells Are Shown - Countries",
+            EMPTY_CELLS_ARE_SHOWN_COUNTRIES_QUERY);
+    }
+
+    public void testEmptyCellsAreShown_States() throws Exception {
+        assertResultsAreEqual(
+            "Empty Cells Are Shown - States",
+            EMPTY_CELLS_ARE_SHOWN_STATES_QUERY);
+    }
+
+    public void testEmptyCellsAreShown_ButNoMoreThanReallyExist() {
+        assertResultsAreEqual(
+            "Empty Cells Are Shown - But no more than really exist",
+            EMPTY_CELLS_ARE_SHOWN_NOT_MORE_THAN_EXIST_QUERY);
+    }
+
+    public void testEmptyCellsAreHidden_WhenNonEmptyIsDeclaredExplicitly() {
+        assertResultsAreEqual(
+            "Empty Cells Are Hidden - When NON EMPTY is declared explicitly",
+            EMPTY_CELLS_ARE_HIDDEN_WHEN_NON_EMPTY_QUERY);
+    }
+
+
+    public void testRoleRestrictionWorks_ForRowWithData() {
+        TestContext ctx = TestContext.instance()
+            .create(
+                null, null, null, null, null,
+                ROLE_RESTRICTION_WORKS_WA_ROLE_DEF)
+            .withRole(ROLE_RESTRICTION_WORKS_WA_ROLE_NAME);
+
+        assertResultsAreEqual(
+            "Role restriction works - For WA state",
+            ROLE_RESTRICTION_WORKS_WA_QUERY, ctx);
+    }
+
+    public void testRoleRestrictionWorks_ForRowWithOutData() {
+        TestContext ctx = TestContext.instance()
+            .create(
+                null, null, null, null, null,
+                ROLE_RESTRICTION_WORKS_DF_ROLE_DEF)
+            .withRole(ROLE_RESTRICTION_WORKS_DF_ROLE_NAME);
+
+        assertResultsAreEqual(
+            "Role restriction works - For DF state",
+            ROLE_RESTRICTION_WORKS_DF_QUERY, ctx);
+    }
+
+}
+
+// End RolapNativeTopCountVersusNonNativeTest.java

--- a/testsrc/main/mondrian/rolap/RolapNativeTopCountVersusNonNativeTest.java
+++ b/testsrc/main/mondrian/rolap/RolapNativeTopCountVersusNonNativeTest.java
@@ -107,6 +107,30 @@ public class RolapNativeTopCountVersusNonNativeTest extends BatchTestCase {
             ROLE_RESTRICTION_WORKS_DF_QUERY, ctx);
     }
 
+
+    public void testMimicsHeadWhenTwoParams_States() {
+        assertResultsAreEqual(
+            "Two Parameters - States",
+            TOPCOUNT_MIMICS_HEAD_WHEN_TWO_PARAMS_STATES_QUERY);
+    }
+
+    public void testMimicsHeadWhenTwoParams_Cities() {
+        assertResultsAreEqual(
+            "Two Parameters - Cities",
+            TOPCOUNT_MIMICS_HEAD_WHEN_TWO_PARAMS_CITIES_QUERY);
+    }
+
+    public void testMimicsHeadWhenTwoParams_ShowsNotMoreThanExist() {
+        assertResultsAreEqual(
+            "Two Parameters - Shows not more than really exist",
+            RESULTS_ARE_SHOWN_NOT_MORE_THAN_EXIST_2_PARAMS_QUERY);
+    }
+
+    public void testMimicsHeadWhenTwoParams_DoesNotIgnoreNonEmpty() {
+        assertResultsAreEqual(
+            "Two Parameters - Does not ignore NON EMPTY",
+            NON_EMPTY_IS_NOT_IGNORED_WHEN_TWO_PARAMS_QUERY);
+    }
 }
 
 // End RolapNativeTopCountVersusNonNativeTest.java

--- a/testsrc/main/mondrian/rolap/TopCountNativeEvaluatorTest.java
+++ b/testsrc/main/mondrian/rolap/TopCountNativeEvaluatorTest.java
@@ -1,0 +1,100 @@
+/*
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (C) 2015-2015 Pentaho and others
+// All Rights Reserved.
+*/
+package mondrian.rolap;
+
+import mondrian.calc.DummyExp;
+import mondrian.olap.Exp;
+import mondrian.olap.FunDef;
+import mondrian.olap.Literal;
+import mondrian.olap.type.EmptyType;
+import mondrian.test.FoodMartTestCase;
+
+import java.math.BigDecimal;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * This class contains tests for some cases related to creating
+ * native evaluator for {@code TOPCOUNT} function.
+ *
+ * @author Andrey Khayrutdinov
+ * @see RolapNativeTopCount#createEvaluator(RolapEvaluator, FunDef, Exp[])
+ */
+public class TopCountNativeEvaluatorTest extends FoodMartTestCase {
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        propSaver.set(propSaver.properties.EnableNativeTopCount, true);
+    }
+
+
+    public void testNonNative_WhenExplicitlyDisabled() throws Exception {
+        propSaver.set(propSaver.properties.EnableNativeTopCount, false);
+        RolapNativeTopCount nativeTopCount = new RolapNativeTopCount();
+
+        assertNull(
+            "Native evaluator should not be created when "
+            + "'mondrian.native.topcount.enable' is 'false'",
+            nativeTopCount.createEvaluator(null, null, null));
+    }
+
+    public void testNonNative_WhenContextIsInvalid() throws Exception {
+        RolapNativeTopCount nativeTopCount = createTopCountSpy();
+        doReturn(false).when(nativeTopCount)
+            .isValidContext(any(RolapEvaluator.class));
+
+        assertNull(
+            "Native evaluator should not be created when "
+            + "evaluation context is invalid",
+            nativeTopCount.createEvaluator(null, null, null));
+    }
+
+    /**
+     * For now, prohibit native evaluation of the function if has two
+     * parameters. According to the specification, this means
+     * the function should behave similarly to {@code HEAD} function.
+     * However, native evaluation joins data with the fact table and if there
+     * is no data there, then some records are ignored, what is not correct.
+     *
+     * @see <a href="http://jira.pentaho.com/browse/MONDRIAN-2394">MONDRIAN-2394</a>
+     */
+    public void testNonNative_WhenTwoParametersArePassed() throws Exception {
+        RolapNativeTopCount nativeTopCount = createTopCountSpy();
+        doReturn(true).when(nativeTopCount)
+            .isValidContext(any(RolapEvaluator.class));
+
+        Exp[] arguments = new Exp[] {
+            new DummyExp(new EmptyType()),
+            Literal.create(BigDecimal.ONE)
+        };
+
+        assertNull(
+            "Native evaluator should not be created when "
+            + "two parameters are passed",
+            nativeTopCount.createEvaluator(
+                null, mockFunctionDef(), arguments));
+    }
+
+    private RolapNativeTopCount createTopCountSpy() {
+        RolapNativeTopCount nativeTopCount = new RolapNativeTopCount();
+        nativeTopCount = spy(nativeTopCount);
+        return nativeTopCount;
+    }
+
+    private FunDef mockFunctionDef() {
+        FunDef topCountFunMock = mock(FunDef.class);
+        when(topCountFunMock.getName()).thenReturn("TOPCOUNT");
+        return topCountFunMock;
+    }
+}
+
+// End TopCountNativeEvaluatorTest.java

--- a/testsrc/main/mondrian/rolap/TopCountWithTwoParamsVersusHeadTest.java
+++ b/testsrc/main/mondrian/rolap/TopCountWithTwoParamsVersusHeadTest.java
@@ -1,0 +1,84 @@
+/*
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (C) 2015-2015 Pentaho and others
+// All Rights Reserved.
+*/
+package mondrian.rolap;
+
+import mondrian.olap.Result;
+import mondrian.test.TestContext;
+
+import static mondrian.rolap.RolapNativeTopCountTestCases.*;
+
+/**
+ * According to
+ * <a href="https://msdn.microsoft.com/en-us/library/ms144792.aspx">MSDN
+ * page</a>, when {@code TOPCOUNT} function is called with two parameters
+ * it should mimic the behaviour of {@code HEAD} function.
+ * <p/>
+ * The idea of these tests is to compare results of both function being
+ * called with same parameters - they should be equal.
+ * <p/>
+ * Queries with {@code HEAD} are made by mere substitution of the name
+ * instead of {@code TOPCOUNT}.
+ *
+ * @author Andrey Khayrutdinov
+ */
+public class TopCountWithTwoParamsVersusHeadTest extends BatchTestCase {
+
+    private void assertResultsAreEqual(
+        String testCase,
+        String topCountQuery)
+    {
+        if (!topCountQuery.contains("TOPCOUNT")) {
+            throw new IllegalArgumentException(
+                "'TOPCOUNT' was not found. Please ensure you are using upper case:\n\t\t"
+                    + topCountQuery);
+        }
+
+        String headQuery = topCountQuery.replace("TOPCOUNT", "HEAD");
+
+        TestContext ctx = getTestContext();
+        Result topCountResult = ctx.executeQuery(topCountQuery);
+        ctx.flushSchemaCache();
+        Result headResult = ctx.executeQuery(headQuery);
+        assertEquals(
+            String.format(
+                "[%s]: TOPCOUNT() and HEAD() results of the query differ. The query:\n\t\t%s",
+                testCase,
+                topCountQuery),
+            TestContext.toString(topCountResult),
+            TestContext.toString(headResult));
+    }
+
+
+    public void test_States() throws Exception {
+        assertResultsAreEqual(
+            "States",
+            TOPCOUNT_MIMICS_HEAD_WHEN_TWO_PARAMS_STATES_QUERY);
+    }
+
+    public void test_Cities() throws Exception {
+        assertResultsAreEqual(
+            "Cities",
+            TOPCOUNT_MIMICS_HEAD_WHEN_TWO_PARAMS_CITIES_QUERY);
+    }
+
+    public void test_ShowsNotMoreThanExist() {
+        assertResultsAreEqual(
+            "Not more than exists",
+            RESULTS_ARE_SHOWN_NOT_MORE_THAN_EXIST_2_PARAMS_QUERY);
+    }
+
+    public void test_DoesNotIgnoreNonEmpty() {
+        assertResultsAreEqual(
+            "Does not ignore NON EMPTY",
+            NON_EMPTY_IS_NOT_IGNORED_WHEN_TWO_PARAMS_QUERY);
+    }
+}
+
+// End TopCountWithTwoParamsVersusHeadTest.java

--- a/testsrc/main/mondrian/test/AccessControlTest.java
+++ b/testsrc/main/mondrian/test/AccessControlTest.java
@@ -5,10 +5,9 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2003-2005 Julian Hyde
-// Copyright (C) 2005-2013 Pentaho
+// Copyright (C) 2005-2015 Pentaho
 // All Rights Reserved.
 */
-
 package mondrian.test;
 
 import mondrian.olap.*;
@@ -628,7 +627,7 @@ public class AccessControlTest extends FoodMartTestCase {
         final TestContext unrestrictedTestContext = getTestContext();
         unrestrictedTestContext.assertQueryReturns(
             "select NON EMPTY {[Measures].[Unit Sales]} ON COLUMNS, \n"
-            + "  TopCount([Store].[USA].[CA].Children, 10, "
+            + "  NON EMPTY TopCount([Store].[USA].[CA].Children, 10, "
             + "           [Measures].[Unit Sales]) ON ROWS \n"
             + "from [Sales] \n"
             + "where ([Time].[1997].[Q1].[2])",
@@ -670,7 +669,7 @@ public class AccessControlTest extends FoodMartTestCase {
         final TestContext unrestrictedTestContext = getTestContext();
         unrestrictedTestContext.assertQueryReturns(
             "select NON EMPTY {[Measures].[Unit Sales]} ON COLUMNS, \n"
-            + "  TopCount([Store].[USA].[CA].Children, 10, "
+            + "  NON EMPTY TopCount([Store].[USA].[CA].Children, 10, "
             + "           [Measures].[Unit Sales]) ON ROWS \n"
             + "from [Sales] \n"
             + "where ([Time].[1997].[Q1].[2] : [Time].[1997].[Q1].[3])",

--- a/testsrc/main/mondrian/test/FoodMartTestCase.java
+++ b/testsrc/main/mondrian/test/FoodMartTestCase.java
@@ -5,7 +5,7 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2002-2005 Julian Hyde
-// Copyright (C) 2005-2013 Pentaho and others
+// Copyright (C) 2005-2015 Pentaho and others
 // All Rights Reserved.
 //
 // jhyde, 29 March, 2002
@@ -434,7 +434,7 @@ public class FoodMartTestCase extends TestCase {
         propSaver.set(propSaver.properties.EnableNativeCrossJoin, false);
         propSaver.set(propSaver.properties.EnableNativeFilter, false);
         propSaver.set(propSaver.properties.EnableNativeNonEmpty, false);
-        propSaver.set(propSaver.properties.EnableNativeTopCount, true);
+        propSaver.set(propSaver.properties.EnableNativeTopCount, false);
 
         Result resultNonNative = context.executeQuery(query);
 

--- a/testsrc/main/mondrian/test/Main.java
+++ b/testsrc/main/mondrian/test/Main.java
@@ -317,6 +317,8 @@ public class Main extends TestSuite {
             addTest(suite, RolapCubeTest.class);
             addTest(suite, RolapNativeTopCountTest.class);
             addTest(suite, RolapNativeTopCountVersusNonNativeTest.class);
+            addTest(suite, TopCountNativeEvaluatorTest.class);
+            addTest(suite, TopCountWithTwoParamsVersusHeadTest.class);
             addTest(suite, RolapStarTest.class);
             addTest(suite, RolapSchemaPoolTest.class);
             addTest(suite, RolapSchemaPoolConcurrencyTest.class);

--- a/testsrc/main/mondrian/test/Main.java
+++ b/testsrc/main/mondrian/test/Main.java
@@ -316,6 +316,7 @@ public class Main extends TestSuite {
             addTest(suite, RolapSchemaReaderTest.class);
             addTest(suite, RolapCubeTest.class);
             addTest(suite, RolapNativeTopCountTest.class);
+            addTest(suite, RolapNativeTopCountVersusNonNativeTest.class);
             addTest(suite, RolapStarTest.class);
             addTest(suite, RolapSchemaPoolTest.class);
             addTest(suite, RolapSchemaPoolConcurrencyTest.class);


### PR DESCRIPTION
- adopt changes from dbdc2bfe1d05b8f11a82f3d3532adce3132d0d7c
  - the idea is to complete output data with result of one new query, where existing rows are filtered
- add tests

@lucboudreau, @mkambol, review it please  