### PR TITLE
[SP-2376] - Backport of MONDRIAN-2225 - Using aggregations with data restrictions return error (5.4 Suite)

### DIFF
--- a/testsrc/main/mondrian/rolap/RolapSchemaTest.java
+++ b/testsrc/main/mondrian/rolap/RolapSchemaTest.java
@@ -1,0 +1,240 @@
+/*
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (c) 2015-2015 Pentaho Corporation..  All rights reserved.
+*/
+package mondrian.rolap;
+
+import mondrian.olap.*;
+import mondrian.resource.MondrianResource;
+import mondrian.test.PropertyRestoringTestCase;
+import mondrian.util.ByteString;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+public class RolapSchemaTest extends PropertyRestoringTestCase {
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+    }
+
+
+    private RolapSchema createSchema() {
+        SchemaKey key = new SchemaKey(
+            mock(SchemaContentKey.class), mock(ConnectionKey.class));
+
+        ByteString md5 = new ByteString("test schema".getBytes());
+        //noinspection deprecation
+        return new RolapSchema(key, md5, mock(RolapConnection.class));
+    }
+
+    private SchemaReader mockSchemaReader(int category, OlapElement element) {
+        SchemaReader reader = mock(SchemaReader.class);
+        when(reader.withLocus()).thenReturn(reader);
+        when(reader.lookupCompound(
+            any(OlapElement.class), anyListOf(Id.Segment.class),
+            anyBoolean(), eq(category)))
+            .thenReturn(element);
+        return reader;
+    }
+
+    private RolapCube mockCube(RolapSchema schema) {
+        RolapCube cube = mock(RolapCube.class);
+        when(cube.getSchema()).thenReturn(schema);
+        return cube;
+    }
+
+
+    public void testCreateUnionRole_ThrowsException_WhenSchemaGrantsExist() {
+        MondrianDef.Role role = new MondrianDef.Role();
+        role.schemaGrants =
+            new MondrianDef.SchemaGrant[] {new MondrianDef.SchemaGrant()};
+        role.union = new MondrianDef.Union();
+
+        try {
+            createSchema().createUnionRole(role);
+        } catch (MondrianException ex) {
+            assertMondrianException(
+                MondrianResource.instance().RoleUnionGrants.ex(), ex);
+            return;
+        }
+        fail("Should fail if union and schema grants exist simultaneously");
+    }
+
+    public void testCreateUnionRole_ThrowsException_WhenRoleNameIsUnknown() {
+        final String roleName = "non-existing role name";
+        MondrianDef.RoleUsage usage = new MondrianDef.RoleUsage();
+        usage.roleName = roleName;
+
+        MondrianDef.Role role = new MondrianDef.Role();
+        role.union = new MondrianDef.Union();
+        role.union.roleUsages = new MondrianDef.RoleUsage[] {usage};
+
+        try {
+            createSchema().createUnionRole(role);
+        } catch (MondrianException ex) {
+            assertMondrianException(
+                MondrianResource.instance().UnknownRole.ex(roleName), ex);
+            return;
+        }
+        fail("Should fail if union and schema grants exist simultaneously");
+    }
+
+
+    public void testHandleSchemaGrant() {
+        RolapSchema schema = createSchema();
+        schema = spy(schema);
+        doNothing().when(schema)
+            .handleCubeGrant(
+                any(RoleImpl.class), any(MondrianDef.CubeGrant.class));
+
+        MondrianDef.SchemaGrant grant = new MondrianDef.SchemaGrant();
+        grant.access = Access.CUSTOM.toString();
+        grant.cubeGrants =  new MondrianDef.CubeGrant[] {
+            new MondrianDef.CubeGrant(), new MondrianDef.CubeGrant()};
+
+        RoleImpl role = new RoleImpl();
+
+        schema.handleSchemaGrant(role, grant);
+        assertEquals(Access.CUSTOM, role.getAccess(schema));
+        verify(schema, times(2))
+            .handleCubeGrant(eq(role), any(MondrianDef.CubeGrant.class));
+    }
+
+
+    public void testHandleCubeGrant_ThrowsException_WhenCubeIsUnknown() {
+        RolapSchema schema = createSchema();
+        schema = spy(schema);
+        doReturn(null).when(schema).lookupCube(anyString());
+
+        MondrianDef.CubeGrant grant = new MondrianDef.CubeGrant();
+        grant.cube = "cube";
+
+        try {
+            schema.handleCubeGrant(new RoleImpl(), grant);
+        } catch (MondrianException e) {
+            String message = e.getMessage();
+            assertTrue(message, message.contains(grant.cube));
+            return;
+        }
+        fail("Should fail if cube is unknown");
+    }
+
+    public void testHandleCubeGrant_GrantsCubeDimensionsAndHierarchies() {
+        RolapSchema schema = createSchema();
+        schema = spy(schema);
+        doNothing().when(schema)
+            .handleHierarchyGrant(
+                any(RoleImpl.class),
+                any(RolapCube.class),
+                any(SchemaReader.class),
+                any(MondrianDef.HierarchyGrant.class));
+
+        final Dimension dimension = mock(Dimension.class);
+        SchemaReader reader = mockSchemaReader(Category.Dimension, dimension);
+
+        RolapCube cube = mockCube(schema);
+        when(cube.getSchemaReader(any(Role.class))).thenReturn(reader);
+        doReturn(cube).when(schema).lookupCube("cube");
+
+        MondrianDef.DimensionGrant dimensionGrant =
+            new MondrianDef.DimensionGrant();
+        dimensionGrant.dimension = "dimension";
+        dimensionGrant.access = Access.NONE.toString();
+
+        MondrianDef.CubeGrant grant = new MondrianDef.CubeGrant();
+        grant.cube = "cube";
+        grant.access = Access.CUSTOM.toString();
+        grant.dimensionGrants =
+            new MondrianDef.DimensionGrant[] {dimensionGrant};
+        grant.hierarchyGrants =
+            new MondrianDef.HierarchyGrant[] {
+                new MondrianDef.HierarchyGrant()};
+
+        RoleImpl role = new RoleImpl();
+
+        schema.handleCubeGrant(role, grant);
+
+        assertEquals(Access.CUSTOM, role.getAccess(cube));
+        assertEquals(Access.NONE, role.getAccess(dimension));
+        verify(schema, times(1))
+            .handleHierarchyGrant(
+                eq(role),
+                eq(cube),
+                eq(reader),
+                any(MondrianDef.HierarchyGrant.class));
+    }
+
+
+    public void testHandleHierarchyGrant_ValidMembers() {
+        doTestHandleHierarchyGrant(Access.CUSTOM, Access.ALL);
+    }
+
+    public void testHandleHierarchyGrant_NoValidMembers() {
+        doTestHandleHierarchyGrant(Access.NONE, null);
+    }
+
+    private void doTestHandleHierarchyGrant(
+        Access expectedHierarchyAccess,
+        Access expectedMemberAccess)
+    {
+        propSaver.set(propSaver.properties.IgnoreInvalidMembers, true);
+
+        RolapSchema schema = createSchema();
+        RolapCube cube = mockCube(schema);
+        RoleImpl role = new RoleImpl();
+
+        MondrianDef.MemberGrant memberGrant = new MondrianDef.MemberGrant();
+        memberGrant.access = Access.ALL.toString();
+        memberGrant.member = "member";
+
+        MondrianDef.HierarchyGrant grant = new MondrianDef.HierarchyGrant();
+        grant.access = Access.CUSTOM.toString();
+        grant.rollupPolicy = Role.RollupPolicy.FULL.toString();
+        grant.hierarchy = "hierarchy";
+        grant.memberGrants = new MondrianDef.MemberGrant[] {memberGrant};
+
+        Level level = mock(Level.class);
+        Hierarchy hierarchy = mock(Hierarchy.class);
+        when(hierarchy.getLevels()).thenReturn(new Level[]{level});
+        when(level.getHierarchy()).thenReturn(hierarchy);
+
+        Dimension dimension = mock(Dimension.class);
+        when(hierarchy.getDimension()).thenReturn(dimension);
+
+        SchemaReader reader = mockSchemaReader(Category.Hierarchy, hierarchy);
+
+        Member member = mock(Member.class);
+        when(member.getHierarchy()).thenReturn(hierarchy);
+        when(member.getLevel()).thenReturn(level);
+
+        if (expectedMemberAccess != null) {
+            when(reader.getMemberByUniqueName(
+                anyListOf(Id.Segment.class), anyBoolean())).thenReturn(member);
+        }
+
+        schema.handleHierarchyGrant(role, cube, reader, grant);
+        assertEquals(expectedHierarchyAccess, role.getAccess(hierarchy));
+        if (expectedMemberAccess != null) {
+            assertEquals(expectedMemberAccess, role.getAccess(member));
+        }
+    }
+
+
+    private void assertMondrianException(
+        MondrianException expected,
+        MondrianException actual)
+    {
+        assertEquals(expected.getMessage(), actual.getMessage());
+    }
+}
+
+// End RolapSchemaTest.java

