### PR TITLE
[BACKLOG-6084]  Remove xalan dependency from Mondrian

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -74,7 +74,6 @@
             <artifact name="olap4j-xmla"/>
         </dependency>
 
-        <dependency org="xalan" name="xalan" rev="2.6.0"/>
         <dependency org="xerces" name="xercesImpl" rev="2.9.1"/>
 
         <!--  OSS Licenses file -->

--- a/src/main/mondrian/tui/NamespaceContextImpl.java
+++ b/src/main/mondrian/tui/NamespaceContextImpl.java
@@ -1,0 +1,56 @@
+/*
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (C) 2005-2016 Pentaho and others
+// All Rights Reserved.
+*/
+package mondrian.tui;
+
+import java.util.*;
+import javax.xml.namespace.NamespaceContext;
+
+public class NamespaceContextImpl implements NamespaceContext {
+
+    private final Map<String, String> prefixUriMap;
+
+    public NamespaceContextImpl(Map<String, String> prefixUriMap) {
+        if (prefixUriMap == null) {
+            throw new IllegalArgumentException("Must define map");
+        }
+        this.prefixUriMap = Collections.unmodifiableMap(prefixUriMap);
+    }
+
+    @Override
+    public String getNamespaceURI(String prefix) {
+        if (prefix == null) {
+            throw new IllegalArgumentException("Prefix cannot be null.");
+        }
+        return prefixUriMap.get(prefix);
+    }
+
+    @Override
+    public String getPrefix(String namespaceURI) {
+        // arbitrarily returns the first associated w/ uri
+        // (consistent w/ spec)
+        Iterator iter = getPrefixes(namespaceURI);
+        return iter.hasNext() ? (String) iter.next() : null;
+    }
+
+    @Override
+    public Iterator getPrefixes(String namespaceURI) {
+        if (namespaceURI == null) {
+            throw new IllegalArgumentException("Namespace URI cannot be null.");
+        }
+        List<String> uris = new ArrayList<>();
+        for (Map.Entry<String, String> entry : prefixUriMap.entrySet()) {
+            if (namespaceURI.equals(entry.getValue())) {
+                uris.add(entry.getKey());
+            }
+        }
+        return uris.iterator();
+    }
+}
+// End NamespaceContextImpl.java

--- a/testsrc/main/mondrian/test/Main.java
+++ b/testsrc/main/mondrian/test/Main.java
@@ -5,7 +5,7 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 1998-2005 Julian Hyde
-// Copyright (C) 2005-2015 Pentaho and others
+// Copyright (C) 2005-2016 Pentaho and others
 // All Rights Reserved.
 //
 // jhyde, 21 January, 1999
@@ -29,6 +29,8 @@ import mondrian.spi.impl.SybaseDialectTest;
 import mondrian.test.build.CodeComplianceTest;
 import mondrian.test.clearview.*;
 import mondrian.test.comp.ResultComparatorTest;
+import mondrian.tui.NamespaceContextImplTest;
+import mondrian.tui.XmlUtilTest;
 import mondrian.udf.CurrentDateMemberUdfTest;
 import mondrian.udf.NullValueTest;
 import mondrian.util.*;
