### PR TITLE
[Sp-2459] - Backport of MONDRIAN-2279 - When a query is cancelled or times out, Mondrian may continue iterating over large tuple lists (5.4 Suite)

### DIFF
--- a/src/main/mondrian/olap/MondrianProperties.xml
+++ b/src/main/mondrian/olap/MondrianProperties.xml
@@ -1040,16 +1040,16 @@ allowed when iterating over members to compute aggregates.  A value of
         <Default>0</Default>
     </PropertyDefinition>
     <PropertyDefinition>
-        <Name>CancelPhaseInterval</Name>
-        <Path>mondrian.rolap.cancelPhaseInterval</Path>
+        <Name>CheckCancelOrTimeoutInterval</Name>
+        <Path>mondrian.util.checkCancelOrTimeoutInterval</Path>
         <Description>
-<p>Positive integer property that determines how many rows are read from sql executions between checks for whether the current mdx query has been cancelled.<br/>
-Setting the interval too small may result in a performance hit when reading large result sets;
-setting it too high can cause a big delay between the query being marked as cancelled and system resources associated to it being released.
+<p>Positive integer property that determines loop iterations number between checks for whether the current mdx query has been cancelled or timeout was exceeded.<br/>
+Setting the interval too small may result in a performance degradation when reading large result sets;
+setting it too high can cause a big delay between the query being marked as cancelled or timeout was exceeded and system resources associated to it being released.
 </p>
         </Description>
         <Type>int</Type>
-        <Default>10000</Default>
+        <Default>1000</Default>
     </PropertyDefinition>
     <PropertyDefinition>
         <Name>ExecutionHistorySize</Name>

--- a/src/main/mondrian/olap/fun/CrossJoinFunDef.java
+++ b/src/main/mondrian/olap/fun/CrossJoinFunDef.java
@@ -5,7 +5,7 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2002-2005 Julian Hyde
-// Copyright (C) 2005-2015 Pentaho and others
+// Copyright (C) 2005-2016 Pentaho and others
 // All Rights Reserved.
 */
 package mondrian.olap.fun;
@@ -17,6 +17,9 @@ import mondrian.olap.*;
 import mondrian.olap.type.*;
 import mondrian.resource.MondrianResource;
 import mondrian.rolap.RolapEvaluator;
+import mondrian.server.Execution;
+import mondrian.server.Locus;
+import mondrian.util.CancellationChecker;
 import mondrian.util.CartesianProductList;
 
 import org.apache.log4j.Logger;
