### PR TITLE
Sp-2469 - Backport of MONDRIAN-2425 - MDX will not stop at timeout for certain Analyzer reports with totals/subtotals (5.4 Suite)

### DIFF
--- a/src/main/mondrian/server/Execution.java
+++ b/src/main/mondrian/server/Execution.java
@@ -1,12 +1,13 @@
 /*
-* This software is subject to the terms of the Eclipse Public License v1.0
-* Agreement, available at the following URL:
-* http://www.eclipse.org/legal/epl-v10.html.
-* You must accept the terms of that agreement to use this software.
-*
-* Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (C) 2002-2005 Julian Hyde
+// Copyright (C) 2005-2015 Pentaho and others
+// All Rights Reserved.
 */
-
 package mondrian.server;
 
 import mondrian.olap.*;
@@ -242,6 +243,7 @@ public class Execution {
             }
             throw MondrianResource.instance().QueryCanceled.ex();
         case RUNNING:
+        case TIMEOUT:
             if (timeoutTimeMillis > 0) {
                 long currTime = System.currentTimeMillis();
                 if (currTime > timeoutTimeMillis) {

--- a/src/main/mondrian/server/Execution.java
+++ b/src/main/mondrian/server/Execution.java
@@ -5,7 +5,7 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2002-2005 Julian Hyde
-// Copyright (C) 2005-2015 Pentaho and others
+// Copyright (C) 2005-2016 Pentaho and others
 // All Rights Reserved.
 */
 package mondrian.server;

--- a/testsrc/main/mondrian/olap/fun/CrossJoinTest.java
+++ b/testsrc/main/mondrian/olap/fun/CrossJoinTest.java
@@ -1,12 +1,11 @@
 /*
-* This software is subject to the terms of the Eclipse Public License v1.0
-* Agreement, available at the following URL:
-* http://www.eclipse.org/legal/epl-v10.html.
-* You must accept the terms of that agreement to use this software.
-*
-* Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
 */
-
 package mondrian.olap.fun;
 
 import mondrian.calc.*;
@@ -325,7 +324,7 @@ if (! Util.Retrowoven) {
     }
 
     public static class NullFunDef implements FunDef {
-        NullFunDef() {
+        public NullFunDef() {
         }
         public Syntax getSyntax() {
             return Syntax.Function;

--- a/testsrc/main/mondrian/rolap/CancellationTest.java
+++ b/testsrc/main/mondrian/rolap/CancellationTest.java
@@ -10,8 +10,10 @@ package mondrian.rolap;
 
 import mondrian.calc.TupleList;
 import mondrian.calc.impl.UnaryTupleList;
+import mondrian.mdx.ResolvedFunCall;
 import mondrian.olap.*;
 import mondrian.olap.fun.CrossJoinFunDef;
+import mondrian.olap.fun.CrossJoinTest;
 import mondrian.server.Execution;
 import mondrian.server.Locus;
 import mondrian.test.FoodMartTestCase;
@@ -20,7 +22,28 @@ import static org.mockito.Mockito.*;
 
 
 public class CancellationTest extends FoodMartTestCase {
-    
+
+    public void testNonEmptyListCancellation() throws MondrianException {
+        // tests that cancellation/timeout is checked in
+        // CrossJoinFunDef.nonEmptyList
+        propSaver.set(propSaver.properties.CheckCancelOrTimeoutInterval, 1);
+        CrossJoinFunDefTester crossJoinFunDef =
+            new CrossJoinFunDefTester(new CrossJoinTest.NullFunDef());
+        Result result =
+            executeQuery("select store.[store name].members on 0 from sales");
+        Evaluator eval = ((RolapResult) result).getEvaluator(new int[]{0});
+        TupleList list = new UnaryTupleList();
+        for (Position pos : result.getAxes()[0].getPositions()) {
+            list.add(pos);
+        }
+        Execution exec = spy(new Execution(eval.getQuery().getStatement(), 0));
+        eval.getQuery().getStatement().start(exec);
+        crossJoinFunDef.nonEmptyList(eval, list, null);
+        // checkCancelOrTimeout should be called once
+        // for each tuple since phase interval is 1
+        verify(exec, times(list.size())).checkCancelOrTimeout();
+    }
+
     public void testMutableCrossJoinCancellation() throws MondrianException {
         // tests that cancellation/timeout is checked in
         // CrossJoinFunDef.mutableCrossJoin
@@ -64,14 +87,28 @@ public class CancellationTest extends FoodMartTestCase {
 
     private TupleList mutableCrossJoin(
         final TupleList list1, final TupleList list2, final Execution execution)
-        {
-            return Locus.execute(
-                execution, "CancellationTest",
-                new Locus.Action<TupleList>() {
-                    public TupleList execute() {
-                        return CrossJoinFunDef.mutableCrossJoin(list1, list2);
-                    }
-                });
+    {
+        return Locus.execute(
+            execution, "CancellationTest",
+            new Locus.Action<TupleList>() {
+                public TupleList execute() {
+                    return CrossJoinFunDef.mutableCrossJoin(list1, list2);
+                }
+            });
+    }
+
+    public class CrossJoinFunDefTester extends CrossJoinFunDef {
+        public CrossJoinFunDefTester(FunDef dummyFunDef) {
+            super(dummyFunDef);
         }
+
+        public TupleList nonEmptyList(
+            Evaluator evaluator,
+            TupleList list,
+            ResolvedFunCall call)
+        {
+            return super.nonEmptyList(evaluator, list, call);
+        }
+    }
 }
 // End CancellationTest.java


### PR DESCRIPTION
@mkambol, here is the backport of https://github.com/pentaho/mondrian/pull/443 to 5.4. The check for timeout in Crossjoin was added in scope of another SP: https://github.com/pentaho/mondrian/pull/652/files#diff-5ec0bb38bb42f48c445dc7c435db6696R957