### PR TITLE
[BACKLOG-5898] - Adding an "Internal Use" annotation to the implicit "Fact Count" measure.

### DIFF
--- a/src/main/mondrian/rolap/RolapCube.java
+++ b/src/main/mondrian/rolap/RolapCube.java
@@ -291,6 +291,15 @@ public class RolapCube extends CubeBase {
             xmlMeasure.aggregator = "count";
             xmlMeasure.name = "Fact Count";
             xmlMeasure.visible = false;
+
+            MondrianDef.Annotation internalUsage = new MondrianDef.Annotation();
+            internalUsage.name = "Internal Use";
+            internalUsage.cdata = "For internal use";
+            MondrianDef.Annotations annotations = new MondrianDef.Annotations();
+            annotations.array = new MondrianDef.Annotation[1];
+            annotations.array[0] = internalUsage;
+            xmlMeasure.annotations = annotations;
+
             factCountMeasure =
                 createMeasure(
                     xmlCube, measuresLevel, measureList.size(), xmlMeasure);

--- a/testsrc/main/mondrian/test/SchemaTest.java
+++ b/testsrc/main/mondrian/test/SchemaTest.java
@@ -4,7 +4,7 @@
 // http://www.eclipse.org/legal/epl-v10.html.
 // You must accept the terms of that agreement to use this software.
 //
-// Copyright (c) 2002-2014 Pentaho Corporation..  All rights reserved.
+// Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
 */
 package mondrian.test;
 
@@ -3269,6 +3269,9 @@ public class SchemaTest extends FoodMartTestCase {
         assertEquals(
             false,
             factCountMeasure.getPropertyValue(Property.VISIBLE.name));
+        checkAnnotations(
+            factCountMeasure.getAnnotationMap(), "Internal Use",
+            "For internal use");
 
         final Member calcMeasure = measures.get(2);
         assertEquals("Foo", calcMeasure.getName());


### PR DESCRIPTION

This will enable a better way for determining which "visible=false" elements should always remain hidden from an Analyzer user. We can look for that annotation rather than a specific named element (like Fact count).