--- a/testsrc/main/mondrian/rolap/agg/AggregationOnInvalidRoleTest.java
+++ b/testsrc/main/mondrian/rolap/agg/AggregationOnInvalidRoleTest.java
@@ -1,0 +1,148 @@
+/*
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (c) 2015-2015 Pentaho Corporation..  All rights reserved.
+*/
+package mondrian.rolap.agg;
+
+import mondrian.test.TestContext;
+import mondrian.test.loader.CsvDBTestCase;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+public class AggregationOnInvalidRoleTest extends CsvDBTestCase {
+
+    @Override
+    protected String getDirectoryName() {
+        return "testsrc/main/mondrian/rolap/agg";
+    }
+
+    @Override
+    protected String getFileName() {
+        return "mondrian_2225.csv";
+    }
+
+    @Override
+    public void setUp() throws Exception {
+        propSaver.set(propSaver.properties.UseAggregates, true);
+        propSaver.set(propSaver.properties.ReadAggregates, true);
+        propSaver.set(propSaver.properties.IgnoreInvalidMembers, true);
+
+        super.setUp();
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+    }
+
+    @Override
+    protected TestContext createTestContext() {
+        TestContext context = super.createTestContext().withRole("Test");
+        context.flushSchemaCache();
+        return context;
+    }
+
+    @Override
+    protected String getCubeDescription() {
+        return CUBE;
+    }
+
+    @Override
+    protected String getRoleDescription() {
+        return ROLE;
+    }
+
+
+    public void test_ExecutesCorrectly_WhenIgnoringInvalidMembers() {
+        TestContext context = getTestContext().withFreshConnection();
+        try {
+            executeAnalyzerQuery(context);
+        } finally {
+            context.close();
+        }
+    }
+
+
+    static final String CUBE = ""
+        + "<Cube name=\"mondrian2225\" visible=\"true\" cache=\"true\" enabled=\"true\">"
+        + "  <Table name=\"mondrian2225_fact\">"
+        + "    <AggName name=\"mondrian2225_agg\" ignorecase=\"true\">"
+        + "      <AggFactCount column=\"fact_count\"/>"
+        + "      <AggMeasure column=\"fact_Measure\" name=\"[Measures].[Measure]\"/>"
+        + "      <AggLevel column=\"dim_Code\" name=\"[Product Code].[Code]\" collapsed=\"true\"/>"
+        + "    </AggName>"
+        + "  </Table>"
+        + "  <Dimension type=\"StandardDimension\" visible=\"true\" foreignKey=\"customer_id\" highCardinality=\"false\" name=\"Customer\">"
+        + "    <Hierarchy name=\"Customer\" visible=\"true\" hasAll=\"true\" primaryKey=\"customer_id\">"
+        + "      <Table name=\"mondrian2225_customer\"/>"
+        + "        <Level name=\"First Name\" visible=\"true\" column=\"customer_name\" type=\"String\" uniqueMembers=\"false\" levelType=\"Regular\" hideMemberIf=\"Never\"/>"
+        + "    </Hierarchy>"
+        + "  </Dimension>"
+        + "  <Dimension type=\"StandardDimension\" visible=\"true\" foreignKey=\"product_ID\" highCardinality=\"false\" name=\"Product Code\">"
+        + "    <Hierarchy name=\"Product Code\" visible=\"true\" hasAll=\"true\" primaryKey=\"product_id\">"
+        + "      <Table name=\"mondrian2225_dim\"/>"
+        + "      <Level name=\"Code\" visible=\"true\" column=\"product_code\" type=\"String\" uniqueMembers=\"false\" levelType=\"Regular\" hideMemberIf=\"Never\"/>"
+        + "    </Hierarchy>"
+        + "  </Dimension>"
+        + "  <Measure name=\"Measure\" column=\"fact\" aggregator=\"sum\" visible=\"true\"/>"
+        + "</Cube>";
+
+    static final String ROLE = ""
+        + "<Role name=\"Test\">"
+        + "  <SchemaGrant access=\"none\">"
+        + "    <CubeGrant cube=\"mondrian2225\" access=\"all\">"
+        + "      <HierarchyGrant hierarchy=\"[Customer.Customer]\" topLevel=\"[Customer.Customer].[First Name]\" access=\"custom\">"
+        + "        <MemberGrant member=\"[Customer.Customer].[NonExistingName]\" access=\"all\"/>"
+        + "      </HierarchyGrant>"
+        + "    </CubeGrant>"
+        + "  </SchemaGrant>"
+        + "</Role>";
+
+    static void executeAnalyzerQuery(TestContext context) {
+        // select measures on columns
+        // and sorted lexicography products on rows
+
+        String queryFromAnalyzer = ""
+            + "with "
+            + "  set [*NATIVE_CJ_SET_WITH_SLICER] as 'Filter([*BASE_MEMBERS__Product Code_], (NOT IsEmpty([Measures].[Measure])))'"
+            + "  set [*NATIVE_CJ_SET] as '[*NATIVE_CJ_SET_WITH_SLICER]'"
+            + "  set [*BASE_MEMBERS__Product Code_] as '[Product Code].[Code].Members'"
+            + "  set [*BASE_MEMBERS__Measures_] as '{[Measures].[Measure]}'"
+            + "  set [*CJ_ROW_AXIS] as 'Generate([*NATIVE_CJ_SET], {[Product Code].CurrentMember})'"
+            + "  set [*SORTED_ROW_AXIS] as 'Order([*CJ_ROW_AXIS], [Product Code].CurrentMember.OrderKey, BASC)' "
+            + "select "
+            + "  [*BASE_MEMBERS__Measures_] on columns,"
+            + "  [*SORTED_ROW_AXIS] on rows "
+            + "from [mondrian2225]";
+
+        String expected = ""
+            + "Axis #0:\n"
+            + "{}\n"
+            + "Axis #1:\n"
+            + "{[Measures].[Measure]}\n"
+            + "Axis #2:\n"
+            + "{[Product Code].[#null]}\n"
+            + "{[Product Code].[five]}\n"
+            + "{[Product Code].[four]}\n"
+            + "{[Product Code].[mdg]}\n"
+            + "{[Product Code].[three]}\n"
+            + "{[Product Code].[tst]}\n"
+            + "{[Product Code].[two]}\n"
+            + "Row #0: 175\n"
+            + "Row #1: 5\n"
+            + "Row #2: 4\n"
+            + "Row #3: 2\n"
+            + "Row #4: 3\n"
+            + "Row #5: 1,000\n"
+            + "Row #6: 2\n";
+
+        context.assertQueryReturns(queryFromAnalyzer, expected);
+    }
+}
+
+// End AggregationOnInvalidRoleTest.java