@@ -565,7 +568,11 @@ public class CrossJoinFunDef extends FunDefBase {
         final int partialSizeNext = partialSize + tupleList.getArity();
         final int iNext = i + 1;
         final TupleCursor cursor = tupleList.tupleCursor();
+        int currentIteration = 0;
+        Execution execution = Locus.peek().execution;
         while (cursor.forward()) {
+            CancellationChecker.checkCancelOrTimeout(
+                currentIteration++, execution);
             cursor.currentToArray(partialArray, partialSize);
             if (i == lists.size() - 1) {
                 result.addAll(partial);
@@ -932,6 +939,8 @@ public class CrossJoinFunDef extends FunDefBase {
             // Measure and non-All Members evaluation is non-null, then
             // add it to the result List.
             final TupleCursor cursor = list.tupleCursor();
+            int currentIteration = 0;
+            Execution execution = query.getStatement().getCurrentExecution();
             while (cursor.forward()) {
                 cursor.setContext(evaluator);
                 for (Member member : memberSet) {
@@ -942,6 +951,11 @@ public class CrossJoinFunDef extends FunDefBase {
                     // hierarchies.
                     evaluator.setContext(member.getHierarchy().getAllMember());
                 }
+                // Check if the MDX query was canceled.
+                // Throws an exception in case of timeout is exceeded
+                // see MONDRIAN-2425
+                CancellationChecker.checkCancelOrTimeout(
+                    currentIteration++, execution);
 
                 if (checkData(
                         nonAllMembers,

--- a/src/main/mondrian/olap/fun/FunUtil.java
+++ b/src/main/mondrian/olap/fun/FunUtil.java
@@ -5,7 +5,7 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2002-2005 Julian Hyde
-// Copyright (C) 2005-2015 Pentaho and others
+// Copyright (C) 2005-2016 Pentaho and others
 // All Rights Reserved.
 */
 package mondrian.olap.fun;
@@ -17,6 +17,7 @@ import mondrian.olap.*;
 import mondrian.olap.type.*;
 import mondrian.resource.MondrianResource;
 import mondrian.rolap.*;
+import mondrian.server.Execution;
 import mondrian.util.*;
 
 import org.apache.commons.collections.ComparatorUtils;
@@ -634,7 +635,12 @@ public class FunUtil extends Util {
         if (tupleList == null) {
             tupleArrayList = new ArrayList<List<Member>>();
             final TupleCursor cursor = tupleIterable.tupleCursor();
+            int currentIteration = 0;
+            Execution execution =
+                evaluator.getQuery().getStatement().getCurrentExecution();
             while (cursor.forward()) {
+                CancellationChecker.checkCancelOrTimeout(
+                    currentIteration++, execution);
                 tupleArrayList.add(cursor.current());
             }
             if (tupleArrayList.size() <= 1) {
@@ -1591,7 +1597,12 @@ public class FunUtil extends Util {
         // todo: treat constant exps as evaluateMembers() does
         SetWrapper retval = new SetWrapper();
         final TupleCursor cursor = members.tupleCursor();
+        int currentIteration = 0;
+        Execution execution =
+            evaluator.getQuery().getStatement().getCurrentExecution();
         while (cursor.forward()) {
+            CancellationChecker.checkCancelOrTimeout(
+                currentIteration++, execution);
             cursor.setContext(evaluator);
             Object o = calc.evaluate(evaluator);
             if (o == null || o == Util.nullValue) {
@@ -1635,7 +1646,12 @@ public class FunUtil extends Util {
             retvals[i] = new SetWrapper();
         }
         final TupleCursor cursor = list.tupleCursor();
+        int currentIteration = 0;
+        Execution execution =
+            evaluator.getQuery().getStatement().getCurrentExecution();
         while (cursor.forward()) {
+            CancellationChecker.checkCancelOrTimeout(
+                currentIteration++, execution);
             cursor.setContext(evaluator);
             for (int i = 0; i < calcs.length; i++) {
                 DoubleCalc calc = calcs[i];

--- a/src/main/mondrian/rolap/RolapResult.java
+++ b/src/main/mondrian/rolap/RolapResult.java
@@ -5,7 +5,7 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2001-2005 Julian Hyde
-// Copyright (C) 2005-2015 Pentaho and others
+// Copyright (C) 2005-2016 Pentaho and others
 // All Rights Reserved.
 */
 package mondrian.rolap;
@@ -1579,7 +1579,11 @@ public class RolapResult extends ResultBase {
         }
 
         private void mergeTupleIter(TupleCursor cursor) {
+            int currentIteration = 0;
+            Execution execution = Locus.peek().execution;
             while (cursor.forward()) {
+                CancellationChecker.checkCancelOrTimeout(
+                    currentIteration++, execution);
                 mergeTuple(cursor);
             }
         }

--- a/src/main/mondrian/rolap/SqlMemberSource.java
+++ b/src/main/mondrian/rolap/SqlMemberSource.java
@@ -5,7 +5,7 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2001-2005 Julian Hyde
-// Copyright (C) 2005-2015 Pentaho and others
+// Copyright (C) 2005-2016 Pentaho and others
 // All Rights Reserved.
 */
 package mondrian.rolap;
@@ -17,6 +17,7 @@ import mondrian.rolap.agg.AggregationManager;
 import mondrian.rolap.agg.CellRequest;
 import mondrian.rolap.aggmatcher.AggStar;
 import mondrian.rolap.sql.*;
+import mondrian.server.Execution;
 import mondrian.server.Locus;
 import mondrian.server.monitor.SqlStatementEvent;
 import mondrian.spi.Dialect;
@@ -337,23 +338,18 @@ class SqlMemberSource
             }
 
             int limit = MondrianProperties.instance().ResultLimit.get();
-            final int checkCancelPeriod =
-                MondrianProperties.instance().CancelPhaseInterval.get();
             ResultSet resultSet = stmt.getResultSet();
+            Execution execution = Locus.peek().execution;
             while (resultSet.next()) {
-                ++stmt.rowCount;
+                // Check if the MDX query was canceled.
+                CancellationChecker.checkCancelOrTimeout(
+                    ++stmt.rowCount, execution);
+
                 if (limit > 0 && limit < stmt.rowCount) {
                     // result limit exceeded, throw an exception
                     throw stmt.handle(
                         MondrianResource.instance().MemberFetchLimitExceeded.ex(
                             limit));
-                }
-
-                // Check if the MDX query was canceled.
-                if (checkCancelPeriod > 0
-                    && stmt.rowCount % checkCancelPeriod == 0)
-                {
-                    Locus.peek().execution.checkCancelOrTimeout();
                 }
 
                 int column = 0;
@@ -973,26 +969,21 @@ RME is this right
                 -1, -1, null);
         try {
             int limit = MondrianProperties.instance().ResultLimit.get();
-            final int checkCancelPeriod =
-                MondrianProperties.instance().CancelPhaseInterval.get();
             boolean checkCacheStatus = true;
 
             final List<SqlStatement.Accessor> accessors = stmt.getAccessors();
             ResultSet resultSet = stmt.getResultSet();
             RolapMember parentMember2 = RolapUtil.strip(parentMember);
+            Execution execution = Locus.peek().execution;
             while (resultSet.next()) {
-                ++stmt.rowCount;
+                // Check if the MDX query was canceled.
+                CancellationChecker.checkCancelOrTimeout(
+                    ++stmt.rowCount, execution);
+
                 if (limit > 0 && limit < stmt.rowCount) {
                     // result limit exceeded, throw an exception
                     throw MondrianResource.instance().MemberFetchLimitExceeded
                         .ex(limit);
-                }
-
-                // Check if the MDX query was canceled.
-                if (checkCancelPeriod > 0
-                    && stmt.rowCount % checkCancelPeriod == 0)
-                {
-                    Locus.peek().execution.checkCancelOrTimeout();
                 }
 
                 Object value = accessors.get(0).get();

--- a/src/main/mondrian/rolap/SqlTupleReader.java
+++ b/src/main/mondrian/rolap/SqlTupleReader.java
@@ -6,7 +6,7 @@
 //
 // Copyright (C) 2004-2005 TONBELLER AG
 // Copyright (C) 2005-2005 Julian Hyde
-// Copyright (C) 2005-2015 Pentaho and others
+// Copyright (C) 2005-2016 Pentaho and others
 // All Rights Reserved.
 */
 package mondrian.rolap;
@@ -21,8 +21,10 @@ import mondrian.rolap.agg.AggregationManager;
 import mondrian.rolap.agg.CellRequest;
 import mondrian.rolap.aggmatcher.AggStar;
 import mondrian.rolap.sql.*;
+import mondrian.server.Execution;
 import mondrian.server.Locus;
 import mondrian.server.monitor.SqlStatementEvent;
+import mondrian.util.CancellationChecker;
 import mondrian.util.Pair;
 
 import org.apache.log4j.Logger;
@@ -415,8 +417,6 @@ public class SqlTupleReader implements TupleReader {
             }
 
             int limit = MondrianProperties.instance().ResultLimit.get();
-            final int checkCancelPeriod =
-                MondrianProperties.instance().CancelPhaseInterval.get();
             int fetchCount = 0;
 
             // determine how many enum targets we have
@@ -436,18 +436,17 @@ public class SqlTupleReader implements TupleReader {
             } else {
                 moreRows = currPartialResultIdx < partialResult.size();
             }
+
+            Execution execution = Locus.peek().execution;
             while (moreRows) {
+                // Check if the MDX query was canceled.
+                CancellationChecker.checkCancelOrTimeout(
+                    stmt.rowCount, execution);
+
                 if (limit > 0 && limit < ++fetchCount) {
                     // result limit exceeded, throw an exception
                     throw MondrianResource.instance().MemberFetchLimitExceeded
                         .ex((long) limit);
-                }
-
-                // Check if the MDX query was canceled.
-                if (checkCancelPeriod > 0
-                    && stmt.rowCount % checkCancelPeriod == 0)
-                {
-                    Locus.peek().execution.checkCancelOrTimeout();
                 }
 
                 if (enumTargetCount == 0) {

--- a/src/main/mondrian/util/CancellationChecker.java
+++ b/src/main/mondrian/util/CancellationChecker.java
@@ -1,0 +1,37 @@
+/*
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (C) 2016-2016 Pentaho and others
+// All Rights Reserved.
+*/
+package mondrian.util;
+
+import mondrian.olap.MondrianProperties;
+import mondrian.server.Execution;
+
+/**
+ * Encapsulates cancel and timeouts checks
+ *
+ * @author Yury_Bakhmutski
+ * @since Jan 18, 2016
+ */
+public class CancellationChecker {
+
+  public static void checkCancelOrTimeout(
+      int currentIteration, Execution execution)
+  {
+    int checkCancelOrTimeoutInterval =
+        MondrianProperties.instance().CheckCancelOrTimeoutInterval.get();
+    synchronized (execution) {
+      if (checkCancelOrTimeoutInterval > 0
+          && currentIteration % checkCancelOrTimeoutInterval == 0)
+      {
+        execution.checkCancelOrTimeout();
+      }
+    }
+  }
+}
+// End CancellationChecker.java

--- a/src/main/mondrian/util/CancellationChecker.java
+++ b/src/main/mondrian/util/CancellationChecker.java
@@ -25,12 +25,14 @@ public class CancellationChecker {
   {
     int checkCancelOrTimeoutInterval =
         MondrianProperties.instance().CheckCancelOrTimeoutInterval.get();
-    synchronized (execution) {
-      if (checkCancelOrTimeoutInterval > 0
-          && currentIteration % checkCancelOrTimeoutInterval == 0)
-      {
-        execution.checkCancelOrTimeout();
-      }
+    if (execution != null) {
+      synchronized (execution) {
+        if (checkCancelOrTimeoutInterval > 0
+            && currentIteration % checkCancelOrTimeoutInterval == 0)
+        {
+          execution.checkCancelOrTimeout();
+        }
+    }
     }
   }
 }

--- a/testsrc/main/mondrian/rolap/CancellationTest.java
+++ b/testsrc/main/mondrian/rolap/CancellationTest.java
@@ -1,0 +1,77 @@
+/*
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
+*/
+package mondrian.rolap;
+
+import mondrian.calc.TupleList;
+import mondrian.calc.impl.UnaryTupleList;
+import mondrian.olap.*;
+import mondrian.olap.fun.CrossJoinFunDef;
+import mondrian.server.Execution;
+import mondrian.server.Locus;
+import mondrian.test.FoodMartTestCase;
+
+import static org.mockito.Mockito.*;
+
+
+public class CancellationTest extends FoodMartTestCase {
+    
+    public void testMutableCrossJoinCancellation() throws MondrianException {
+        // tests that cancellation/timeout is checked in
+        // CrossJoinFunDef.mutableCrossJoin
+        propSaver.set(propSaver.properties.CheckCancelOrTimeoutInterval, 1);
+
+        RolapCube salesCube = (RolapCube) cubeByName(
+            getTestContext().getConnection(),
+            "Sales");
+        SchemaReader salesCubeSchemaReader =
+            salesCube.getSchemaReader(
+                getTestContext().getConnection().getRole()).withLocus();
+
+        TupleList productMembers =
+            productMembersPotScrubbersPotsAndPans(salesCubeSchemaReader);
+
+        String selectGenders = "select Gender.members on 0 from sales";
+        Result genders = executeQuery(selectGenders);
+
+        Evaluator gendersEval =
+            ((RolapResult) genders).getEvaluator(new int[]{0});
+        TupleList genderMembers = new UnaryTupleList();
+        for (Position pos : genders.getAxes()[0].getPositions()) {
+            genderMembers.add(pos);
+        }
+
+        Execution execution =
+            spy(new Execution(genders.getQuery().getStatement(), 0));
+        TupleList mutableCrossJoinResult =
+            mutableCrossJoin(productMembers, genderMembers, execution);
+
+        gendersEval.getQuery().getStatement().start(execution);
+
+        // checkCancelOrTimeout should be called once
+        // for each tuple from mutableCrossJoin since phase interval is 1
+        // plus once for each productMembers item
+        // since it gets through SqlStatement.execute
+        int expectedCallsQuantity =
+            mutableCrossJoinResult.size() + productMembers.size();
+        verify(execution, times(expectedCallsQuantity)).checkCancelOrTimeout();
+    }
+
+    private TupleList mutableCrossJoin(
+        final TupleList list1, final TupleList list2, final Execution execution)
+        {
+            return Locus.execute(
+                execution, "CancellationTest",
+                new Locus.Action<TupleList>() {
+                    public TupleList execute() {
+                        return CrossJoinFunDef.mutableCrossJoin(list1, list2);
+                    }
+                });
+        }
+}
+// End CancellationTest.java

--- a/testsrc/main/mondrian/test/BasicQueryTest.java
+++ b/testsrc/main/mondrian/test/BasicQueryTest.java
@@ -5,7 +5,7 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2003-2005 Julian Hyde
-// Copyright (C) 2005-2014 Pentaho
+// Copyright (C) 2005-2016 Pentaho
 // All Rights Reserved.
 //
 // jhyde, Feb 14, 2003
@@ -6163,7 +6163,7 @@ public class BasicQueryTest extends FoodMartTestCase {
             "SELECT {[Measures].[Unit Sales]} ON COLUMNS,\n"
             + "  {[Product].members} ON ROWS\n"
             + "FROM [Sales]";
-        propSaver.set(props.CancelPhaseInterval, cancelInterval);
+        propSaver.set(props.CheckCancelOrTimeoutInterval, cancelInterval);
         final String triggerSql = "product_name";
 
         Long rows = executeAndCancelAtSqlFetch(
@@ -6184,7 +6184,7 @@ public class BasicQueryTest extends FoodMartTestCase {
     public void testCancelSqlFetchSegmentLoad() throws Exception {
           // 512 rows
           final int cancelInterval = 101;
-          propSaver.set(props.CancelPhaseInterval, cancelInterval);
+          propSaver.set(props.CheckCancelOrTimeoutInterval, cancelInterval);
           // this will avoid spamming output with cache failures, but should
           // also work without side effects with cache enabled
           propSaver.set(props.DisableCaching, true);
@@ -6216,7 +6216,7 @@ public class BasicQueryTest extends FoodMartTestCase {
             "SELECT {[Measures].[Unit Sales]} ON COLUMNS,\n"
             + "  {[Customers].[Mexico].[Guerrero].[Acapulco].Children} ON ROWS\n"
             + "FROM [Sales]";
-        propSaver.set(props.CancelPhaseInterval, cancelInterval);
+        propSaver.set(props.CheckCancelOrTimeoutInterval, cancelInterval);
 
         Long rows = executeAndCancelAtSqlFetch(
             query, "customer_id", "SqlMemberSource.getMemberChildren");
@@ -8333,11 +8333,11 @@ public class BasicQueryTest extends FoodMartTestCase {
         // Some DBs return 0 when we ask for null. Like Oracle.
         final String returnedValue;
         switch (getTestContext().getDialect().getDatabaseProduct()) {
-            case ORACLE:
-                returnedValue = "0";
-                break;
-            default:
-                returnedValue = "";
+        case ORACLE:
+            returnedValue = "0";
+            break;
+        default:
+            returnedValue = "";
         }
 
         testContext.assertQueryReturns(
@@ -8419,21 +8419,28 @@ public class BasicQueryTest extends FoodMartTestCase {
                 + "    <Level name=\"IsZero\" visible=\"true\" table=\"product\" column=\"product_id\" type=\"Integer\" uniqueMembers=\"false\" levelType=\"Regular\" hideMemberIf=\"Never\">\n"
                 + "      <NameExpression>\n"
                 + "        <SQL dialect=\"generic\">\n"
-                + "          <![CDATA[case when " + dialect.quoteIdentifier("product","product_id") + "=0 then 'Zero' else 'Non-Zero' end]]>\n"
+                + "          <![CDATA[case when "
+                + dialect.quoteIdentifier("product", "product_id")
+                + "=0 then 'Zero' else 'Non-Zero' end]]>\n"
                 + "        </SQL>\n"
                 + "      </NameExpression>\n"
                 + "    </Level>\n"
                 + "    <Level name=\"SubCat\" visible=\"true\" table=\"product_class\" column=\"product_class_id\" type=\"String\" uniqueMembers=\"false\" levelType=\"Regular\" hideMemberIf=\"Never\">\n"
                 + "      <NameExpression>\n"
                 + "        <SQL dialect=\"generic\">\n"
-                + "          <![CDATA[" + dialect.quoteIdentifier("product_class","product_subcategory") + "]]>\n"
+                + "          <![CDATA["
+                + dialect.quoteIdentifier(
+                    "product_class", "product_subcategory")
+                + "]]>\n"
                 + "        </SQL>\n"
                 + "      </NameExpression>\n"
                 + "    </Level>\n"
                 + "    <Level name=\"ProductName\" visible=\"true\" table=\"product\" column=\"product_id\" type=\"Integer\" uniqueMembers=\"false\" levelType=\"Regular\" hideMemberIf=\"Never\">\n"
                 + "      <NameExpression>\n"
                 + "        <SQL dialect=\"generic\">\n"
-                + "          <![CDATA["+ dialect.quoteIdentifier("product","product_name") + "]]>\n"
+                + "          <![CDATA["
+                + dialect.quoteIdentifier("product", "product_name")
+                + "]]>\n"
                 + "        </SQL>\n"
                 + "      </NameExpression>\n"
                 + "    </Level>\n"

--- a/testsrc/main/mondrian/test/Main.java
+++ b/testsrc/main/mondrian/test/Main.java
@@ -377,6 +377,7 @@ public class Main extends TestSuite {
             addTest(suite, CodeSetTest.class);
             addTest(suite, ExplicitRecognizerTest.class);
             addTest(suite, AggregationOverAggTableTest.class);
+            addTest(suite, CancellationTest.class);
 
             if (MondrianProperties.instance().EnableNativeCrossJoin.get()) {
                 addTest(suite, BatchedFillTest.class, "suite");


### PR DESCRIPTION
@mkambol, @pamval here is backport of https://github.com/pentaho/mondrian/pull/639 and https://github.com/pentaho/mondrian/pull/643 to 3.10 (5.4) branch