### PR TITLE
[MONDRIAN-2430]  The 2 arg form of TopCount can perform badly

### DIFF
--- a/src/main/mondrian/rolap/DefaultTupleConstraint.java
+++ b/src/main/mondrian/rolap/DefaultTupleConstraint.java
@@ -5,10 +5,9 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2004-2005 TONBELLER AG
-// Copyright (C) 2006-2012 Pentaho and others
+// Copyright (C) 2006-2015 Pentaho and others
 // All Rights Reserved.
 */
-
 package mondrian.rolap;
 
 import mondrian.olap.Evaluator;
@@ -62,6 +61,11 @@ public class DefaultTupleConstraint implements TupleConstraint {
 
     public Evaluator getEvaluator() {
         return null;
+    }
+
+    @Override
+    public boolean supportsAggTables() {
+        return false;
     }
 }
 

--- a/src/main/mondrian/rolap/DescendantsConstraint.java
+++ b/src/main/mondrian/rolap/DescendantsConstraint.java
@@ -5,10 +5,9 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2004-2005 TONBELLER AG
-// Copyright (C) 2006-2012 Pentaho and others
+// Copyright (C) 2006-2015 Pentaho and others
 // All Rights Reserved.
 */
-
 package mondrian.rolap;
 
 import mondrian.olap.Evaluator;
@@ -77,6 +76,11 @@ class DescendantsConstraint implements TupleConstraint {
 
     public Evaluator getEvaluator() {
         return null;
+    }
+
+    @Override
+    public boolean supportsAggTables() {
+        return true;
     }
 }
 

--- a/src/main/mondrian/rolap/MemberExcludeConstraint.java
+++ b/src/main/mondrian/rolap/MemberExcludeConstraint.java
@@ -124,6 +124,11 @@ class MemberExcludeConstraint implements TupleConstraint {
             return null;
         }
     }
+
+    @Override
+    public boolean supportsAggTables() {
+        return true;
+    }
 }
 
 // End MemberExcludeConstraint.java