--- a/testsrc/main/mondrian/rolap/agg/AggregationOnInvalidRoleWhenNotIgnoringTest.java
+++ b/testsrc/main/mondrian/rolap/agg/AggregationOnInvalidRoleWhenNotIgnoringTest.java
@@ -1,0 +1,73 @@
+/*
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (c) 2015-2015 Pentaho Corporation..  All rights reserved.
+*/
+package mondrian.rolap.agg;
+
+import mondrian.test.TestContext;
+import mondrian.test.loader.CsvDBTestCase;
+
+import static mondrian.rolap.agg.AggregationOnInvalidRoleTest.CUBE;
+import static mondrian.rolap.agg.AggregationOnInvalidRoleTest.ROLE;
+import static mondrian.rolap.agg.AggregationOnInvalidRoleTest.executeAnalyzerQuery;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+public class AggregationOnInvalidRoleWhenNotIgnoringTest extends CsvDBTestCase {
+
+    @Override
+    protected String getDirectoryName() {
+        return "testsrc/main/mondrian/rolap/agg";
+    }
+
+    @Override
+    protected String getFileName() {
+        return "mondrian_2225.csv";
+    }
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        propSaver.set(propSaver.properties.UseAggregates, true);
+        propSaver.set(propSaver.properties.ReadAggregates, true);
+        propSaver.set(propSaver.properties.IgnoreInvalidMembers, false);
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+    }
+
+    @Override
+    protected TestContext createTestContext() {
+        // don't do anything dangerous here, just get standard context
+        return TestContext.instance();
+    }
+
+    private TestContext createContext() {
+        TestContext context = TestContext.instance()
+            .create(null, CUBE, null, null, null, ROLE)
+            .withRole("Test");
+        context.flushSchemaCache();
+        return context;
+    }
+
+
+    public void test_ThrowsException_WhenNonIgnoringInvalidMembers() {
+        try {
+            executeAnalyzerQuery(createContext());
+        } catch (Exception e) {
+            // that's ok, junit's assertion errors are derived from Error,
+            // hence they will not be caught here
+            return;
+        }
+        fail("Schema should not load when restriction is invalid");
+    }
+}
+
+// End AggregationOnInvalidRole_IfNotIgnore_Test.java

