### PR TITLE
[MONDRIAN-2437]  Special handling to eliminate the

### DIFF
--- a/src/main/mondrian/rolap/RolapNativeSet.java
+++ b/src/main/mondrian/rolap/RolapNativeSet.java
@@ -268,8 +268,12 @@ public abstract class RolapNativeSet extends RolapNative {
             }
 
             // Did not get as many members as expected - try to complete using
-            // less constraints
-            if (completeWithNullValues && result.size() < maxRows) {
+            // less constraints.
+            // if !joinRequired then no need to try again, since the first
+            // query was pulling from the dimension table directly.
+            if (completeWithNullValues && result.size() < maxRows
+                && joinRequired(constraint))
+            {
                 RolapLevel l = args[0].getLevel();
                 List<RolapMember> list = new ArrayList<RolapMember>();
                 for (List<Member> lm : result) {
@@ -307,6 +311,17 @@ public abstract class RolapNativeSet extends RolapNative {
                 }
             }
             return filterInaccessibleTuples(result);
+        }
+
+        /**
+         * Returns true if the constraint may require a join to the
+         * fact table.
+         */
+        private boolean joinRequired(TupleConstraint constraint) {
+            return !(constraint
+                instanceof RolapNativeTopCount.TopCountConstraint)
+                || ((RolapNativeTopCount.TopCountConstraint)constraint)
+                .isJoinRequired();
         }
 
         /**

--- a/testsrc/main/mondrian/test/NativeSetEvaluationTest.java
+++ b/testsrc/main/mondrian/test/NativeSetEvaluationTest.java
@@ -631,6 +631,37 @@ public class NativeSetEvaluationTest extends BatchTestCase {
             + "Row #0: 6,838\n");
     }
 
+    public void testTCTwoArgDoesNotUseMemberExcludeQuery() {
+        // will throw an error if native eval is not used
+        propSaver.set(
+            propSaver.properties.AlertNativeEvaluationUnsupported, "ERROR");
+        propSaver.set(
+            propSaver.properties.GenerateFormattedSql, true);
+        // verifies that the second, member exclude query is not fired.
+        // That second query is only needed for the 3 arg form of TC
+        // MONDRIAN-2437
+        assertQuerySqlOrNot(
+            getTestContext(),
+            "select TopCount(Customers.Country.members, 5) "
+            + "on 0 from Sales",
+            new SqlPattern[]{
+                new SqlPattern(
+                    DatabaseProduct.MYSQL,
+                    "select\n"
+                    + "    `customer`.`country` as `c0`\n"
+                    + "from\n"
+                    + "    `customer` as `customer`\n"
+                    + "where\n"
+                    + "    ((not (`customer`.`country` in ('Canada', 'Mexico', 'USA')) or (`customer`.`country` is null)))\n"
+                    + "group by\n"
+                    + "    `customer`.`country`\n"
+                    + "order by\n"
+                    + "    ISNULL(`customer`.`country`) ASC, "
+                    + "`customer`.`country` ASC", null)
+            }, true, true, true);
+    }
+
+
     public void testAggTCTwoArg() {
         // will throw an error if native eval is not used
         propSaver.set(


### PR DESCRIPTION
MemberExclude query with the 2 arg form of TopCount.

Formerly a second SQL query would be fired for
native TC if the number of items retrieved
fell below the TC value specified.  That second
query is only needed for the 3 arg form of TC, as
a way to retrieve empty tuples that aren't associated
with fact data.

 http://jira.pentaho.com/browse/MONDRIAN-2437

@lucboudreau 