--- a/src/main/mondrian/rolap/RolapNativeSet.java
+++ b/src/main/mondrian/rolap/RolapNativeSet.java
@@ -99,19 +99,23 @@ public abstract class RolapNativeSet extends RolapNative {
         {
             super.addConstraint(sqlQuery, baseCube, aggStar);
             for (CrossJoinArg arg : args) {
-                // if the cross join argument has calculated members in its
-                // enumerated set, ignore the constraint since we won't
-                // produce that set through the native sql and instead
-                // will simply enumerate through the members in the set
-                if (!(arg instanceof MemberListCrossJoinArg)
-                    || !((MemberListCrossJoinArg) arg).hasCalcMembers())
-                {
+                if (canApplyCrossJoinArgConstraint(arg)) {
                     RolapLevel level = arg.getLevel();
                     if (level == null || levelIsOnBaseCube(baseCube, level)) {
                         arg.addConstraint(sqlQuery, baseCube, aggStar);
                     }
                 }
             }
+        }
+
+        /** If the cross join argument has calculated members in its
+         *  enumerated set, ignore the constraint since we won't
+         *  produce that set through the native sql and instead
+         *  will simply enumerate through the members in the set
+         */
+        protected boolean canApplyCrossJoinArgConstraint(CrossJoinArg arg) {
+            return !(arg instanceof MemberListCrossJoinArg)
+                || !((MemberListCrossJoinArg) arg).hasCalcMembers();
         }
 
         private boolean levelIsOnBaseCube(
@@ -142,9 +146,7 @@ public abstract class RolapNativeSet extends RolapNative {
             // args that are sets with calculated members aren't executed
             // natively
             for (CrossJoinArg arg : args) {
-                if (!(arg instanceof MemberListCrossJoinArg)
-                    || !((MemberListCrossJoinArg) arg).hasCalcMembers())
-                {
+                if (canApplyCrossJoinArgConstraint(arg)) {
                     key.add(arg);
                 }
             }

--- a/src/main/mondrian/rolap/RolapNativeTopCount.java
+++ b/src/main/mondrian/rolap/RolapNativeTopCount.java
@@ -51,13 +51,41 @@ public class RolapNativeTopCount extends RolapNativeSet {
         }
 
         /**
+         * If the orderByExpr is not present than we're dealing with
+         * the 2 arg form of TC.  The 2 arg form cannot be evaluated
+         * with a join to the fact.  Because of this, it's only valid
+         * to apply a native constraint for the 2 arg form if a single CJ
+         * arg is in place.  Otherwise we'd need to join the dims together
+         * via the fact table, which could eliminate tuples that should
+         * be returned.
+         */
+        protected boolean isValid() {
+            if (orderByExpr == null) {
+                return args.length == 1
+                    && canApplyCrossJoinArgConstraint(args[0]);
+            }
+            return true;
+        }
+
+        /**
          * {@inheritDoc}
          *
-         * <p>TopCount always needs to join the fact table because we want to
-         * evaluate the top count expression which involves a fact.
+         * <p>TopCount needs to join the fact table if a top count expression
+         * is present (i.e. orderByExpr).  If not present than the results of
+         * TC should be the natural ordering of the set in the first argument,
+         * which cannot use a join to the fact table without potentially
+         * eliminating empty tuples.
          */
         protected boolean isJoinRequired() {
-            return true;
+            return orderByExpr != null;
+        }
+
+        @Override
+        public boolean supportsAggTables() {
+            // We can only safely use agg tables if we can limit
+            // results to those with data (i.e. if we would be
+            // joining to a fact table).
+            return isJoinRequired();
         }
 
         public void addConstraint(
@@ -65,6 +93,7 @@ public class RolapNativeTopCount extends RolapNativeSet {
             RolapCube baseCube,
             AggStar aggStar)
         {
+            assert isValid();
             if (orderByExpr != null) {
                 RolapNativeSql sql =
                     new RolapNativeSql(
@@ -83,7 +112,11 @@ public class RolapNativeTopCount extends RolapNativeSet {
                     nullable,
                     true);
             }
-            super.addConstraint(sqlQuery, baseCube, aggStar);
+            if (isJoinRequired()) {
+                super.addConstraint(sqlQuery, baseCube, aggStar);
+            } else if (args.length == 1) {
+                args[0].addConstraint(sqlQuery, baseCube, null);
+            }
         }
 
         private boolean deduceNullability(Exp expr) {
@@ -146,11 +179,6 @@ public class RolapNativeTopCount extends RolapNativeSet {
             return null;
         }
 
-        if (args.length == 2) {
-            // MONDRIAN-2394: for now, prohibit native evaluation
-            return null;
-        }
-
         // extract the set expression
         List<CrossJoinArg[]> allArgs =
             crossJoinArgFactory().checkCrossJoinArg(evaluator, args[0]);
@@ -160,16 +188,22 @@ public class RolapNativeTopCount extends RolapNativeSet {
         // contains additional constraints on the dimensions. If either the list
         // or the first array is null, then native cross join is not feasible.
         if (allArgs == null || allArgs.isEmpty() || allArgs.get(0) == null) {
+            alertNonNativeTopCount(
+                "Set in 1st argument does not support native eval.");
             return null;
         }
 
         CrossJoinArg[] cjArgs = allArgs.get(0);
         if (isPreferInterpreter(cjArgs, false)) {
+            alertNonNativeTopCount(
+                "One or more args prefer non-native.");
             return null;
         }
 
         // extract count
         if (!(args[1] instanceof Literal)) {
+            alertNonNativeTopCount(
+                "TopCount value cannot be determined.");
             return null;
         }
         int count = ((Literal) args[1]).getIntValue();
@@ -191,10 +225,12 @@ public class RolapNativeTopCount extends RolapNativeSet {
             orderByExpr = args[2];
             String orderBySQL = sql.generateTopCountOrderBy(args[2]);
             if (orderBySQL == null) {
+                alertNonNativeTopCount(
+                    "Cannot convert order by expression to SQL.");
                 return null;
             }
         }
-        LOGGER.debug("using native topcount");
+
         final int savepoint = evaluator.savepoint();
         try {
             overrideContext(evaluator, cjArgs, sql.getStoredMeasure());
@@ -213,9 +249,15 @@ public class RolapNativeTopCount extends RolapNativeSet {
             } else {
                 combinedArgs = cjArgs;
             }
-            TupleConstraint constraint =
+            TopCountConstraint constraint =
                 new TopCountConstraint(
                     count, combinedArgs, evaluator, orderByExpr, ascending);
+            if (!constraint.isValid()) {
+                alertNonNativeTopCount(
+                    "Constraint constructed cannot be used for native eval.");
+                return null;
+            }
+            LOGGER.debug("using native topcount");
             SetEvaluator sev =
                 new SetEvaluator(cjArgs, schemaReader, constraint);
             sev.setMaxRows(count);
@@ -224,6 +266,10 @@ public class RolapNativeTopCount extends RolapNativeSet {
         } finally {
             evaluator.restore(savepoint);
         }
+    }
+
+    private void alertNonNativeTopCount(String msg) {
+        RolapUtil.alertNonNative("TopCount", msg);
     }
 
     // package-local visibility for testing purposes

--- a/src/main/mondrian/rolap/SqlContextConstraint.java
+++ b/src/main/mondrian/rolap/SqlContextConstraint.java
@@ -231,9 +231,9 @@ public class SqlContextConstraint
 
         // Now we'll need to expand the aggregated members
         expandedMembers.addAll(
-                SqlConstraintUtils.expandSupportedCalculatedMembers(
-                    members,
-                    evaluator));
+            SqlConstraintUtils.expandSupportedCalculatedMembers(
+                members,
+                evaluator));
         cacheKey.add(expandedMembers);
         cacheKey.add(evaluator.getSlicerTuples());
 
@@ -365,6 +365,11 @@ public class SqlContextConstraint
 
     public Evaluator getEvaluator() {
         return evaluator;
+    }
+
+    @Override
+    public boolean supportsAggTables() {
+        return true;
     }
 }
 

--- a/src/main/mondrian/rolap/SqlTupleReader.java
+++ b/src/main/mondrian/rolap/SqlTupleReader.java
@@ -1394,7 +1394,7 @@ public class SqlTupleReader implements TupleReader {
             return null;
         }
 
-        if (evaluator == null) {
+        if (evaluator == null || !constraint.supportsAggTables()) {
             return null;
         }
 

--- a/src/main/mondrian/rolap/sql/MemberKeyConstraint.java
+++ b/src/main/mondrian/rolap/sql/MemberKeyConstraint.java
@@ -1,12 +1,11 @@
 /*
-* This software is subject to the terms of the Eclipse Public License v1.0
-* Agreement, available at the following URL:
-* http://www.eclipse.org/legal/epl-v10.html.
-* You must accept the terms of that agreement to use this software.
-*
-* Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
 */
-
 package mondrian.rolap.sql;
 
 import mondrian.olap.Evaluator;
@@ -84,6 +83,11 @@ public class MemberKeyConstraint
 
     public Evaluator getEvaluator() {
         return null;
+    }
+
+    @Override
+    public boolean supportsAggTables() {
+        return true;
     }
 }
 

--- a/src/main/mondrian/rolap/sql/TupleConstraint.java
+++ b/src/main/mondrian/rolap/sql/TupleConstraint.java
@@ -5,10 +5,9 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2004-2005 TONBELLER AG
-// Copyright (C) 2006-2012 Pentaho and others
+// Copyright (C) 2006-2015 Pentaho and others
 // All Rights Reserved.
 */
-
 package mondrian.rolap.sql;
 
 import mondrian.olap.Evaluator;
@@ -78,6 +77,11 @@ public interface TupleConstraint extends SqlConstraint {
      * if there is no associated evaluator
      */
     public Evaluator getEvaluator();
+
+    /**
+     * @return true if the constraint can leverage an aggregate table
+     */
+    public boolean supportsAggTables();
 }
 
 // End TupleConstraint.java


### PR DESCRIPTION
The 2 arg form of TC/BC should return the tuple set in its
natural order.  Because of this, we cannot join to the fact table
when determining the set.  Native eval can still be  valuable,
however, since member constraints and limiting sql to top N rows
can reduce set evaluation time.

This change makes the isJoinRequired method of TopCountConstraint
conditional on whether an orderByExpression is present.  It
also adds logic to determine whether the constraint is valid, since
push down with the 2 arg form of TC can only be done if
a single crossjoin arg is present.

http://jira.pentaho.com/browse/MONDRIAN-2430

@lucboudreau 