--- a/testsrc/main/mondrian/rolap/agg/mondrian_2225.csv
+++ b/testsrc/main/mondrian/rolap/agg/mondrian_2225.csv
@@ -1,0 +1,54 @@
+# fact table
+# it is incomplete and contains dummy rows, because data, needed for tests, is taken from agg table
+## TableName: mondrian2225_fact
+## ColumnNames: product_ID,customer_id,fact
+## ColumnTypes: INTEGER,INTEGER,INTEGER
+## NosOfRows: 10
+1,1,1
+2,2,2
+3,3,3
+4,4,4
+5,5,5
+6,5,6
+7,5,7
+8,5,8
+9,5,9
+10,5,10
+# agg table
+## TableName: mondrian2225_agg
+## ColumnNames: dim_code,fact_measure,fact_count
+## ColumnTypes: VARCHAR(45):null,DECIMAL(10,2),INTEGER
+## NosOfRows: 7
+,175,14
+five,5,1
+four,4,1
+mdg,2,1
+tst,1000,1
+three,3,1
+two,2,1
+## TableName: mondrian2225_customer
+## ColumnNames: customer_id,customer_name
+## ColumnTypes: INTEGER,VARCHAR(45):null
+## NosOfRows: 8
+1,Name1
+2,Name2
+3,Name3
+4,Name4
+5,Name5
+6,Name6
+7,Name7
+8,Name8
+## TableName: mondrian2225_dim
+## ColumnNames: product_id,product_code,product_sub_code
+## ColumnTypes: INTEGER,VARCHAR(45):null,VARCHAR(45):null
+## NosOfRows: 10
+1,mdg,mdg
+2,two,second
+3,three,third
+4,four,fourth
+5,five,fifth
+6,,
+7,seven,seventh
+8,eight,eighth
+9,nine,ninth
+10,ten,tenth

