### PR TITLE
[TEST] - Make RolapNativeSqlInjectionTest tolerant to different environments

### DIFF
--- a/testsrc/main/mondrian/rolap/RolapNativeSqlInjectionTest.java
+++ b/testsrc/main/mondrian/rolap/RolapNativeSqlInjectionTest.java
@@ -18,16 +18,20 @@ import mondrian.test.TestContext;
  */
 public class RolapNativeSqlInjectionTest extends FoodMartTestCase {
 
-    public void testMondrian2436() {
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
         propSaver.set(propSaver.properties.EnableNativeFilter, true);
         propSaver.set(propSaver.properties.EnableNativeCrossJoin, true);
+    }
 
+    public void testMondrian2436() {
         String mdxQuery = ""
             + "select {[Measures].[Store Sales]} on columns, "
             + "filter([Customers].[Name].Members, (([Measures].[Store Sales]) > '(select 1000)')) on rows "
             + "from [Sales]";
 
-        TestContext context = getTestContext();
+        TestContext context = getTestContext().withFreshConnection();
         try {
             context.executeQuery(mdxQuery);
         } catch (MondrianException e) {
@@ -38,7 +42,10 @@ public class RolapNativeSqlInjectionTest extends FoodMartTestCase {
                 "Expected to get decimal, but got (select 1000)",
                 e.getCause().getMessage());
             return;
+        } finally {
+            context.close();
         }
+
         fail("[Store Sales] filtering should not work for non-valid decimals");
     }
 }


### PR DESCRIPTION
- force Mondrian to open a fresh connection as it compels it to re-create schemas and, consequently, RolapNativeRegistry, where native-related instances are stored

@mkambol, @lucboudreau, @kurtwalker, review it please