### PR TITLE
[MONDRIAN-2394] - Mondrian TopCount returns only non empty tuples whe…

### DIFF
--- a/src/main/mondrian/rolap/RolapNativeTopCount.java
+++ b/src/main/mondrian/rolap/RolapNativeTopCount.java
@@ -26,7 +26,7 @@ import javax.sql.DataSource;
  *
  * @author av
  * @since Nov 21, 2005
-  */
+ */
 public class RolapNativeTopCount extends RolapNativeSet {
 
     public RolapNativeTopCount() {
@@ -112,7 +112,7 @@ public class RolapNativeTopCount extends RolapNativeSet {
             if (this.getEvaluator() instanceof RolapEvaluator) {
                 key.add(
                     ((RolapEvaluator)this.getEvaluator())
-                    .getSlicerMembers());
+                        .getSlicerMembers());
             }
             return key;
         }
@@ -127,18 +127,12 @@ public class RolapNativeTopCount extends RolapNativeSet {
         FunDef fun,
         Exp[] args)
     {
-        boolean ascending;
-
-        if (!isEnabled()) {
-            return null;
-        }
-        if (!TopCountConstraint.isValidContext(
-                evaluator, restrictMemberTypes()))
-        {
+        if (!isEnabled() || !isValidContext(evaluator)) {
             return null;
         }
 
         // is this "TopCount(<set>, <count>, [<numeric expr>])"
+        boolean ascending;
         String funName = fun.getName();
         if ("TopCount".equalsIgnoreCase(funName)) {
             ascending = false;
@@ -148,6 +142,11 @@ public class RolapNativeTopCount extends RolapNativeSet {
             return null;
         }
         if (args.length < 2 || args.length > 3) {
+            return null;
+        }
+
+        if (args.length == 2) {
+            // MONDRIAN-2394: for now, prohibit native evaluation
             return null;
         }
 
@@ -209,7 +208,7 @@ public class RolapNativeTopCount extends RolapNativeSet {
                 // Combined the CJ and the additional predicate args
                 // to form the TupleConstraint.
                 combinedArgs =
-                        Util.appendArrays(cjArgs, predicateArgs);
+                    Util.appendArrays(cjArgs, predicateArgs);
             } else {
                 combinedArgs = cjArgs;
             }
@@ -223,6 +222,12 @@ public class RolapNativeTopCount extends RolapNativeSet {
         } finally {
             evaluator.restore(savepoint);
         }
+    }
+
+    // package-local visibility for testing purposes
+    boolean isValidContext(RolapEvaluator evaluator) {
+        return TopCountConstraint.isValidContext(
+            evaluator, restrictMemberTypes());
     }
 }
 

--- a/testsrc/main/mondrian/rolap/RolapNativeTopCountTest.java
+++ b/testsrc/main/mondrian/rolap/RolapNativeTopCountTest.java
@@ -1,0 +1,126 @@
+/*
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (C) 2015-2015 Pentaho and others
+// All Rights Reserved.
+*/
+package mondrian.rolap;
+
+import mondrian.test.TestContext;
+
+import static mondrian.rolap.RolapNativeTopCountTestCases.*;
+
+/**
+ * @author Andrey Khayrutdinov
+ * @see RolapNativeTopCountTestCases
+ */
+public class RolapNativeTopCountTest extends BatchTestCase {
+
+    public void setUp() throws Exception {
+        super.setUp();
+        propSaver.set(propSaver.properties.EnableNativeTopCount, true);
+    }
+
+    public void testTopCount_ImplicitCountMeasure() throws Exception {
+        assertQueryReturns(
+            IMPLICIT_COUNT_MEASURE_QUERY, IMPLICIT_COUNT_MEASURE_RESULT);
+    }
+
+    public void testTopCount_CountMeasure() throws Exception {
+        final String schema = TestContext.instance()
+                .getSchema(
+                    null, CUSTOM_COUNT_MEASURE_CUBE,
+                    null, null, null, null);
+
+        TestContext ctx = TestContext.instance()
+                .withSchema(schema)
+                .withCube(CUSTOM_COUNT_MEASURE_CUBE_NAME);
+
+        ctx.assertQueryReturns(
+            CUSTOM_COUNT_MEASURE_QUERY, CUSTOM_COUNT_MEASURE_RESULT);
+    }
+
+    public void testTopCount_SumMeasure() throws Exception {
+        assertQueryReturns(SUM_MEASURE_QUERY, SUM_MEASURE_RESULT);
+    }
+
+
+    public void testEmptyCellsAreShown_Countries() {
+        assertQueryReturns(
+            EMPTY_CELLS_ARE_SHOWN_COUNTRIES_QUERY,
+            EMPTY_CELLS_ARE_SHOWN_COUNTRIES_RESULT);
+    }
+
+    public void testEmptyCellsAreShown_States() {
+        assertQueryReturns(
+            EMPTY_CELLS_ARE_SHOWN_STATES_QUERY,
+            EMPTY_CELLS_ARE_SHOWN_STATES_RESULT);
+    }
+
+    public void testEmptyCellsAreShown_ButNoMoreThanReallyExist() {
+        assertQueryReturns(
+            EMPTY_CELLS_ARE_SHOWN_NOT_MORE_THAN_EXIST_QUERY,
+            EMPTY_CELLS_ARE_SHOWN_NOT_MORE_THAN_EXIST_RESULT);
+    }
+
+    public void testEmptyCellsAreHidden_WhenNonEmptyIsDeclaredExplicitly() {
+        assertQueryReturns(
+            EMPTY_CELLS_ARE_HIDDEN_WHEN_NON_EMPTY_QUERY,
+            EMPTY_CELLS_ARE_HIDDEN_WHEN_NON_EMPTY_RESULT);
+    }
+
+
+    public void testRoleRestrictionWorks_ForRowWithData() throws Exception {
+        TestContext ctx = TestContext.instance()
+            .create(
+                null, null, null, null, null,
+                ROLE_RESTRICTION_WORKS_WA_ROLE_DEF)
+            .withRole(ROLE_RESTRICTION_WORKS_WA_ROLE_NAME);
+
+        ctx.assertQueryReturns(
+            ROLE_RESTRICTION_WORKS_WA_QUERY,
+            ROLE_RESTRICTION_WORKS_WA_RESULT);
+    }
+
+    public void testRoleRestrictionWorks_ForRowWithOutData() throws Exception {
+        TestContext ctx = TestContext.instance()
+            .create(
+                null, null, null, null, null,
+                ROLE_RESTRICTION_WORKS_DF_ROLE_DEF)
+            .withRole(ROLE_RESTRICTION_WORKS_DF_ROLE_NAME);
+
+        ctx.assertQueryReturns(
+            ROLE_RESTRICTION_WORKS_DF_QUERY,
+            ROLE_RESTRICTION_WORKS_DF_RESULT);
+    }
+
+
+    public void testMimicsHeadWhenTwoParams_States() {
+        assertQueryReturns(
+            TOPCOUNT_MIMICS_HEAD_WHEN_TWO_PARAMS_STATES_QUERY,
+            TOPCOUNT_MIMICS_HEAD_WHEN_TWO_PARAMS_STATES_RESULT);
+    }
+
+    public void testMimicsHeadWhenTwoParams_Cities() {
+        assertQueryReturns(
+            TOPCOUNT_MIMICS_HEAD_WHEN_TWO_PARAMS_CITIES_QUERY,
+            TOPCOUNT_MIMICS_HEAD_WHEN_TWO_PARAMS_CITIES_RESULT);
+    }
+
+    public void testMimicsHeadWhenTwoParams_ShowsNotMoreThanExist() {
+        assertQueryReturns(
+            RESULTS_ARE_SHOWN_NOT_MORE_THAN_EXIST_2_PARAMS_QUERY,
+            RESULTS_ARE_SHOWN_NOT_MORE_THAN_EXIST_2_PARAMS_RESULT);
+    }
+
+    public void testMimicsHeadWhenTwoParams_DoesNotIgnoreNonEmpty() {
+        assertQueryReturns(
+            NON_EMPTY_IS_NOT_IGNORED_WHEN_TWO_PARAMS_QUERY,
+            NON_EMPTY_IS_NOT_IGNORED_WHEN_TWO_PARAMS_RESULT);
+    }
+}
+
+// End RolapNativeTopCountTest.java

--- a/testsrc/main/mondrian/rolap/RolapNativeTopCountTestCases.java
+++ b/testsrc/main/mondrian/rolap/RolapNativeTopCountTestCases.java
@@ -1,0 +1,463 @@
+/*
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (C) 2015-2015 Pentaho and others
+// All Rights Reserved.
+*/
+package mondrian.rolap;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+class RolapNativeTopCountTestCases {
+
+    //
+    // The case for verifying NativeTopCount can handle implicit
+    // count measure, which is created each time.
+    //
+
+    static final String IMPLICIT_COUNT_MEASURE_QUERY = ""
+        + "SELECT [Measures].[Fact Count] ON COLUMNS, "
+        + "TOPCOUNT([Store Type].[All Store Types].Children, 3, [Measures].[Fact Count]) ON ROWS "
+        + "FROM [Store]";
+
+    static final String IMPLICIT_COUNT_MEASURE_RESULT = ""
+        + "Axis #0:\n"
+        + "{}\n"
+        + "Axis #1:\n"
+        + "{[Measures].[Fact Count]}\n"
+        + "Axis #2:\n"
+        + "{[Store Type].[Supermarket]}\n"
+        + "{[Store Type].[Deluxe Supermarket]}\n"
+        + "{[Store Type].[Mid-Size Grocery]}\n"
+        + "Row #0: 8\n"
+        + "Row #1: 6\n"
+        + "Row #2: 4\n";
+
+
+    //
+    // The case for verifying NativeTopCount can handle explicitly defined
+    // count measure.
+    //
+
+    static final String CUSTOM_COUNT_MEASURE_CUBE_NAME = "StoreWithCountM";
+
+    static final String CUSTOM_COUNT_MEASURE_CUBE = ""
+        + "  <Cube name=\"StoreWithCountM\" visible=\"true\" cache=\"true\" enabled=\"true\">\n"
+        + "    <Table name=\"store\">\n"
+        + "    </Table>\n"
+        + "    <Dimension visible=\"true\" highCardinality=\"false\" name=\"Store Type\">\n"
+        + "      <Hierarchy visible=\"true\" hasAll=\"true\">\n"
+        + "        <Level name=\"Store Type\" visible=\"true\" column=\"store_type\" type=\"String\" uniqueMembers=\"true\" levelType=\"Regular\" hideMemberIf=\"Never\">\n"
+        + "        </Level>\n"
+        + "      </Hierarchy>\n"
+        + "    </Dimension>\n"
+        + "    <DimensionUsage source=\"Store\" name=\"Store\" visible=\"true\" highCardinality=\"false\">\n"
+        + "    </DimensionUsage>\n"
+        + "    <Dimension visible=\"true\" highCardinality=\"false\" name=\"Has coffee bar\">\n"
+        + "      <Hierarchy visible=\"true\" hasAll=\"true\">\n"
+        + "        <Level name=\"Has coffee bar\" visible=\"true\" column=\"coffee_bar\" type=\"Boolean\" uniqueMembers=\"true\" levelType=\"Regular\" hideMemberIf=\"Never\">\n"
+        + "        </Level>\n"
+        + "      </Hierarchy>\n"
+        + "    </Dimension>\n"
+        + "    <Measure name=\"Store Sqft\" column=\"store_sqft\" formatString=\"#,###\" aggregator=\"sum\">\n"
+        + "    </Measure>\n"
+        + "    <Measure name=\"Grocery Sqft\" column=\"grocery_sqft\" formatString=\"#,###\" aggregator=\"sum\">\n"
+        + "    </Measure>\n"
+        + "    <Measure name=\"CountM\" column=\"store_id\" formatString=\"Standard\" aggregator=\"count\" visible=\"true\">\n"
+        + "    </Measure>\n"
+        + "  </Cube>";
+
+    static final String CUSTOM_COUNT_MEASURE_QUERY = ""
+        + "SELECT [Measures].[CountM] ON COLUMNS, "
+        + "TOPCOUNT([Store Type].[All Store Types].Children, 3, [Measures].[CountM]) ON ROWS "
+        + "FROM [StoreWithCountM]";
+
+    static final String CUSTOM_COUNT_MEASURE_RESULT = ""
+        + "Axis #0:\n"
+        + "{}\n"
+        + "Axis #1:\n"
+        + "{[Measures].[CountM]}\n"
+        + "Axis #2:\n"
+        + "{[Store Type].[Supermarket]}\n"
+        + "{[Store Type].[Deluxe Supermarket]}\n"
+        + "{[Store Type].[Mid-Size Grocery]}\n"
+        + "Row #0: 8\n"
+        + "Row #1: 6\n"
+        + "Row #2: 4\n";
+
+
+    //
+    // The case for verifying NativeTopCount can handle sum measure.
+    //
+
+    static final String SUM_MEASURE_QUERY = ""
+        + "SELECT [Measures].[Store Sqft] ON COLUMNS, "
+        + "TOPCOUNT([Store Type].[All Store Types].Children, 3, [Measures].[Store Sqft]) ON ROWS "
+        + "FROM [Store]";
+
+    static final String SUM_MEASURE_RESULT = ""
+        + "Axis #0:\n"
+        + "{}\n"
+        + "Axis #1:\n"
+        + "{[Measures].[Store Sqft]}\n"
+        + "Axis #2:\n"
+        + "{[Store Type].[Supermarket]}\n"
+        + "{[Store Type].[Deluxe Supermarket]}\n"
+        + "{[Store Type].[Mid-Size Grocery]}\n"
+        + "Row #0: 193,480\n"
+        + "Row #1: 146,045\n"
+        + "Row #2: 109,343\n";
+
+
+    //
+    // The case for verifying NativeTopCount returns tuples for those members
+    // that have no corresponding records in the fact table.
+    //
+    // This case checks countries level.
+    //
+
+    static final String EMPTY_CELLS_ARE_SHOWN_COUNTRIES_QUERY = ""
+        + "SELECT [Measures].[Unit Sales] ON COLUMNS, "
+        + "TOPCOUNT([Customers].[Country].Members, 2, [Measures].[Unit Sales]) ON ROWS "
+        + "FROM [Sales] "
+        + "WHERE [Time].[1997].[Q3]";
+
+    static final String EMPTY_CELLS_ARE_SHOWN_COUNTRIES_RESULT = ""
+        + "Axis #0:\n"
+        + "{[Time].[1997].[Q3]}\n"
+        + "Axis #1:\n"
+        + "{[Measures].[Unit Sales]}\n"
+        + "Axis #2:\n"
+        + "{[Customers].[USA]}\n"
+        + "{[Customers].[Canada]}\n"
+        + "Row #0: 65,848\n"
+        + "Row #1: \n";
+
+
+    //
+    // The case for verifying NativeTopCount returns tuples for those members
+    // that have no corresponding records in the fact table.
+    //
+    // This case checks states level.
+    //
+
+    static final String EMPTY_CELLS_ARE_SHOWN_STATES_QUERY = ""
+        + "SELECT [Measures].[Unit Sales] ON COLUMNS, "
+        + "TOPCOUNT([Customers].[State Province].Members, 6, [Measures].[Unit Sales]) ON ROWS "
+        + "FROM [Sales] "
+        + "WHERE [Time].[1997].[Q3]";
+
+    static final String EMPTY_CELLS_ARE_SHOWN_STATES_RESULT = ""
+        + "Axis #0:\n"
+        + "{[Time].[1997].[Q3]}\n"
+        + "Axis #1:\n"
+        + "{[Measures].[Unit Sales]}\n"
+        + "Axis #2:\n"
+        + "{[Customers].[USA].[WA]}\n"
+        + "{[Customers].[USA].[CA]}\n"
+        + "{[Customers].[USA].[OR]}\n"
+        + "{[Customers].[Canada].[BC]}\n"
+        + "{[Customers].[Mexico].[DF]}\n"
+        + "{[Customers].[Mexico].[Guerrero]}\n"
+        + "Row #0: 30,538\n"
+        + "Row #1: 18,370\n"
+        + "Row #2: 16,940\n"
+        + "Row #3: \n"
+        + "Row #4: \n"
+        + "Row #5: \n";
+
+
+    //
+    // The case for verifying NativeTopCount returns tuples for those members
+    // that have no corresponding records in the fact table.
+    //
+    // This case checks that no extra lines are returned. For instance,
+    // in the [Sales] cube (year 1997) there are records only for USA, Canada
+    // and Mexico; hence, even if limit parameter is 10
+    // then only 3 rows should be shown.
+    //
+
+    static final String EMPTY_CELLS_ARE_SHOWN_NOT_MORE_THAN_EXIST_QUERY = ""
+        + "SELECT [Measures].[Unit Sales] ON COLUMNS, "
+        + "TOPCOUNT([Customers].[Country].Members, 10, [Measures].[Unit Sales]) ON ROWS "
+        + "FROM [Sales] "
+        + "WHERE [Time].[1997].[Q3]";
+
+    static final String EMPTY_CELLS_ARE_SHOWN_NOT_MORE_THAN_EXIST_RESULT = ""
+        + "Axis #0:\n"
+        + "{[Time].[1997].[Q3]}\n"
+        + "Axis #1:\n"
+        + "{[Measures].[Unit Sales]}\n"
+        + "Axis #2:\n"
+        + "{[Customers].[USA]}\n"
+        + "{[Customers].[Canada]}\n"
+        + "{[Customers].[Mexico]}\n"
+        + "Row #0: 65,848\n"
+        + "Row #1: \n"
+        + "Row #2: \n";
+
+
+    //
+    // The case for verifying NativeTopCount does not return tuples for those
+    // members that have no corresponding records in the fact table if
+    // NON EMPTY modifier is explicitly used.
+    //
+
+    static final String EMPTY_CELLS_ARE_HIDDEN_WHEN_NON_EMPTY_QUERY = ""
+        + "SELECT [Measures].[Unit Sales] ON COLUMNS, "
+        + "NON EMPTY TOPCOUNT([Customers].[Country].Members, 2, [Measures].[Unit Sales]) ON ROWS "
+        + "FROM [Sales] "
+        + "WHERE [Time].[1997].[Q3]";
+
+    static final String EMPTY_CELLS_ARE_HIDDEN_WHEN_NON_EMPTY_RESULT = ""
+        + "Axis #0:\n"
+        + "{[Time].[1997].[Q3]}\n"
+        + "Axis #1:\n"
+        + "{[Measures].[Unit Sales]}\n"
+        + "Axis #2:\n"
+        + "{[Customers].[USA]}\n"
+        + "Row #0: 65,848\n";
+
+
+    //
+    // The case for verifying NativeTopCount respects roles restriction.
+    //
+    // This case checks that restriction works for rows with data
+    // ([USA].[WA] has 30538)
+    //
+
+    static final String ROLE_RESTRICTION_WORKS_WA_ROLE_NAME = "No_WA_State";
+
+    static final String ROLE_RESTRICTION_WORKS_WA_ROLE_DEF = ""
+        + "<Role name=\"No_WA_State\">\n"
+        + "  <SchemaGrant access=\"none\">\n"
+        + "    <CubeGrant cube=\"Sales\" access=\"all\">\n"
+        + "      <HierarchyGrant hierarchy=\"[Customers]\" access=\"custom\" rollupPolicy=\"partial\">\n"
+        + "        <MemberGrant member=\"[Customers].[USA].[WA]\" access=\"none\"/>\n"
+        + "        <MemberGrant member=\"[Customers].[USA].[OR]\" access=\"all\"/>\n"
+        + "        <MemberGrant member=\"[Customers].[USA].[CA]\" access=\"all\"/>\n"
+        + "        <MemberGrant member=\"[Customers].[Canada]\" access=\"all\"/>\n"
+        + "        <MemberGrant member=\"[Customers].[Mexico]\" access=\"all\"/>\n"
+        + "      </HierarchyGrant>\n"
+        + "    </CubeGrant>\n"
+        + "  </SchemaGrant>\n"
+        + "</Role>\n";
+
+    static final String ROLE_RESTRICTION_WORKS_WA_QUERY = ""
+        + "SELECT [Measures].[Unit Sales] ON COLUMNS, "
+        + "TOPCOUNT([Customers].[State Province].Members, 6, [Measures].[Unit Sales]) ON ROWS "
+        + "FROM [Sales] "
+        + "WHERE [Time].[1997].[Q3]";
+
+    static final String ROLE_RESTRICTION_WORKS_WA_RESULT = ""
+        + "Axis #0:\n"
+        + "{[Time].[1997].[Q3]}\n"
+        + "Axis #1:\n"
+        + "{[Measures].[Unit Sales]}\n"
+        + "Axis #2:\n"
+        + "{[Customers].[USA].[CA]}\n"
+        + "{[Customers].[USA].[OR]}\n"
+        + "{[Customers].[Canada].[BC]}\n"
+        + "{[Customers].[Mexico].[DF]}\n"
+        + "{[Customers].[Mexico].[Guerrero]}\n"
+        + "{[Customers].[Mexico].[Jalisco]}\n"
+        + "Row #0: 18,370\n"
+        + "Row #1: 16,940\n"
+        + "Row #2: \n"
+        + "Row #3: \n"
+        + "Row #4: \n"
+        + "Row #5: \n";
+
+
+    //
+    // The case for verifying NativeTopCount respects roles restriction.
+    //
+    // This case checks that restriction works for rows w/o data:
+    // only [Mexico].[DF] is visible among [Mexico].Children.
+    //
+
+    static final String ROLE_RESTRICTION_WORKS_DF_ROLE_NAME = "Only_DF_State";
+
+    static final String ROLE_RESTRICTION_WORKS_DF_ROLE_DEF = ""
+        + "<Role name=\"Only_DF_State\">\n"
+        + "  <SchemaGrant access=\"none\">\n"
+        + "    <CubeGrant cube=\"Sales\" access=\"all\">\n"
+        + "      <HierarchyGrant hierarchy=\"[Customers]\" access=\"custom\" rollupPolicy=\"partial\">\n"
+        + "        <MemberGrant member=\"[Customers].[USA].[WA]\" access=\"all\"/>\n"
+        + "        <MemberGrant member=\"[Customers].[USA].[OR]\" access=\"all\"/>\n"
+        + "        <MemberGrant member=\"[Customers].[USA].[CA]\" access=\"all\"/>\n"
+        + "        <MemberGrant member=\"[Customers].[Canada]\" access=\"all\"/>\n"
+        + "        <MemberGrant member=\"[Customers].[Mexico].[DF]\" access=\"all\"/>\n"
+        + "      </HierarchyGrant>\n"
+        + "    </CubeGrant>\n"
+        + "  </SchemaGrant>\n"
+        + "</Role>\n";
+
+    static final String ROLE_RESTRICTION_WORKS_DF_QUERY = ""
+        + "SELECT [Measures].[Unit Sales] ON COLUMNS, "
+        + "TOPCOUNT([Customers].[State Province].Members, 6, [Measures].[Unit Sales]) ON ROWS "
+        + "FROM [Sales] "
+        + "WHERE [Time].[1997].[Q3]";
+
+    static final String ROLE_RESTRICTION_WORKS_DF_RESULT = ""
+        + "Axis #0:\n"
+        + "{[Time].[1997].[Q3]}\n"
+        + "Axis #1:\n"
+        + "{[Measures].[Unit Sales]}\n"
+        + "Axis #2:\n"
+        + "{[Customers].[USA].[WA]}\n"
+        + "{[Customers].[USA].[CA]}\n"
+        + "{[Customers].[USA].[OR]}\n"
+        + "{[Customers].[Canada].[BC]}\n"
+        + "{[Customers].[Mexico].[DF]}\n"
+        + "Row #0: 30,538\n"
+        + "Row #1: 18,370\n"
+        + "Row #2: 16,940\n"
+        + "Row #3: \n"
+        + "Row #4: \n";
+
+
+
+    //
+    // The case for verifying NativeTopCount mimics HEAD's behaviour.
+    //
+    // This case checks states level.
+    //
+
+    static final String TOPCOUNT_MIMICS_HEAD_WHEN_TWO_PARAMS_STATES_QUERY = ""
+        + "SELECT TOPCOUNT([Customers].[State Province].members, 3) ON COLUMNS "
+        + "FROM [Sales] ";
+
+    static final String TOPCOUNT_MIMICS_HEAD_WHEN_TWO_PARAMS_STATES_RESULT = ""
+        + "Axis #0:\n"
+        + "{}\n" + "Axis #1:\n"
+        + "{[Customers].[Canada].[BC]}\n"
+        + "{[Customers].[Mexico].[DF]}\n"
+        + "{[Customers].[Mexico].[Guerrero]}\n"
+        + "Row #0: \n"
+        + "Row #0: \n"
+        + "Row #0: \n";
+
+
+    //
+    // The case for verifying NativeTopCount mimics HEAD's behaviour.
+    //
+    // This case checks cities level.
+    //
+
+    static final String TOPCOUNT_MIMICS_HEAD_WHEN_TWO_PARAMS_CITIES_QUERY = ""
+        + "SELECT TOPCOUNT([Customers].[City].members, 30) ON COLUMNS "
+        + "FROM [Sales] ";
+
+    static final String TOPCOUNT_MIMICS_HEAD_WHEN_TWO_PARAMS_CITIES_RESULT = ""
+        + "Axis #0:\n"
+        + "{}\n"
+        + "Axis #1:\n"
+        + "{[Customers].[Canada].[BC].[Burnaby]}\n"
+        + "{[Customers].[Canada].[BC].[Cliffside]}\n"
+        + "{[Customers].[Canada].[BC].[Haney]}\n"
+        + "{[Customers].[Canada].[BC].[Ladner]}\n"
+        + "{[Customers].[Canada].[BC].[Langford]}\n"
+        + "{[Customers].[Canada].[BC].[Langley]}\n"
+        + "{[Customers].[Canada].[BC].[Metchosin]}\n"
+        + "{[Customers].[Canada].[BC].[N. Vancouver]}\n"
+        + "{[Customers].[Canada].[BC].[Newton]}\n"
+        + "{[Customers].[Canada].[BC].[Oak Bay]}\n"
+        + "{[Customers].[Canada].[BC].[Port Hammond]}\n"
+        + "{[Customers].[Canada].[BC].[Richmond]}\n"
+        + "{[Customers].[Canada].[BC].[Royal Oak]}\n"
+        + "{[Customers].[Canada].[BC].[Shawnee]}\n"
+        + "{[Customers].[Canada].[BC].[Sooke]}\n"
+        + "{[Customers].[Canada].[BC].[Vancouver]}\n"
+        + "{[Customers].[Canada].[BC].[Victoria]}\n"
+        + "{[Customers].[Canada].[BC].[Westminster]}\n"
+        + "{[Customers].[Mexico].[DF].[San Andres]}\n"
+        + "{[Customers].[Mexico].[DF].[Santa Anita]}\n"
+        + "{[Customers].[Mexico].[DF].[Santa Fe]}\n"
+        + "{[Customers].[Mexico].[DF].[Tixapan]}\n"
+        + "{[Customers].[Mexico].[Guerrero].[Acapulco]}\n"
+        + "{[Customers].[Mexico].[Jalisco].[Guadalajara]}\n"
+        + "{[Customers].[Mexico].[Mexico].[Mexico City]}\n"
+        + "{[Customers].[Mexico].[Oaxaca].[Tlaxiaco]}\n"
+        + "{[Customers].[Mexico].[Sinaloa].[La Cruz]}\n"
+        + "{[Customers].[Mexico].[Veracruz].[Orizaba]}\n"
+        + "{[Customers].[Mexico].[Yucatan].[Merida]}\n"
+        + "{[Customers].[Mexico].[Zacatecas].[Camacho]}\n"
+        + "Row #0: \n"
+        + "Row #0: \n"
+        + "Row #0: \n"
+        + "Row #0: \n"
+        + "Row #0: \n"
+        + "Row #0: \n"
+        + "Row #0: \n"
+        + "Row #0: \n"
+        + "Row #0: \n"
+        + "Row #0: \n"
+        + "Row #0: \n"
+        + "Row #0: \n"
+        + "Row #0: \n"
+        + "Row #0: \n"
+        + "Row #0: \n"
+        + "Row #0: \n"
+        + "Row #0: \n"
+        + "Row #0: \n"
+        + "Row #0: \n"
+        + "Row #0: \n"
+        + "Row #0: \n"
+        + "Row #0: \n"
+        + "Row #0: \n"
+        + "Row #0: \n"
+        + "Row #0: \n"
+        + "Row #0: \n"
+        + "Row #0: \n"
+        + "Row #0: \n"
+        + "Row #0: \n"
+        + "Row #0: \n";
+
+
+    //
+    // The case for verifying NativeTopCount mimics HEAD's behaviour.
+    //
+    // This case checks that no extra lines are returned.
+    //
+
+    static final String RESULTS_ARE_SHOWN_NOT_MORE_THAN_EXIST_2_PARAMS_QUERY =
+        ""
+        + "SELECT TOPCOUNT([Customers].[Country].members, 5) ON COLUMNS "
+        + "FROM [Sales] ";
+
+    static final String RESULTS_ARE_SHOWN_NOT_MORE_THAN_EXIST_2_PARAMS_RESULT =
+        ""
+        + "Axis #0:\n"
+        + "{}\n"
+        + "Axis #1:\n"
+        + "{[Customers].[Canada]}\n"
+        + "{[Customers].[Mexico]}\n"
+        + "{[Customers].[USA]}\n"
+        + "Row #0: \n"
+        + "Row #0: \n"
+        + "Row #0: 266,773\n";
+
+
+    //
+    // The case for verifying NativeTopCount mimics HEAD's behaviour.
+    //
+    // This case checks NON EMPTY modifier is not neglected.
+    //
+
+    static final String NON_EMPTY_IS_NOT_IGNORED_WHEN_TWO_PARAMS_QUERY = ""
+        + "SELECT NON EMPTY TOPCOUNT([Customers].[State Province].members, 3) ON COLUMNS "
+        + "FROM [Sales] ";
+
+    static final String NON_EMPTY_IS_NOT_IGNORED_WHEN_TWO_PARAMS_RESULT = ""
+        + "Axis #0:\n"
+        + "{}\n"
+        + "Axis #1:\n";
+
+}
+
+// End RolapNativeTopCountTestCases.java

--- a/testsrc/main/mondrian/rolap/RolapNativeTopCountVersusNonNativeTest.java
+++ b/testsrc/main/mondrian/rolap/RolapNativeTopCountVersusNonNativeTest.java
@@ -1,0 +1,136 @@
+/*
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (C) 2015-2015 Pentaho and others
+// All Rights Reserved.
+*/
+package mondrian.rolap;
+
+import mondrian.test.TestContext;
+
+import static mondrian.rolap.RolapNativeTopCountTestCases.*;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+public class RolapNativeTopCountVersusNonNativeTest extends BatchTestCase {
+
+    private void assertResultsAreEqual(String testCase, String query) {
+        assertResultsAreEqual(testCase, query, getTestContext());
+    }
+
+    private void assertResultsAreEqual(
+        String testCase,
+        String query,
+        TestContext ctx)
+    {
+        String message = String.format(
+            "[%s]: native and non-native results of the query differ. The query:\n\t\t%s",
+            testCase,
+            query);
+        verifySameNativeAndNot(query, message, ctx);
+    }
+
+
+    public void testTopCount_ImplicitCountMeasure() throws Exception {
+        assertResultsAreEqual(
+            "Implicit Count Measure", IMPLICIT_COUNT_MEASURE_QUERY);
+    }
+
+    public void testTopCount_SumMeasure() throws Exception {
+        assertResultsAreEqual(
+            "Sum Measure", SUM_MEASURE_QUERY);
+    }
+
+    public void testTopCount_CountMeasure() throws Exception {
+        final String schema = TestContext.instance()
+            .getSchema(null, CUSTOM_COUNT_MEASURE_CUBE, null, null, null, null);
+
+        TestContext ctx = TestContext.instance()
+            .withSchema(schema)
+            .withCube(CUSTOM_COUNT_MEASURE_CUBE_NAME);
+
+        assertResultsAreEqual(
+            "Custom Count Measure", CUSTOM_COUNT_MEASURE_QUERY, ctx);
+    }
+
+
+    public void testEmptyCellsAreShown_Countries() throws Exception {
+        assertResultsAreEqual(
+            "Empty Cells Are Shown - Countries",
+            EMPTY_CELLS_ARE_SHOWN_COUNTRIES_QUERY);
+    }
+
+    public void testEmptyCellsAreShown_States() throws Exception {
+        assertResultsAreEqual(
+            "Empty Cells Are Shown - States",
+            EMPTY_CELLS_ARE_SHOWN_STATES_QUERY);
+    }
+
+    public void testEmptyCellsAreShown_ButNoMoreThanReallyExist() {
+        assertResultsAreEqual(
+            "Empty Cells Are Shown - But no more than really exist",
+            EMPTY_CELLS_ARE_SHOWN_NOT_MORE_THAN_EXIST_QUERY);
+    }
+
+    public void testEmptyCellsAreHidden_WhenNonEmptyIsDeclaredExplicitly() {
+        assertResultsAreEqual(
+            "Empty Cells Are Hidden - When NON EMPTY is declared explicitly",
+            EMPTY_CELLS_ARE_HIDDEN_WHEN_NON_EMPTY_QUERY);
+    }
+
+
+    public void testRoleRestrictionWorks_ForRowWithData() {
+        TestContext ctx = TestContext.instance()
+            .create(
+                null, null, null, null, null,
+                ROLE_RESTRICTION_WORKS_WA_ROLE_DEF)
+            .withRole(ROLE_RESTRICTION_WORKS_WA_ROLE_NAME);
+
+        assertResultsAreEqual(
+            "Role restriction works - For WA state",
+            ROLE_RESTRICTION_WORKS_WA_QUERY, ctx);
+    }
+
+    public void testRoleRestrictionWorks_ForRowWithOutData() {
+        TestContext ctx = TestContext.instance()
+            .create(
+                null, null, null, null, null,
+                ROLE_RESTRICTION_WORKS_DF_ROLE_DEF)
+            .withRole(ROLE_RESTRICTION_WORKS_DF_ROLE_NAME);
+
+        assertResultsAreEqual(
+            "Role restriction works - For DF state",
+            ROLE_RESTRICTION_WORKS_DF_QUERY, ctx);
+    }
+
+
+    public void testMimicsHeadWhenTwoParams_States() {
+        assertResultsAreEqual(
+            "Two Parameters - States",
+            TOPCOUNT_MIMICS_HEAD_WHEN_TWO_PARAMS_STATES_QUERY);
+    }
+
+    public void testMimicsHeadWhenTwoParams_Cities() {
+        assertResultsAreEqual(
+            "Two Parameters - Cities",
+            TOPCOUNT_MIMICS_HEAD_WHEN_TWO_PARAMS_CITIES_QUERY);
+    }
+
+    public void testMimicsHeadWhenTwoParams_ShowsNotMoreThanExist() {
+        assertResultsAreEqual(
+            "Two Parameters - Shows not more than really exist",
+            RESULTS_ARE_SHOWN_NOT_MORE_THAN_EXIST_2_PARAMS_QUERY);
+    }
+
+    public void testMimicsHeadWhenTwoParams_DoesNotIgnoreNonEmpty() {
+        assertResultsAreEqual(
+            "Two Parameters - Does not ignore NON EMPTY",
+            NON_EMPTY_IS_NOT_IGNORED_WHEN_TWO_PARAMS_QUERY);
+    }
+}
+
+// End RolapNativeTopCountVersusNonNativeTest.java

--- a/testsrc/main/mondrian/rolap/TopCountNativeEvaluatorTest.java
+++ b/testsrc/main/mondrian/rolap/TopCountNativeEvaluatorTest.java
@@ -1,0 +1,100 @@
+/*
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (C) 2015-2015 Pentaho and others
+// All Rights Reserved.
+*/
+package mondrian.rolap;
+
+import mondrian.calc.DummyExp;
+import mondrian.olap.Exp;
+import mondrian.olap.FunDef;
+import mondrian.olap.Literal;
+import mondrian.olap.type.EmptyType;
+import mondrian.test.FoodMartTestCase;
+
+import java.math.BigDecimal;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * This class contains tests for some cases related to creating
+ * native evaluator for {@code TOPCOUNT} function.
+ *
+ * @author Andrey Khayrutdinov
+ * @see RolapNativeTopCount#createEvaluator(RolapEvaluator, FunDef, Exp[])
+ */
+public class TopCountNativeEvaluatorTest extends FoodMartTestCase {
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        propSaver.set(propSaver.properties.EnableNativeTopCount, true);
+    }
+
+
+    public void testNonNative_WhenExplicitlyDisabled() throws Exception {
+        propSaver.set(propSaver.properties.EnableNativeTopCount, false);
+        RolapNativeTopCount nativeTopCount = new RolapNativeTopCount();
+
+        assertNull(
+            "Native evaluator should not be created when "
+            + "'mondrian.native.topcount.enable' is 'false'",
+            nativeTopCount.createEvaluator(null, null, null));
+    }
+
+    public void testNonNative_WhenContextIsInvalid() throws Exception {
+        RolapNativeTopCount nativeTopCount = createTopCountSpy();
+        doReturn(false).when(nativeTopCount)
+            .isValidContext(any(RolapEvaluator.class));
+
+        assertNull(
+            "Native evaluator should not be created when "
+            + "evaluation context is invalid",
+            nativeTopCount.createEvaluator(null, null, null));
+    }
+
+    /**
+     * For now, prohibit native evaluation of the function if has two
+     * parameters. According to the specification, this means
+     * the function should behave similarly to {@code HEAD} function.
+     * However, native evaluation joins data with the fact table and if there
+     * is no data there, then some records are ignored, what is not correct.
+     *
+     * @see <a href="http://jira.pentaho.com/browse/MONDRIAN-2394">MONDRIAN-2394</a>
+     */
+    public void testNonNative_WhenTwoParametersArePassed() throws Exception {
+        RolapNativeTopCount nativeTopCount = createTopCountSpy();
+        doReturn(true).when(nativeTopCount)
+            .isValidContext(any(RolapEvaluator.class));
+
+        Exp[] arguments = new Exp[] {
+            new DummyExp(new EmptyType()),
+            Literal.create(BigDecimal.ONE)
+        };
+
+        assertNull(
+            "Native evaluator should not be created when "
+            + "two parameters are passed",
+            nativeTopCount.createEvaluator(
+                null, mockFunctionDef(), arguments));
+    }
+
+    private RolapNativeTopCount createTopCountSpy() {
+        RolapNativeTopCount nativeTopCount = new RolapNativeTopCount();
+        nativeTopCount = spy(nativeTopCount);
+        return nativeTopCount;
+    }
+
+    private FunDef mockFunctionDef() {
+        FunDef topCountFunMock = mock(FunDef.class);
+        when(topCountFunMock.getName()).thenReturn("TOPCOUNT");
+        return topCountFunMock;
+    }
+}
+
+// End TopCountNativeEvaluatorTest.java

--- a/testsrc/main/mondrian/rolap/TopCountWithTwoParamsVersusHeadTest.java
+++ b/testsrc/main/mondrian/rolap/TopCountWithTwoParamsVersusHeadTest.java
@@ -1,0 +1,84 @@
+/*
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (C) 2015-2015 Pentaho and others
+// All Rights Reserved.
+*/
+package mondrian.rolap;
+
+import mondrian.olap.Result;
+import mondrian.test.TestContext;
+
+import static mondrian.rolap.RolapNativeTopCountTestCases.*;
+
+/**
+ * According to
+ * <a href="https://msdn.microsoft.com/en-us/library/ms144792.aspx">MSDN
+ * page</a>, when {@code TOPCOUNT} function is called with two parameters
+ * it should mimic the behaviour of {@code HEAD} function.
+ * <p/>
+ * The idea of these tests is to compare results of both function being
+ * called with same parameters - they should be equal.
+ * <p/>
+ * Queries with {@code HEAD} are made by mere substitution of the name
+ * instead of {@code TOPCOUNT}.
+ *
+ * @author Andrey Khayrutdinov
+ */
+public class TopCountWithTwoParamsVersusHeadTest extends BatchTestCase {
+
+    private void assertResultsAreEqual(
+        String testCase,
+        String topCountQuery)
+    {
+        if (!topCountQuery.contains("TOPCOUNT")) {
+            throw new IllegalArgumentException(
+                "'TOPCOUNT' was not found. Please ensure you are using upper case:\n\t\t"
+                    + topCountQuery);
+        }
+
+        String headQuery = topCountQuery.replace("TOPCOUNT", "HEAD");
+
+        TestContext ctx = getTestContext();
+        Result topCountResult = ctx.executeQuery(topCountQuery);
+        ctx.flushSchemaCache();
+        Result headResult = ctx.executeQuery(headQuery);
+        assertEquals(
+            String.format(
+                "[%s]: TOPCOUNT() and HEAD() results of the query differ. The query:\n\t\t%s",
+                testCase,
+                topCountQuery),
+            TestContext.toString(topCountResult),
+            TestContext.toString(headResult));
+    }
+
+
+    public void test_States() throws Exception {
+        assertResultsAreEqual(
+            "States",
+            TOPCOUNT_MIMICS_HEAD_WHEN_TWO_PARAMS_STATES_QUERY);
+    }
+
+    public void test_Cities() throws Exception {
+        assertResultsAreEqual(
+            "Cities",
+            TOPCOUNT_MIMICS_HEAD_WHEN_TWO_PARAMS_CITIES_QUERY);
+    }
+
+    public void test_ShowsNotMoreThanExist() {
+        assertResultsAreEqual(
+            "Not more than exists",
+            RESULTS_ARE_SHOWN_NOT_MORE_THAN_EXIST_2_PARAMS_QUERY);
+    }
+
+    public void test_DoesNotIgnoreNonEmpty() {
+        assertResultsAreEqual(
+            "Does not ignore NON EMPTY",
+            NON_EMPTY_IS_NOT_IGNORED_WHEN_TWO_PARAMS_QUERY);
+    }
+}
+
+// End TopCountWithTwoParamsVersusHeadTest.java

--- a/testsrc/main/mondrian/test/Main.java
+++ b/testsrc/main/mondrian/test/Main.java
@@ -22,9 +22,10 @@ import mondrian.olap4j.XmlaExtraTest;
 import mondrian.rolap.*;
 import mondrian.rolap.agg.*;
 import mondrian.rolap.aggmatcher.*;
-import mondrian.rolap.sql.SelectNotInGroupByTest;
-import mondrian.rolap.sql.SqlQueryTest;
+import mondrian.rolap.sql.*;
 import mondrian.server.FileRepositoryTest;
+import mondrian.spi.impl.ImpalaDialectTest;
+import mondrian.spi.impl.SybaseDialectTest;
 import mondrian.test.build.CodeComplianceTest;
 import mondrian.test.clearview.*;
 import mondrian.test.comp.ResultComparatorTest;
@@ -208,7 +209,10 @@ public class Main extends TestSuite {
                 return suite;
             }
             addTest(suite, SegmentBuilderTest.class);
+            addTest(suite, DenseDoubleSegmentBodyTest.class);
+            addTest(suite, DenseIntSegmentBodyTest.class);
             addTest(suite, NativeFilterMatchingTest.class);
+            addTest(suite, NativeFilterAgainstAggTableTest.class);
             addTest(suite, RolapConnectionTest.class);
             addTest(suite, FilteredIterableTest.class);
             addTest(suite, HighDimensionsTest.class);
@@ -219,6 +223,7 @@ public class Main extends TestSuite {
             addTest(suite, DialectTest.class);
             addTest(suite, ResultComparatorTest.class, "suite");
             addTest(suite, DrillThroughTest.class);
+            addTest(suite, DrillThroughFieldListTest.class);
             addTest(suite, ScenarioTest.class);
             addTest(suite, BasicQueryTest.class);
             addTest(suite, SegmentCacheTest.class);
@@ -313,8 +318,13 @@ public class Main extends TestSuite {
             addTest(suite, QueryTest.class);
             addTest(suite, RolapSchemaReaderTest.class);
             addTest(suite, RolapCubeTest.class);
+            addTest(suite, RolapNativeTopCountTest.class);
+            addTest(suite, RolapNativeTopCountVersusNonNativeTest.class);
+            addTest(suite, TopCountNativeEvaluatorTest.class);
+            addTest(suite, TopCountWithTwoParamsVersusHeadTest.class);
             addTest(suite, RolapStarTest.class);
             addTest(suite, RolapSchemaPoolTest.class);
+            addTest(suite, RolapSchemaPoolConcurrencyTest.class);
             addTest(suite, NullMemberRepresentationTest.class);
             addTest(suite, IgnoreUnrelatedDimensionsTest.class);
             addTest(
@@ -337,8 +347,15 @@ public class Main extends TestSuite {
             addTest(suite, BlockingHashMapTest.class);
             addTest(suite, FileRepositoryTest.class);
             addTest(suite, XmlaExtraTest.class);
+            addTest(suite, CrossJoinArgFactoryTest.class);
             addTest(suite, UnionFunDefTest.class);
+            addTest(suite, ImpalaDialectTest.class);
+            addTest(suite, SybaseDialectTest.class);
+            addTest(suite, IdBatchResolverTest.class);
+            addTest(suite, MemberCacheHelperTest.class);
+            addTest(suite, EffectiveMemberCacheTest.class);
             addTest(suite, SqlStatementTest.class);
+            addTest(suite, ValidMeasureFunDefTest.class);
 
             boolean testNonEmpty = isRunOnce();
             if (!MondrianProperties.instance().EnableNativeNonEmpty.get()) {
@@ -357,7 +374,9 @@ public class Main extends TestSuite {
 
             addTest(suite, FastBatchingCellReaderTest.class);
             addTest(suite, SqlQueryTest.class);
+            addTest(suite, CodeSetTest.class);
             addTest(suite, ExplicitRecognizerTest.class);
+            addTest(suite, AggregationOverAggTableTest.class);
 
             if (MondrianProperties.instance().EnableNativeCrossJoin.get()) {
                 addTest(suite, BatchedFillTest.class, "suite");


### PR DESCRIPTION
…n native.topcount is enabled

- prohibit creating native evaluator when TOPCOUNT is called with two parameters
- add tests

Conflicts:
	testsrc/main/mondrian/rolap/RolapNativeTopCountTest.java
	testsrc/main/mondrian/rolap/RolapNativeTopCountTestCases.java
	testsrc/main/mondrian/rolap/RolapNativeTopCountVersusNonNativeTest.java
	testsrc/main/mondrian/test/Main.java