### PR TITLE
[SP-2326] - Backport of MONDRIAN-2433 - Filtering in analyzer report for Integer, Numeric values returns UPPER() error message with Impala (6.0 Suite)

### DIFF
--- a/src/main/mondrian/spi/impl/ImpalaDialect.java
+++ b/src/main/mondrian/spi/impl/ImpalaDialect.java
@@ -198,8 +198,9 @@ public class ImpalaDialect extends HiveDialect {
                     escapeMatcher.group(1),
                     escapeMatcher.group(2));
         }
-        final StringBuilder sb = new StringBuilder();
 
+        source = "cast(" + source + " as string)";
+        final StringBuilder sb = new StringBuilder();
         // Now build the string.
         if (caseSensitive) {
             sb.append(source);

--- a/testsrc/main/mondrian/spi/impl/ImpalaDialectTest.java
+++ b/testsrc/main/mondrian/spi/impl/ImpalaDialectTest.java
@@ -1,0 +1,75 @@
+/*
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (c) 2015-2015 Pentaho Corporation.
+// All rights reserved.
+ */
+package mondrian.spi.impl;
+
+import mondrian.spi.Dialect;
+
+import junit.framework.TestCase;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+public class ImpalaDialectTest extends TestCase {
+
+    public void testGenerateRegularExpression_InvalidRegex()
+        throws Exception
+    {
+        assertNull(
+            "Invalid regex should be ignored",
+            callGenerateRegularExpression("table.column", "(a"));
+    }
+
+    public void testGenerateRegularExpression_CaseInsensitive()
+        throws Exception
+    {
+        String sql = callGenerateRegularExpression("table.column", "(?i).*1.*");
+        assertSqlWithRegex(false, sql, "'.*1.*'");
+    }
+
+    public void testGenerateRegularExpression_CaseSensitive()
+        throws Exception
+    {
+        String sql = callGenerateRegularExpression("table.column", ".*1.*");
+        assertSqlWithRegex(true, sql, "'.*1.*'");
+    }
+
+    private String callGenerateRegularExpression(String source, String regex)
+        throws Exception
+    {
+        DatabaseMetaData metaData = mock(DatabaseMetaData.class);
+        when(metaData.getDatabaseProductName())
+            .thenReturn(Dialect.DatabaseProduct.IMPALA.name());
+
+        Connection connection = mock(Connection.class);
+        when(connection.getMetaData()).thenReturn(metaData);
+
+        return new ImpalaDialect(connection)
+            .generateRegularExpression(source, regex);
+    }
+
+    private void assertSqlWithRegex(
+        boolean isCaseSensitive,
+        String sql,
+        String quotedRegex) throws Exception
+    {
+        assertNotNull("Sql should be generated", sql);
+        assertEquals(sql, isCaseSensitive, !sql.contains("UPPER"));
+        assertTrue(sql, sql.contains("cast(table.column as string)"));
+        assertTrue(sql, sql.contains("REGEXP"));
+        assertTrue(sql, sql.contains(quotedRegex));
+    }
+}
+// End ImpalaDialectTest.java

--- a/testsrc/main/mondrian/test/Main.java
+++ b/testsrc/main/mondrian/test/Main.java
@@ -24,6 +24,7 @@ import mondrian.rolap.agg.*;
 import mondrian.rolap.aggmatcher.*;
 import mondrian.rolap.sql.*;
 import mondrian.server.FileRepositoryTest;
+import mondrian.spi.impl.ImpalaDialectTest;
 import mondrian.spi.impl.SybaseDialectTest;
 import mondrian.test.build.CodeComplianceTest;
 import mondrian.test.clearview.*;
@@ -348,6 +349,7 @@ public class Main extends TestSuite {
             addTest(suite, XmlaExtraTest.class);
             addTest(suite, CrossJoinArgFactoryTest.class);
             addTest(suite, UnionFunDefTest.class);
+            addTest(suite, ImpalaDialectTest.class);
             addTest(suite, SybaseDialectTest.class);
             addTest(suite, IdBatchResolverTest.class);
             addTest(suite, MemberCacheHelperTest.class);


### PR DESCRIPTION
- explicitly cast values to string when generating regex condition for Impala
- add tests
(cherry picked from commit 040b5c4)

@mkambol, @lucboudreau, review it please. This is a backport of https://github.com/pentaho/mondrian/pull/597  