### PR TITLE
[MONDRIAN-1803] - Getting Wrong Results on 3.5 while correct results on 3.4 for same MDX and schema properties also

### DIFF
--- a/src/main/mondrian/resource/MondrianResource.xml
+++ b/src/main/mondrian/resource/MondrianResource.xml
@@ -878,6 +878,12 @@
     </text>
 </message>
 
+<message id="8000200" name="MembersQuantityExceedsMaxConstraints">
+    <text>
+        Quantify of supported calculated members(''{0}'') exceeds value of the mondrian.rolap.maxConstraints property.
+    </text>
+</message>
+
 <!-- ====================================================================== -->
 <!-- Execution -->
 <exception id="8500001" name="ExecutionStatementCleanupException">

--- a/src/main/mondrian/rolap/RolapNativeFilter.java
+++ b/src/main/mondrian/rolap/RolapNativeFilter.java
@@ -6,7 +6,7 @@
 //
 // Copyright (C) 2004-2005 TONBELLER AG
 // Copyright (C) 2005-2005 Julian Hyde
-// Copyright (C) 2005-2014 Pentaho
+// Copyright (C) 2005-2015 Pentaho
 // All Rights Reserved.
 */
 package mondrian.rolap;
@@ -130,7 +130,7 @@ public class RolapNativeFilter extends RolapNativeSet {
             return null;
         }
         if (!FilterConstraint.isValidContext(
-                evaluator, restrictMemberTypes()))
+                evaluator, true, null, restrictMemberTypes(), fun))
         {
             return null;
         }

--- a/src/main/mondrian/rolap/RolapUtil.java
+++ b/src/main/mondrian/rolap/RolapUtil.java
@@ -5,7 +5,7 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2001-2005 Julian Hyde
-// Copyright (C) 2005-2014 Pentaho and others
+// Copyright (C) 2005-2015 Pentaho and others
 // All Rights Reserved.
 //
 // jhyde, 22 December, 2001
@@ -368,10 +368,16 @@ public class RolapUtil {
         String reason)
         throws NativeEvaluationUnsupportedException
     {
+        String predicate = "Unable to use native SQL evaluation";
         // No i18n for log message, but yes for excn
-        String alertMsg =
-            "Unable to use native SQL evaluation for '" + functionName
-            + "'; reason:  " + reason;
+        StringBuilder alertMsg = new StringBuilder(predicate);
+        if (functionName != null && !functionName.isEmpty()) {
+            alertMsg.append(" for '").append(functionName).append("'");
+        }
+        if (reason != null && !reason.isEmpty()) {
+            alertMsg.append("; reason: ").append(reason);
+        }
+
 
         StringProperty alertProperty =
             MondrianProperties.instance().AlertNativeEvaluationUnsupported;


### PR DESCRIPTION
@mkambol, @lucboudreau, could you please take a look?
Here is a fallback strategy. 
In order to use it mondrian.native.unsupported.alert=ERROR property should be added to mondrian.properties