### PR TITLE
[TEST] Adds the MySQL driver for testing convenience

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -87,6 +87,7 @@
         <dependency org="xmlunit" name="xmlunit" rev="1.1" conf="test->default"/>
         <dependency org="monetdb" name="monetdb-jdbc" rev="2.6" conf="test->default"/>
         <dependency org="org.mockito" name="mockito-all" rev="1.9.5" conf="test->default"/>
+        <dependency org="mysql" name="mysql-connector-java" rev="5.1.25" conf="test->default"/>
 
         <!-- Exclusions -->
         <exclude org="avalon-framework" module="avalon-framework"/>


### PR DESCRIPTION
Adding the MySQL driver as a dependency will prevent a lot of SSH and SCP operations on CI servers. It is OK to add MySQL connector as a test dependency; it is part of other projects as a test dependency as well, like analyzer.