### PR TITLE
[TEST] fixing testAggregatingTuples when run with

### DIFF
--- a/testsrc/main/mondrian/rolap/TestAggregationManager.java
+++ b/testsrc/main/mondrian/rolap/TestAggregationManager.java
@@ -1416,6 +1416,7 @@ public class TestAggregationManager extends BatchTestCase {
     }
 
     public void testAggregatingTuples() {
+        propSaver.set(propSaver.properties.LevelPreCacheThreshold, 1);
         if (!(MondrianProperties.instance().UseAggregates.get()
                 && MondrianProperties.instance().ReadAggregates.get()))
         {


### PR DESCRIPTION
agg tables.  Was using DefaultConstraint, so not
attempting to join to the agg table since the level
cardinality fell below threshold.

@lucboudreau 