### PR TITLE
[MONDRIAN-2451] Mondrian generates ORDER BY sql that is invalid with default settings of MySQL 5.7.5+

### DIFF
--- a/src/main/mondrian/rolap/SqlMemberSource.java
+++ b/src/main/mondrian/rolap/SqlMemberSource.java
@@ -616,7 +616,7 @@ RME is this right
         hierarchy.addToFrom(sqlQuery, level.getKeyExp());
         String q = level.getKeyExp().getExpression(sqlQuery);
         String idAlias =
-            sqlQuery.addSelectGroupBy(q, level.getInternalType());
+            sqlQuery.addSelectGroupBy(q, level.getInternalType(), true);
 
         // in non empty mode the level table must be joined to the fact
         // table

--- a/src/main/mondrian/spi/Dialect.java
+++ b/src/main/mondrian/spi/Dialect.java
@@ -442,6 +442,19 @@ public interface Dialect {
         boolean collateNullsLast);
 
     /**
+     * Generates an item for an GROUP BY section and ensuring that
+     * nullable fields will be processed correctly.
+     *
+     * @param expr expression for the GROUP BY clause
+     * @param nullable whether expression may have NULL values
+     *
+     * @return Expression modified according to the nullable parameter
+     */
+    public String generateGroupItem(
+        String expr,
+        boolean nullable);
+
+    /**
      * Returns whether this Dialect supports expressions in the GROUP BY
      * clause. Derby/Cloudscape and Infobright do not.
      *

--- a/src/main/mondrian/spi/impl/JdbcDialectImpl.java
+++ b/src/main/mondrian/spi/impl/JdbcDialectImpl.java
@@ -752,6 +752,9 @@ public class JdbcDialectImpl implements Dialect {
         return !readOnly;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public String generateOrderItem(
         String expr,
         boolean nullable,
@@ -822,6 +825,34 @@ public class JdbcDialectImpl implements Dialect {
                     + " DESC";
             }
         }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public String generateGroupItem(
+        String expr,
+        boolean nullable)
+    {
+        if (nullable) {
+            return generateGroupByNulls(expr);
+        } else {
+            return expr;
+        }
+    }
+
+    /**
+     * Generates expression for GROUP BY section to correspond fields generated
+     * by {@link #generateOrderByNulls(String, boolean, boolean)} method.
+     *
+     * Additional info: http://jira.pentaho.com/browse/MONDRIAN-2451
+     *
+     * @param expr expression for the GROUP BY section
+     * @return expression modified according to the nullable parameter
+     */
+    protected String generateGroupByNulls(String expr)
+    {
+        return "CASE WHEN " + expr + " IS NULL THEN 1 ELSE 0 END, " + expr;
     }
 
     /**

--- a/src/main/mondrian/spi/impl/MySqlDialect.java
+++ b/src/main/mondrian/spi/impl/MySqlDialect.java
@@ -247,6 +247,14 @@ public class MySqlDialect extends JdbcDialectImpl {
         }
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    protected String generateGroupByNulls(String expr)
+    {
+        return "ISNULL(" + expr + "), " + expr;
+    }
+
     public boolean requiresHavingAlias() {
         return true;
     }

--- a/testsrc/main/mondrian/rolap/sql/EffectiveMemberCacheTest.java
+++ b/testsrc/main/mondrian/rolap/sql/EffectiveMemberCacheTest.java
@@ -49,7 +49,7 @@ public class EffectiveMemberCacheTest extends BatchTestCase {
                     + "and\n"
                     + "    ( UPPER(`product`.`product_name`) IN (UPPER('Hermanos Fancy Plums'),UPPER('Hermanos Lemons'),UPPER('Hermanos Plums')))\n"
                     + "group by\n"
-                    + "    `product`.`product_name`\n"
+                    + "    ISNULL(`product`.`product_name`), `product`.`product_name`\n"
                     + "order by\n"
                     + "    ISNULL(`product`.`product_name`) ASC, "
                     + "`product`.`product_name` ASC", null)}
@@ -82,7 +82,7 @@ public class EffectiveMemberCacheTest extends BatchTestCase {
                     + "    ( UPPER(`product`.`product_name`) IN "
                     + "(UPPER('Hermanos Fancy Plums'),UPPER('Hermanos Lemons'),UPPER('Hermanos Plums')))\n"
                     + "group by\n"
-                    + "    `product`.`product_name`\n"
+                    + "    ISNULL(`product`.`product_name`), `product`.`product_name`\n"
                     + "order by\n"
                     + "    ISNULL(`product`.`product_name`) ASC, "
                     + "`product`.`product_name` ASC", null) }
@@ -107,7 +107,7 @@ public class EffectiveMemberCacheTest extends BatchTestCase {
                     + "from\n"
                     + "    `store` as `store`\n"
                     + "group by\n"
-                    + "    `store`.`store_type`\n"
+                    + "    ISNULL(`store`.`store_type`), `store`.`store_type`\n"
                     + "order by\n"
                     + "    ISNULL(`store`.`store_type`) ASC, "
                     + "`store`.`store_type` ASC", null)
@@ -135,7 +135,7 @@ public class EffectiveMemberCacheTest extends BatchTestCase {
                     + "    ( UPPER(`store`.`store_type`) IN "
                     + "(UPPER('Gourmet Supermarket'),UPPER('HeadQuarters')))\n"
                     + "group by\n"
-                    + "    `store`.`store_type`\n"
+                    + "    ISNULL(`store`.`store_type`), `store`.`store_type`\n"
                     + "order by\n"
                     + "    ISNULL(`store`.`store_type`) ASC, "
                     + "`store`.`store_type` ASC", null)
@@ -160,7 +160,7 @@ public class EffectiveMemberCacheTest extends BatchTestCase {
                     + "where\n"
                     + "    `store`.`coffee_bar` = false\n"
                     + "group by\n"
-                    + "    `store`.`coffee_bar`\n"
+                    + "    ISNULL(`store`.`coffee_bar`), `store`.`coffee_bar`\n"
                     + "order by\n"
                     + "    ISNULL(`store`.`coffee_bar`) ASC, "
                     + "`store`.`coffee_bar` ASC", null)});

--- a/testsrc/main/mondrian/test/NativeSetEvaluationTest.java
+++ b/testsrc/main/mondrian/test/NativeSetEvaluationTest.java
@@ -998,7 +998,7 @@ public class NativeSetEvaluationTest extends BatchTestCase {
             + "and\n"
             + "    `customer`.`city` = 'San Francisco'\n"
             + "group by\n"
-            + "    `customer`.`customer_id`,\n"
+            + "    ISNULL(`customer`.`customer_id`), `customer`.`customer_id`,\n"
             + "    CONCAT(`customer`.`fname`, ' ', `customer`.`lname`),\n"
             + "    `customer`.`gender`,\n"
             + "    `customer`.`marital_status`,\n"


### PR DESCRIPTION
- Ability to generate GROUP BY expressions for nullable fields is added to Dialect interface and SqlQuery class
- UTs fixed