### PR TITLE
[MONDRIAN-1107] - Mondrian does not call SegmentCache.getSegmentHeaders()

### DIFF
--- a/src/main/mondrian/rolap/RolapSchema.java
+++ b/src/main/mondrian/rolap/RolapSchema.java
@@ -1402,6 +1402,10 @@ System.out.println("RolapSchema.createMemberReader: CONTAINS NAME");
             if (star == null) {
                 star = makeRolapStar(fact);
                 stars.put(factTableName, star);
+                // let cache manager load pending segments
+                // from external cache if needed
+                MondrianServer.forConnection(internalConnection)
+                    .getAggregationManager().cacheMgr.loadCacheForStar(star);
             }
             return star;
         }

--- a/testsrc/main/mondrian/rolap/agg/MockSegmentCache.java
+++ b/testsrc/main/mondrian/rolap/agg/MockSegmentCache.java
@@ -1,20 +1,22 @@
 /*
-* This software is subject to the terms of the Eclipse Public License v1.0
-* Agreement, available at the following URL:
-* http://www.eclipse.org/legal/epl-v10.html.
-* You must accept the terms of that agreement to use this software.
-*
-* Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
 */
-
 package mondrian.rolap.agg;
 
 import mondrian.olap.Util;
+import mondrian.rolap.CellKey;
 import mondrian.spi.*;
 
 import java.io.*;
 import java.util.*;
 import java.util.concurrent.*;
+
+import static java.util.Collections.singletonMap;
 
 /**
  * Mock implementation of {@link SegmentCache} that is used for automated
@@ -180,6 +182,48 @@ public class MockSegmentCache implements SegmentCache {
     {
         for (SegmentCacheListener listener : listeners) {
             listener.handle(event);
+        }
+    }
+
+    public static SegmentBody mockSegmentBody(Object value) {
+        return new MockSegmentBody(value);
+    }
+
+    public static class MockSegmentBody implements SegmentBody, Serializable {
+
+        private final Object value;
+
+        public MockSegmentBody(Object value) {
+            this.value = value;
+        }
+
+        @Override
+        public Map<CellKey, Object> getValueMap() {
+            return singletonMap(CellKey.Generator.newCellKey(1), value);
+        }
+
+        @Override
+        public Object getValueArray() {
+            return new Object[] {value};
+        }
+
+        @Override
+        public BitSet getNullValueIndicators() {
+            BitSet bitSet = new BitSet();
+            bitSet.set(0);
+            return bitSet;
+        }
+
+        @Override
+        public SortedSet<Comparable>[] getAxisValueSets() {
+            SortedSet<Integer> set = new TreeSet<Integer>();
+            set.add(0);
+            return new SortedSet[]{set};
+        }
+
+        @Override
+        public boolean[] getNullAxisFlags() {
+            return new boolean[]{false};
         }
     }
 }

--- a/testsrc/main/mondrian/rolap/agg/SegmentCacheManager_ExternalCache_Test.java
+++ b/testsrc/main/mondrian/rolap/agg/SegmentCacheManager_ExternalCache_Test.java
@@ -1,0 +1,168 @@
+/*
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (c) 2015-2015 Pentaho Corporation..  All rights reserved.
+*/
+package mondrian.rolap.agg;
+
+import mondrian.olap.MondrianServer;
+import mondrian.rolap.BitKey;
+import mondrian.rolap.RolapSchema;
+import mondrian.rolap.RolapStar;
+import mondrian.rolap.cache.SegmentCacheIndex;
+import mondrian.server.Locus;
+import mondrian.server.monitor.CellCacheSegmentCreateEvent;
+import mondrian.server.monitor.Monitor;
+import mondrian.spi.SegmentColumn;
+import mondrian.spi.SegmentHeader;
+import mondrian.test.PropertyRestoringTestCase;
+import mondrian.util.ByteString;
+
+import java.util.Collections;
+
+import static org.mockito.Mockito.*;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+public class SegmentCacheManager_ExternalCache_Test
+    extends PropertyRestoringTestCase
+{
+
+    private static final String TABLE = "factTable";
+
+    private MondrianServer server;
+    private SegmentHeader cachedHeader;
+    private RolapSchema schema;
+
+    private SegmentCacheManager manager;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        initDefaultSettings();
+
+        schema = mockSchema();
+        cachedHeader = createSegmentHeader();
+        prepareMockCache();
+        server = mockServer();
+
+        manager = new SegmentCacheManager(server);
+    }
+
+    private void initDefaultSettings() {
+        // ensure caching is enabled
+        propSaver.set(propSaver.properties.DisableCaching, false);
+        // switch off in-memory cache in these tests
+        propSaver.set(propSaver.properties.DisableLocalSegmentCache, true);
+        // define test instance of cache
+        propSaver.set(
+            propSaver.properties.SegmentCache,
+            MockSegmentCache.class.getName());
+    }
+
+    private RolapSchema mockSchema() {
+        RolapSchema schema = mock(RolapSchema.class);
+        when(schema.getName()).thenReturn("schema");
+        when(schema.getChecksum()).thenReturn(
+            new ByteString("schema".getBytes()));
+        return schema;
+    }
+
+    private SegmentHeader createSegmentHeader() {
+        return new SegmentHeader(
+            schema.getName(), schema.getChecksum(), "cube", "measure",
+            Collections.<SegmentColumn>emptyList(),
+            Collections.<String>emptyList(), TABLE,
+            BitKey.EMPTY, Collections.<SegmentColumn>emptyList());
+    }
+
+    private void prepareMockCache() {
+        MockSegmentCache cache = new MockSegmentCache();
+        // clear static map and initialise with values for test
+        cache.tearDown();
+        cache.put(cachedHeader, MockSegmentCache.mockSegmentBody("body"));
+    }
+
+    private MondrianServer mockServer() {
+        MondrianServer server = mock(MondrianServer.class);
+        Monitor monitor = mock(Monitor.class);
+        when(server.getMonitor()).thenReturn(monitor);
+        return server;
+    }
+
+
+    @Override
+    public void tearDown() throws Exception {
+        manager.shutdown();
+        manager = null;
+
+        server = null;
+        cachedHeader = null;
+        schema = null;
+
+        super.tearDown();
+    }
+
+
+    private RolapStar mockStar() {
+        return mockStar(TABLE);
+    }
+
+    private RolapStar mockStar(String tableName) {
+        RolapStar.Table table = mock(RolapStar.Table.class);
+        when(table.getAlias()).thenReturn(tableName);
+
+        RolapStar star = mock(RolapStar.class);
+        when(star.getFactTable()).thenReturn(table);
+        when(star.getSchema()).thenReturn(schema);
+        return star;
+    }
+
+
+    public void testAddsPreloadedCacheForKnownTable() {
+        final RolapStar star = mockStar();
+
+        assertTrue(manager.loadCacheForStar(star));
+        verify(server.getMonitor(), times(1))
+            .sendEvent(any(CellCacheSegmentCreateEvent.class));
+
+        SegmentCacheIndex index = manager.execute(
+            new SegmentCacheManager.Command<SegmentCacheIndex>()
+            {
+                @Override
+                public Locus getLocus() {
+                    return null;
+                }
+
+                @Override
+                public SegmentCacheIndex call() throws Exception {
+                    return manager.getIndexRegistry().getIndex(star);
+                }
+        });
+        assertTrue(index.contains(cachedHeader));
+    }
+
+    public void testDoesNothing_ForUnknownTable() {
+        RolapStar star = mockStar("someTable");
+
+        assertFalse(manager.loadCacheForStar(star));
+        verify(server.getMonitor(), never())
+            .sendEvent(any(CellCacheSegmentCreateEvent.class));
+    }
+
+    @SuppressWarnings("deprecation")
+    public void testDoesNothing_WhenCacheIsDisabled() {
+        propSaver.set(propSaver.properties.DisableCaching, true);
+        RolapStar star = mockStar();
+
+        assertFalse(manager.loadCacheForStar(star));
+        assertTrue(manager.getStarFactTablesToSync().contains(TABLE));
+    }
+}
+
+// End SegmentCacheManager_ExternalCache_Test.java

