### PR TITLE
[MONDRIAN-2436] - SQL Injection through MDX Filter

### DIFF
--- a/src/main/mondrian/rolap/RolapNativeSql.java
+++ b/src/main/mondrian/rolap/RolapNativeSql.java
@@ -12,6 +12,7 @@ package mondrian.rolap;
 
 import mondrian.mdx.*;
 import mondrian.olap.*;
+import mondrian.olap.fun.MondrianEvaluationException;
 import mondrian.olap.type.MemberType;
 import mondrian.olap.type.StringType;
 import mondrian.rolap.aggmatcher.AggStar;
@@ -130,6 +131,14 @@ public class RolapNativeSql {
             }
             Literal literal = (Literal) exp;
             String expr = String.valueOf(literal.getValue());
+            try {
+                // MONDRIAN-2436: reject everything except valid decimals
+                Double.parseDouble(expr);
+            } catch (NumberFormatException e) {
+                throw new MondrianEvaluationException(
+                    "Expected to get decimal, but got " + expr);
+            }
+
             if (dialect.getDatabaseProduct().getFamily()
                 == Dialect.DatabaseProduct.DB2)
             {

--- a/testsrc/main/mondrian/rolap/RolapNativeSqlInjectionTest.java
+++ b/testsrc/main/mondrian/rolap/RolapNativeSqlInjectionTest.java
@@ -1,0 +1,43 @@
+/*
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (c) 2015-2015 Pentaho Corporation.
+// All Rights Reserved.
+*/
+package mondrian.rolap;
+
+import mondrian.olap.MondrianException;
+import mondrian.test.FoodMartTestCase;
+import mondrian.test.TestContext;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+public class RolapNativeSqlInjectionTest extends FoodMartTestCase {
+
+    public void testMondrian2436() {
+        String mdxQuery = ""
+            + "select {[Measures].[Store Sales]} on columns, "
+            + "filter([Customers].[Name].Members, (([Measures].[Store Sales]) > '(select 1000)')) on rows "
+            + "from [Sales]";
+
+        TestContext context = getTestContext();
+        try {
+            context.executeQuery(mdxQuery);
+        } catch (MondrianException e) {
+            assertNotNull(
+                "MondrianEvaluationException is expected on invalid filter condition",
+                e.getCause());
+            assertEquals(
+                "Expected to get decimal, but got (select 1000)",
+                e.getCause().getMessage());
+            return;
+        }
+        fail("[Store Sales] filtering should not work for non-valid decimals");
+    }
+}
+
+// End RolapNativeSqlInjectionTest.java

--- a/testsrc/main/mondrian/rolap/RolapNativeSql_NumberSqlCompiler_Test.java
+++ b/testsrc/main/mondrian/rolap/RolapNativeSql_NumberSqlCompiler_Test.java
@@ -1,0 +1,75 @@
+/*
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (c) 2015-2015 Pentaho Corporation.
+// All Rights Reserved.
+*/
+package mondrian.rolap;
+
+import mondrian.calc.DummyExp;
+import mondrian.olap.Exp;
+import mondrian.olap.Literal;
+import mondrian.olap.type.NullType;
+import mondrian.rolap.sql.SqlQuery;
+import mondrian.spi.Dialect;
+
+import junit.framework.TestCase;
+
+import java.math.BigDecimal;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+public class RolapNativeSql_NumberSqlCompiler_Test extends TestCase {
+
+    private RolapNativeSql.NumberSqlCompiler compiler;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        Dialect dialect = mock(Dialect.class);
+        when(dialect.getDatabaseProduct())
+            .thenReturn(Dialect.DatabaseProduct.MYSQL);
+
+        SqlQuery query = mock(SqlQuery.class);
+        when(query.getDialect()).thenReturn(dialect);
+
+        RolapNativeSql sql = new RolapNativeSql(query, null, null, null);
+        compiler = sql.new NumberSqlCompiler();
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        compiler = null;
+        super.tearDown();
+    }
+
+    public void testRejectsNonLiteral() {
+        Exp exp = new DummyExp(new NullType());
+        assertNull(compiler.compile(exp));
+    }
+
+    public void testAcceptsNumeric() {
+        Exp exp = Literal.create(BigDecimal.ONE);
+        assertNotNull(compiler.compile(exp));
+    }
+
+    public void testAcceptsString() {
+        Exp exp = Literal.createString("1");
+        assertNotNull(compiler.compile(exp));
+    }
+
+    public void testRejectsStrings_ThatCannotBeParsedAsDouble() {
+        Exp exp = Literal.createString("(select 100)");
+        assertNull(compiler.compile(exp));
+    }
+}
+
+// End RolapNativeSql_NumberSqlCompiler_Test.java

--- a/testsrc/main/mondrian/test/Main.java
+++ b/testsrc/main/mondrian/test/Main.java
@@ -318,6 +318,8 @@ public class Main extends TestSuite {
             addTest(suite, QueryTest.class);
             addTest(suite, RolapSchemaReaderTest.class);
             addTest(suite, RolapCubeTest.class);
+            addTest(suite, RolapNativeSql_NumberSqlCompiler_Test.class);
+            addTest(suite, RolapNativeSqlInjectionTest.class);
             addTest(suite, RolapNativeTopCountTest.class);
             addTest(suite, RolapNativeTopCountVersusNonNativeTest.class);
             addTest(suite, TopCountNativeEvaluatorTest.class);


### PR DESCRIPTION
- prohibit invalid decimal literals in NumberSqlCompiler
- add tests

@lucboudreau, @mkambol, @kurtwalker, review it please.   