### PR TITLE
[SP-2314] - Backport of MONDRIAN-2436 - SQL Injection through MDX Filter (5.4 Suite)

### DIFF
--- a/src/main/mondrian/rolap/RolapNativeSql.java
+++ b/src/main/mondrian/rolap/RolapNativeSql.java
@@ -12,6 +12,7 @@ package mondrian.rolap;
 
 import mondrian.mdx.*;
 import mondrian.olap.*;
+import mondrian.olap.fun.MondrianEvaluationException;
 import mondrian.olap.type.MemberType;
 import mondrian.olap.type.StringType;
 import mondrian.rolap.aggmatcher.AggStar;
@@ -20,6 +21,7 @@ import mondrian.spi.Dialect;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Pattern;
 
 /**
  * Creates SQL from parse tree nodes. Currently it creates the SQL that
@@ -29,6 +31,9 @@ import java.util.List;
  * @since Nov 17, 2005
   */
 public class RolapNativeSql {
+
+    private static final Pattern DECIMAL =
+        Pattern.compile("[+-]?((\\d+(\\.\\d*)?)|(\\.\\d+))");
 
     private SqlQuery sqlQuery;
     private Dialect dialect;
@@ -130,6 +135,11 @@ public class RolapNativeSql {
             }
             Literal literal = (Literal) exp;
             String expr = String.valueOf(literal.getValue());
+            if (!DECIMAL.matcher(expr).matches()) {
+                throw new MondrianEvaluationException(
+                    "Expected to get decimal, but got " + expr);
+            }
+
             if (dialect.getDatabaseProduct().getFamily()
                 == Dialect.DatabaseProduct.DB2)
             {

--- a/testsrc/main/mondrian/rolap/NumberSqlCompilerTest.java
+++ b/testsrc/main/mondrian/rolap/NumberSqlCompilerTest.java
@@ -1,0 +1,122 @@
+/*
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (c) 2015-2015 Pentaho Corporation.
+// All Rights Reserved.
+*/
+package mondrian.rolap;
+
+import mondrian.calc.DummyExp;
+import mondrian.olap.Exp;
+import mondrian.olap.Literal;
+import mondrian.olap.fun.MondrianEvaluationException;
+import mondrian.olap.type.NullType;
+import mondrian.rolap.sql.SqlQuery;
+import mondrian.spi.Dialect;
+
+import junit.framework.TestCase;
+
+import java.math.BigDecimal;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+public class NumberSqlCompilerTest extends TestCase {
+
+    private RolapNativeSql.NumberSqlCompiler compiler;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        Dialect dialect = mock(Dialect.class);
+        when(dialect.getDatabaseProduct())
+            .thenReturn(Dialect.DatabaseProduct.MYSQL);
+
+        SqlQuery query = mock(SqlQuery.class);
+        when(query.getDialect()).thenReturn(dialect);
+
+        RolapNativeSql sql = new RolapNativeSql(query, null, null, null);
+        compiler = sql.new NumberSqlCompiler();
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        compiler = null;
+        super.tearDown();
+    }
+
+    public void testRejectsNonLiteral() {
+        Exp exp = new DummyExp(new NullType());
+        assertNull(compiler.compile(exp));
+    }
+
+    public void testAcceptsNumeric() {
+        Exp exp = Literal.create(BigDecimal.ONE);
+        assertNotNull(compiler.compile(exp));
+    }
+
+    public void testAcceptsString_Int() {
+        checkAcceptsString("1");
+    }
+
+    public void testAcceptsString_Negative() {
+        checkAcceptsString("-1");
+    }
+
+    public void testAcceptsString_ExplicitlyPositive() {
+        checkAcceptsString("+1.01");
+    }
+
+    public void testAcceptsString_NoIntegerPart() {
+        checkAcceptsString("-.00001");
+    }
+
+    private void checkAcceptsString(String value) {
+        Exp exp = Literal.createString(value);
+        assertNotNull(value, compiler.compile(exp));
+    }
+
+
+    public void testRejectsString_SelectStatement() {
+        checkRejectsString("(select 100)");
+    }
+
+    public void testRejectsString_NaN() {
+        checkRejectsString("NaN");
+    }
+
+    public void testRejectsString_Infinity() {
+        checkRejectsString("Infinity");
+    }
+
+    public void testRejectsString_TwoDots() {
+        checkRejectsString("1.0.");
+    }
+
+    public void testRejectsString_OnlyDot() {
+        checkRejectsString(".");
+    }
+
+    public void testRejectsString_DoubleNegation() {
+        checkRejectsString("--1.0");
+    }
+
+    private void checkRejectsString(String value) {
+        Exp exp = Literal.createString(value);
+        try {
+            compiler.compile(exp);
+        } catch (MondrianEvaluationException e) {
+            return;
+        }
+        fail("Expected to get MondrianEvaluationException for " + value);
+    }
+}
+
+// End NumberSqlCompilerTest.java

--- a/testsrc/main/mondrian/rolap/RolapNativeSqlInjectionTest.java
+++ b/testsrc/main/mondrian/rolap/RolapNativeSqlInjectionTest.java
@@ -1,0 +1,43 @@
+/*
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (c) 2015-2015 Pentaho Corporation.
+// All Rights Reserved.
+*/
+package mondrian.rolap;
+
+import mondrian.olap.MondrianException;
+import mondrian.test.FoodMartTestCase;
+import mondrian.test.TestContext;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+public class RolapNativeSqlInjectionTest extends FoodMartTestCase {
+
+    public void testMondrian2436() {
+        String mdxQuery = ""
+            + "select {[Measures].[Store Sales]} on columns, "
+            + "filter([Customers].[Name].Members, (([Measures].[Store Sales]) > '(select 1000)')) on rows "
+            + "from [Sales]";
+
+        TestContext context = getTestContext();
+        try {
+            context.executeQuery(mdxQuery);
+        } catch (MondrianException e) {
+            assertNotNull(
+                "MondrianEvaluationException is expected on invalid filter condition",
+                e.getCause());
+            assertEquals(
+                "Expected to get decimal, but got (select 1000)",
+                e.getCause().getMessage());
+            return;
+        }
+        fail("[Store Sales] filtering should not work for non-valid decimals");
+    }
+}
+
+// End RolapNativeSqlInjectionTest.java

--- a/testsrc/main/mondrian/test/Main.java
+++ b/testsrc/main/mondrian/test/Main.java
@@ -319,6 +319,8 @@ public class Main extends TestSuite {
             addTest(suite, QueryTest.class);
             addTest(suite, RolapSchemaReaderTest.class);
             addTest(suite, RolapCubeTest.class);
+            addTest(suite, NumberSqlCompilerTest.class);
+            addTest(suite, RolapNativeSqlInjectionTest.class);
             addTest(suite, RolapNativeTopCountTest.class);
             addTest(suite, RolapStarTest.class);
             addTest(suite, RolapSchemaPoolTest.class);


### PR DESCRIPTION
- prohibit invalid decimal literals in NumberSqlCompiler, throw exception in such cases
  - to do it, introduce a pattern for expected decimal values, as Double.parseDouble() accepts such values as 'NaN', 'Infinity' and others
- add tests
(cherry picked from commits 232f75e, 7dea3f6, 37a2c2d, ba79374)

@lucboudreau, @mkambol, review it please. This is a backport of #607, #608, #609, #614  