@@ -382,6 +384,8 @@ public class Main extends TestSuite {
             addTest(suite, CodeSetTest.class);
             addTest(suite, ExplicitRecognizerTest.class);
             addTest(suite, AggregationOverAggTableTest.class);
+            addTest(suite, XmlUtilTest.class);
+            addTest(suite, NamespaceContextImplTest.class);
             addTest(suite, CancellationTest.class);
 
             if (MondrianProperties.instance().EnableNativeCrossJoin.get()) {

--- a/testsrc/main/mondrian/tui/NamespaceContextImplTest.java
+++ b/testsrc/main/mondrian/tui/NamespaceContextImplTest.java
@@ -1,0 +1,75 @@
+/*
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (C) 2005-2016 Pentaho and others
+// All Rights Reserved.
+*/
+package mondrian.tui;
+
+import junit.framework.TestCase;
+
+import javax.xml.namespace.NamespaceContext;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+public class NamespaceContextImplTest extends TestCase {
+
+    Map<String, String> namespaces = new HashMap<>();
+    NamespaceContext namespaceContext;
+
+    public void setUp() {
+        namespaces.put("FOO", "http://foo.bar.baz");
+        namespaces.put("BAR", "http://foo.bar.baz");
+        namespaces.put("BAZ", "http://schema.other");
+        namespaces.put("BOP", "http://schema.other2");
+        namespaceContext =  new NamespaceContextImpl(namespaces);
+    }
+
+    public void testGetNamespaceURI() throws Exception
+    {
+        assertEquals(
+            "http://foo.bar.baz",
+            namespaceContext.getNamespaceURI("FOO"));
+        assertEquals(
+            "http://foo.bar.baz",
+            namespaceContext.getNamespaceURI("BAR"));
+        assertEquals(
+            "http://schema.other",
+            namespaceContext.getNamespaceURI("BAZ"));
+    }
+
+    public void testGetPrefix() throws Exception {
+        String prefix = namespaceContext.getPrefix("http://foo.bar.baz");
+        // will arbitrarily get one when more than one prefix maps
+        assertTrue(prefix.equals("FOO") || prefix.equals("BAR"));
+    }
+
+    public void testGetPrefixNullArg() throws Exception {
+        try {
+            namespaceContext.getPrefix(null);
+            fail("expected exception");
+        } catch (Exception e) {
+            assertEquals(IllegalArgumentException.class, e.getClass());
+        }
+    }
+
+    public void testGetPrefixes() throws Exception {
+        Iterator iter = namespaceContext.getPrefixes("http://foo.bar.baz");
+        assertTrue(iter.hasNext());
+        List<String> list = new ArrayList<>();
+        list.add((String)iter.next());
+        list.add((String)iter.next());
+        assertFalse(iter.hasNext());
+        assertTrue(list.contains("FOO"));
+        assertTrue(list.contains("BAR"));
+    }
+
+}
+// End NamespaceContextImplTest.java

--- a/testsrc/main/mondrian/tui/XmlUtilTest.java
+++ b/testsrc/main/mondrian/tui/XmlUtilTest.java
@@ -1,0 +1,162 @@
+/*
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (C) 2005-2016 Pentaho and others
+// All Rights Reserved.
+*/
+package mondrian.tui;
+
+import mondrian.xmla.XmlaConstants;
+
+import junit.framework.TestCase;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.xml.sax.SAXException;
+
+import javax.xml.xpath.XPathException;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class XmlUtilTest extends TestCase {
+
+    public void testSelectAsNodesWithEmptyNamespace()
+            throws IOException, SAXException, XPathException
+    {
+        String x = "<doc><foo><bar></bar><baz></baz></foo></doc>";
+        Document doc = XmlUtil.parseString(x);
+        Node[] nodes = XmlUtil.selectAsNodes(
+            doc, "/doc/foo/*",
+            Collections.<String, String>emptyMap());
+
+        assertEquals(2, nodes.length);
+        assertEquals("bar", nodes[0].getNodeName());
+        assertEquals("baz", nodes[1].getNodeName());
+    }
+
+    public void testSmallWithSingleNamespace()
+            throws IOException, SAXException, XPathException
+    {
+        String x = "<bop:doc xmlns:bop='http://foo.bar.baz'><bop:foo><bop:bar>"
+                + "</bop:bar><bop:baz></bop:baz></bop:foo></bop:doc>";
+        Document doc = XmlUtil.parseString(x);
+        Node[] nodes = XmlUtil.selectAsNodes(
+            doc, "/bop:doc/bop:foo/*",
+            Collections.singletonMap("bop", "http://foo.bar.baz"));
+
+        assertEquals(2, nodes.length);
+        assertEquals("bop:bar", nodes[0].getNodeName());
+        assertEquals("bop:baz", nodes[1].getNodeName());
+    }
+
+    public void testSelectAsNodesDiscover()
+            throws IOException, SAXException, XPathException
+    {
+        String xml =
+                "\n"
+                + "<SOAP-ENV:Envelope\n"
+                + "    xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\"\n"
+                + "    SOAP-ENV:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\">\n"
+                + "  <SOAP-ENV:Body>\n"
+                + "    <Discover xmlns=\"urn:schemas-microsoft-com:xml-analysis\"\n"
+                + "        SOAP-ENV:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\">\n"
+                + "    <RequestType>DISCOVER_ENUMERATORS</RequestType>\n"
+                + "    <Restrictions>\n"
+                + "      <RestrictionList>\n"
+                + "      </RestrictionList>\n"
+                + "    </Restrictions>\n"
+                + "    <Properties>\n"
+                + "      <PropertyList>\n"
+                + "        <DataSourceInfo>FoodMart</DataSourceInfo>\n"
+                + "        <Content>SchemaData</Content>\n"
+                + "      </PropertyList>\n"
+                + "    </Properties>\n"
+                + "    </Discover>\n"
+                + "</SOAP-ENV:Body>\n"
+                + "</SOAP-ENV:Envelope>\n";
+        Node[] nodes = XmlUtil.selectAsNodes(
+            XmlUtil.parseString(xml),
+            "/SOAP-ENV:Envelope/SOAP-ENV:Body/*",
+            Collections.singletonMap(
+                XmlaConstants.SOAP_PREFIX,
+                XmlaConstants.NS_SOAP_ENV_1_1));
+        assertEquals(nodes.length, 1);
+        assertEquals("Discover", nodes[0].getNodeName());
+    }
+
+    public void testSelectAsNodes3Namespaces()
+            throws IOException, SAXException, XPathException
+    {
+        String soapResp =
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                + "<SOAP-ENV:Envelope xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\" "
+                + "SOAP-ENV:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\" >\n"
+                + "<SOAP-ENV:Header>\n"
+                + "</SOAP-ENV:Header>\n"
+                + "<SOAP-ENV:Body>\n"
+                + "<cxmla:DiscoverResponse xmlns:cxmla=\"urn:schemas-microsoft-com:xml-analysis\">\n"
+                + "  <cxmla:return>\n"
+                + "    <root xmlns=\"urn:schemas-microsoft-com:xml-analysis:rowset\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:EX=\"urn:schemas-microsoft-com:xml-analysis:exception\">\n"
+                + "      <xsd:schema xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns=\"urn:schemas-microsoft-com:xml-analysis:rowset\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:sql=\"urn:schemas-microsoft-com:xml-sql\" targetNamespace=\"urn:schemas-microsoft-com:xml-analysis:rowset\" elementFormDefault=\"qualified\">\n"
+                + "        <xsd:element name=\"root\">\n"
+                + "          <xsd:complexType>\n"
+                + "            <xsd:sequence>\n"
+                + "              <xsd:element name=\"row\" type=\"row\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n"
+                + "            </xsd:sequence>\n"
+                + "          </xsd:complexType>\n"
+                + "        </xsd:element>\n"
+                + "        <xsd:simpleType name=\"uuid\">\n"
+                + "          <xsd:restriction base=\"xsd:string\">\n"
+                + "            <xsd:pattern value=\"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\"/>\n"
+                + "          </xsd:restriction>\n"
+                + "        </xsd:simpleType>\n"
+                + "        <xsd:complexType name=\"row\">\n"
+                + "          <xsd:sequence>\n"
+                + "            <xsd:element sql:field=\"DataSourceName\" name=\"DataSourceName\" type=\"xsd:string\"/>\n"
+                + "            <xsd:element sql:field=\"DataSourceDescription\" name=\"DataSourceDescription\" type=\"xsd:string\" minOccurs=\"0\"/>\n"
+                + "            <xsd:element sql:field=\"URL\" name=\"URL\" type=\"xsd:string\" minOccurs=\"0\"/>\n"
+                + "            <xsd:element sql:field=\"DataSourceInfo\" name=\"DataSourceInfo\" type=\"xsd:string\" minOccurs=\"0\"/>\n"
+                + "            <xsd:element sql:field=\"ProviderName\" name=\"ProviderName\" type=\"xsd:string\" minOccurs=\"0\"/>\n"
+                + "            <xsd:element sql:field=\"ProviderType\" name=\"ProviderType\" type=\"xsd:string\" maxOccurs=\"unbounded\"/>\n"
+                + "            <xsd:element sql:field=\"AuthenticationMode\" name=\"AuthenticationMode\" type=\"xsd:string\"/>\n"
+                + "          </xsd:sequence>\n"
+                + "        </xsd:complexType>\n"
+                + "      </xsd:schema>\n"
+                + "      <row>\n"
+                + "        <DataSourceName>FoodMart</DataSourceName>\n"
+                + "        <DataSourceDescription>Mondrian FoodMart data source</DataSourceDescription>\n"
+                + "        <URL>http://localhost:8080/mondrian/xmla</URL>\n"
+                + "        <DataSourceInfo>Catalog=file:/Users/mcampbell/dev/mondrian/demo/FoodMart.xml; Provider=mondrian; PoolNeeded=false</DataSourceInfo>\n"
+                + "        <ProviderName>Mondrian</ProviderName>\n"
+                + "        <ProviderType>MDP</ProviderType>\n"
+                + "        <AuthenticationMode>Unauthenticated</AuthenticationMode>\n"
+                + "      </row>\n"
+                + "    </root>\n"
+                + "  </cxmla:return>\n"
+                + "</cxmla:DiscoverResponse>\n"
+                + "</SOAP-ENV:Body>\n"
+                + "</SOAP-ENV:Envelope>\n";
+
+        String xpath =
+                "/SOAP-ENV:Envelope/SOAP-ENV:Body/xmla:DiscoverResponse/xmla:return/ROW:root/*";
+        Map<String, String> namespaces = new HashMap<>();
+        namespaces.put(
+            XmlaConstants.SOAP_PREFIX, XmlaConstants.NS_SOAP_ENV_1_1);
+        namespaces.put("xmla", XmlaConstants.NS_XMLA);
+        namespaces.put("ROW", XmlaConstants.NS_XMLA_ROWSET);
+        Node[] nodes = XmlUtil.selectAsNodes(
+            XmlUtil.parseString(soapResp),
+            xpath,
+            namespaces);
+        assertEquals(2, nodes.length);
+        assertEquals("xsd:schema", nodes[0].getNodeName());
+        assertEquals("row", nodes[1].getNodeName());
+    }
+}
+// End XmlUtilTest.java


### PR DESCRIPTION
This change refactors parts of XmlUtil and XmlaSupport which were
dependent on Xalan 2.6, switching to standard java.xml.xpath.
A number of unused methods were also cleared out.

http://jira.pentaho.com/browse/BACKLOG-6084

@lucboudreau 