### PR TITLE
[MONDRIAN-1562] - NPE in SegmentCacheIndexImpl.loadSucceeded.

### DIFF
--- a/src/main/mondrian/rolap/cache/SegmentCacheIndexImpl.java
+++ b/src/main/mondrian/rolap/cache/SegmentCacheIndexImpl.java
@@ -240,12 +240,27 @@ public class SegmentCacheIndexImpl implements SegmentCacheIndex {
     {
         checkThread();
 
-        LOGGER.trace(
-            "SegmentCacheIndexImpl.update: Updating header from:\n"
-            + oldHeader.toString()
-            + "\n\nto\n\n"
-            + newHeader.toString());
+        if (LOGGER.isTraceEnabled()) {
+            LOGGER.trace(
+                "SegmentCacheIndexImpl.update: Updating header from:\n"
+                + oldHeader.toString()
+                + "\n\nto\n\n"
+                + newHeader.toString());
+        }
+
         final HeaderInfo headerInfo = headerMap.get(oldHeader);
+
+        //[MONDRIAN-1562] NPE in SegmentCacheIndexImpl.loadSucceeded
+        if (headerInfo == null){
+            LOGGER.warn("SegmentCacheIndexImpl.update: Updating header from:\n"
+                    + oldHeader.toString()
+                    + "\n\nto\n\n"
+                    + newHeader.toString()
+                    + ". oldHeader not found. Has it already been removed after" +
+                    " previous FlushCommands?");
+            return;
+        }
+
         headerMap.remove(oldHeader);
         headerMap.put(newHeader, headerInfo);
 


### PR DESCRIPTION
#### Changes
- Fixed: added null check for headerInfo.
- Added warn to notify that 'headerMap.get(oldHeader)' returned null.
- Added 'return;' if 'headerMap.get(oldHeader)' returned null.

#### Comment
This is a fix of issue [MONDRIAN-1562]. I work with Dmitry Amelin, who described the problem in our application in comments to the issue. Please look through his comment in the issue to understand what kind of problem in this commit we've fixed.