### PR TITLE
[CLEANUP]  Correcting compile error introduced w/ java 8 switch.

### DIFF
--- a/testsrc/main/mondrian/olap/UtilTestCase.java
+++ b/testsrc/main/mondrian/olap/UtilTestCase.java
@@ -5,10 +5,9 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2004-2005 Julian Hyde
-// Copyright (C) 2005-2012 Pentaho and others
+// Copyright (C) 2005-2016 Pentaho and others
 // All Rights Reserved.
 */
-
 package mondrian.olap;
 
 import mondrian.olap.Util.ByteMatcher;
@@ -1398,7 +1397,7 @@ public class UtilTestCase extends TestCase {
         // Will throw a ClassCastException if it fails.
         Util.binarySearch(
             compArray, 0, compArray.length,
-            RolapUtil.sqlNullValue);
+            (Comparable)RolapUtil.sqlNullValue);
     }
 
     public void testByteMatcher() throws Exception {


### PR DESCRIPTION
This will at least get the compile working w/ j8, but there will be lots of failed/error'd tests due to hashcode changes, etc.

@lucboudreau @kurtwalker 