--- a/testsrc/main/mondrian/test/FoodMartTestCase.java
+++ b/testsrc/main/mondrian/test/FoodMartTestCase.java
@@ -28,24 +28,13 @@ import java.util.*;
  * @author jhyde
  * @since 29 March, 2002
  */
-public class FoodMartTestCase extends TestCase {
-
-    /**
-     * Access properties via this object and their values will be reset on
-     * {@link #tearDown()}.
-     */
-    protected final PropertySaver propSaver = new PropertySaver();
+public class FoodMartTestCase extends PropertyRestoringTestCase {
 
     public FoodMartTestCase(String name) {
         super(name);
     }
 
     public FoodMartTestCase() {
-    }
-
-    protected void tearDown() throws Exception {
-        // revert any properties that have been set during this test
-        propSaver.reset();
     }
 
     /**

--- a/testsrc/main/mondrian/test/Main.java
+++ b/testsrc/main/mondrian/test/Main.java
@@ -226,6 +226,7 @@ public class Main extends TestSuite {
             addTest(suite, ScenarioTest.class);
             addTest(suite, BasicQueryTest.class);
             addTest(suite, SegmentCacheTest.class);
+            addTest(suite, SegmentCacheManager_ExternalCache_Test.class);
             addTest(suite, CVBasicTest.class, "suite");
             addTest(suite, GrandTotalTest.class, "suite");
             addTest(suite, HangerDimensionTest.class, "suite");

--- a/testsrc/main/mondrian/test/PropertyRestoringTestCase.java
+++ b/testsrc/main/mondrian/test/PropertyRestoringTestCase.java
@@ -1,0 +1,38 @@
+/*
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (c) 2015-2015 Pentaho Corporation..  All rights reserved.
+*/
+package mondrian.test;
+
+import junit.framework.TestCase;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+public class PropertyRestoringTestCase extends TestCase {
+
+    public PropertyRestoringTestCase() {
+    }
+
+    public PropertyRestoringTestCase(String name) {
+        super(name);
+    }
+
+    /**
+     * Access properties via this object and their values will be reset on
+     * {@link #tearDown()}.
+     */
+    protected final PropertySaver propSaver = new PropertySaver();
+
+    @Override
+    protected void tearDown() throws Exception {
+        // revert any properties that have been set during this test
+        propSaver.reset();
+    }
+}
+
+// End PropertyRestoringTestCase.java


### PR DESCRIPTION
- adopt 9ab54555427f5482c56003cfd3ddff267b8086cc
- add tests

@mkambol, @lucboudreau, review it please. This is a rework over https://github.com/pentaho/mondrian/commit/9ab54555427f5482c56003cfd3ddff267b8086cc with additional tests  