### PR TITLE
[MONDRIAN-2436] - SQL Injection through MDX Filter

### DIFF
--- a/src/main/mondrian/rolap/RolapNativeSql.java
+++ b/src/main/mondrian/rolap/RolapNativeSql.java
@@ -21,6 +21,7 @@ import mondrian.spi.Dialect;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Pattern;
 
 /**
  * Creates SQL from parse tree nodes. Currently it creates the SQL that
@@ -30,6 +31,9 @@ import java.util.List;
  * @since Nov 17, 2005
   */
 public class RolapNativeSql {
+
+    private static final Pattern DECIMAL =
+        Pattern.compile("[+-]?((\\d+(\\.\\d*)?)|(\\.\\d+))");
 
     private SqlQuery sqlQuery;
     private Dialect dialect;
@@ -131,10 +135,7 @@ public class RolapNativeSql {
             }
             Literal literal = (Literal) exp;
             String expr = String.valueOf(literal.getValue());
-            try {
-                // MONDRIAN-2436: reject everything except valid decimals
-                Double.parseDouble(expr);
-            } catch (NumberFormatException e) {
+            if (!DECIMAL.matcher(expr).matches()) {
                 throw new MondrianEvaluationException(
                     "Expected to get decimal, but got " + expr);
             }

--- a/testsrc/main/mondrian/rolap/NumberSqlCompilerTest.java
+++ b/testsrc/main/mondrian/rolap/NumberSqlCompilerTest.java
@@ -62,20 +62,61 @@ public class NumberSqlCompilerTest extends TestCase {
         assertNotNull(compiler.compile(exp));
     }
 
-    public void testAcceptsString() {
-        Exp exp = Literal.createString("1");
-        assertNotNull(compiler.compile(exp));
+    public void testAcceptsString_Int() {
+        checkAcceptsString("1");
     }
 
-    public void testRejectsStrings_ThatCannotBeParsedAsDouble() {
-        Exp exp = Literal.createString("(select 100)");
+    public void testAcceptsString_Negative() {
+        checkAcceptsString("-1");
+    }
+
+    public void testAcceptsString_ExplicitlyPositive() {
+        checkAcceptsString("+1.01");
+    }
+
+    public void testAcceptsString_NoIntegerPart() {
+        checkAcceptsString("-.00001");
+    }
+
+    private void checkAcceptsString(String value) {
+        Exp exp = Literal.createString(value);
+        assertNotNull(value, compiler.compile(exp));
+    }
+
+
+    public void testRejectsString_SelectStatement() {
+        checkRejectsString("(select 100)");
+    }
+
+    public void testRejectsString_NaN() {
+        checkRejectsString("NaN");
+    }
+
+    public void testRejectsString_Infinity() {
+        checkRejectsString("Infinity");
+    }
+
+    public void testRejectsString_TwoDots() {
+        checkRejectsString("1.0.");
+    }
+
+    public void testRejectsString_OnlyDot() {
+        checkRejectsString(".");
+    }
+
+    public void testRejectsString_DoubleNegation() {
+        checkRejectsString("--1.0");
+    }
+
+    private void checkRejectsString(String value) {
+        Exp exp = Literal.createString(value);
         try {
             compiler.compile(exp);
         } catch (MondrianEvaluationException e) {
             return;
         }
-        fail("Expected to get MondrianEvaluationException");
+        fail("Expected to get MondrianEvaluationException for " + value);
     }
 }
 
-// End RolapNativeSql_NumberSqlCompiler_Test.java
+// End NumberSqlCompilerTest.java


### PR DESCRIPTION
- introduce a pattern for expected decimal values, as Double.parseDouble() accepts such values as 'NaN', 'Infinity' and others
- add tests

@lucboudreau, review it please 