--- a/testsrc/main/mondrian/test/FoodMartTestCase.java
+++ b/testsrc/main/mondrian/test/FoodMartTestCase.java
@@ -28,24 +28,13 @@ import java.util.*;
  * @author jhyde
  * @since 29 March, 2002
  */
-public class FoodMartTestCase extends TestCase {
-
-    /**
-     * Access properties via this object and their values will be reset on
-     * {@link #tearDown()}.
-     */
-    protected final PropertySaver propSaver = new PropertySaver();
+public class FoodMartTestCase extends PropertyRestoringTestCase {
 
     public FoodMartTestCase(String name) {
         super(name);
     }
 
     public FoodMartTestCase() {
-    }
-
-    protected void tearDown() throws Exception {
-        // revert any properties that have been set during this test
-        propSaver.reset();
     }
 
     /**

--- a/testsrc/main/mondrian/test/Main.java
+++ b/testsrc/main/mondrian/test/Main.java
@@ -324,6 +324,7 @@ public class Main extends TestSuite {
             addTest(suite, RolapNativeSqlInjectionTest.class);
             addTest(suite, RolapNativeTopCountTest.class);
             addTest(suite, RolapStarTest.class);
+            addTest(suite, RolapSchemaTest.class);
             addTest(suite, RolapSchemaPoolTest.class);
             addTest(suite, NullMemberRepresentationTest.class);
             addTest(suite, IgnoreUnrelatedDimensionsTest.class);
@@ -333,6 +334,8 @@ public class Main extends TestSuite {
             addTest(suite, SetFunDefTest.class);
             addTest(suite, VisualTotalsTest.class);
             addTest(suite, AggregationOnDistinctCountMeasuresTest.class);
+            addTest(suite, AggregationOnInvalidRoleTest.class);
+            addTest(suite, AggregationOnInvalidRoleWhenNotIgnoringTest.class);
             addTest(suite, NonCollapsedAggTest.class);
             addTest(suite, SpeciesNonCollapsedAggTest.class);
             addTest(suite, UsagePrefixTest.class);

--- a/testsrc/main/mondrian/test/PropertyRestoringTestCase.java
+++ b/testsrc/main/mondrian/test/PropertyRestoringTestCase.java
@@ -1,0 +1,38 @@
+/*
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (c) 2015-2015 Pentaho Corporation..  All rights reserved.
+*/
+package mondrian.test;
+
+import junit.framework.TestCase;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+public class PropertyRestoringTestCase extends TestCase {
+
+    public PropertyRestoringTestCase() {
+    }
+
+    public PropertyRestoringTestCase(String name) {
+        super(name);
+    }
+
+    /**
+     * Access properties via this object and their values will be reset on
+     * {@link #tearDown()}.
+     */
+    protected final PropertySaver propSaver = new PropertySaver();
+
+    @Override
+    protected void tearDown() throws Exception {
+        // revert any properties that have been set during this test
+        propSaver.reset();
+    }
+}
+
+// End PropertyRestoringTestCase.java


### PR DESCRIPTION
- restrict hierarchy entirely if it contains no members and was initially defined with CUSTOM access
- introduce separate methods for each OlapElement to be used in granting routine
- introduce PropertyRestoringTestCase to be a parent for those tests that need changed properties
- add tests for the ticket's case
(adopted from commit 8dfab89)

@mkambol, @lucboudreau, review it please. This is a backport of https://github.com/pentaho/mondrian/pull/599  