### PR TITLE
[MONDRIAN-1599]  Virt Cube MDX mishandled w/ non-joining dims

### DIFF
--- a/src/main/mondrian/olap/fun/CrossJoinFunDef.java
+++ b/src/main/mondrian/olap/fun/CrossJoinFunDef.java
@@ -17,6 +17,7 @@ import mondrian.olap.*;
 import mondrian.olap.type.*;
 import mondrian.resource.MondrianResource;
 import mondrian.rolap.RolapEvaluator;
+import mondrian.rolap.SqlConstraintUtils;
 import mondrian.server.Execution;
 import mondrian.server.Locus;
 import mondrian.util.CancellationChecker;
@@ -776,6 +777,12 @@ public class CrossJoinFunDef extends FunDefBase {
             Formula[] formula = query.getFormulas();
             if (formula != null) {
                 for (Formula f : formula) {
+                    if (SqlConstraintUtils.containsValidMeasure(
+                            f.getExpression()))
+                    {
+                        // short circuit if VM is present.
+                        return list;
+                    }
                     f.accept(measureVisitor);
                 }
             }

--- a/src/main/mondrian/rolap/HighCardSqlTupleReader.java
+++ b/src/main/mondrian/rolap/HighCardSqlTupleReader.java
@@ -5,10 +5,9 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2004-2005 TONBELLER AG
-// Copyright (C) 2005-2013 Pentaho and others
+// Copyright (C) 2005-2016 Pentaho and others
 // All Rights Reserved.
 */
-
 package mondrian.rolap;
 
 import mondrian.calc.TupleList;
@@ -58,7 +57,8 @@ public class HighCardSqlTupleReader extends SqlTupleReader {
     protected void prepareTuples(
         final DataSource dataSource,
         final TupleList partialResult,
-        final List<List<RolapMember>> newPartialResult)
+        final List<List<RolapMember>> newPartialResult,
+        final List<TargetBase> targetGroup)
     {
         String message = "Populating member cache with members for " + targets;
         SqlStatement stmt = null;
@@ -75,7 +75,7 @@ public class HighCardSqlTupleReader extends SqlTupleReader {
                     }
                 }
                 final Pair<String, List<SqlStatement.Type>> pair =
-                    makeLevelMembersSql(dataSource);
+                    makeLevelMembersSql(dataSource, targetGroup);
                 String sql = pair.left;
                 List<SqlStatement.Type> types = pair.right;
                 stmt = RolapUtil.executeQuery(
@@ -136,7 +136,7 @@ public class HighCardSqlTupleReader extends SqlTupleReader {
         final TupleList partialResult,
         final List<List<RolapMember>> newPartialResult)
     {
-        prepareTuples(dataSource, partialResult, newPartialResult);
+        prepareTuples(dataSource, partialResult, newPartialResult, targets);
 
         assert targets.size() == 1;
 
@@ -149,7 +149,8 @@ public class HighCardSqlTupleReader extends SqlTupleReader {
         final TupleList partialResult,
         final List<List<RolapMember>> newPartialResult)
     {
-        prepareTuples(jdbcConnection, partialResult, newPartialResult);
+        prepareTuples(
+            jdbcConnection, partialResult, newPartialResult, targets);
 
         // List of tuples
         final int n = targets.size();

--- a/testsrc/main/mondrian/rolap/NativeEvalVirtualCubeTest.java
+++ b/testsrc/main/mondrian/rolap/NativeEvalVirtualCubeTest.java
@@ -1,0 +1,328 @@
+/*
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (C) 2009-2016 Pentaho
+// All Rights Reserved.
+*/
+package mondrian.rolap;
+
+public class NativeEvalVirtualCubeTest extends BatchTestCase {
+
+  /**
+   * Both dims fully join to the applicable base cube.
+   */
+  public void testSimpleFullyJoiningCJ() {
+    verifySameNativeAndNot(
+        "select {measures.[unit sales], measures.[warehouse sales]} on 0, "
+        + " nonemptycrossjoin( Gender.Gender.members, product.[product category].members) on 1 "
+        + "from [warehouse and sales]",
+        "", getTestContext());
+  }
+
+  public void testPartiallyJoiningCJ() {
+    String query = "select measures.[warehouse sales] on 0, "
+      + " NON EMPTY Crossjoin ( Gender.gender.members, product.[product category].members) on 1 "
+      + " from [warehouse and sales]";
+
+      verifySameNativeAndNot(query, "", getTestContext());
+      assertQueryReturns(
+          query,
+          "Axis #0:\n"
+          + "{}\n"
+          + "Axis #1:\n"
+          + "{[Measures].[Warehouse Sales]}\n"
+          + "Axis #2:\n");
+  }
+
+  /**
+   * Both dims fully join to one of the applicable base cubes.
+   */
+  public void testOneFullyJoiningCube() {
+    verifySameNativeAndNot(
+        "select {measures.[unit sales], measures.[warehouse sales]} on 0, "
+        + " nonemptycrossjoin( Gender.Gender.members, product.[product category].members) on 1 "
+        + "from [warehouse and sales]",
+        "", getTestContext());
+  }
+
+  public void testNoApplicableCube() {
+    verifySameNativeAndNot(
+        "select {measures.[unit sales]} on 0, "
+        + " nonemptycrossjoin( Gender.Gender.members, [Warehouse].[All Warehouses].children) on 1 "
+        + "from [warehouse and sales]",
+        "", getTestContext());
+  }
+
+  /**
+   * [All Gender] should not impact the nonempty tuple list,
+   * even though Gender does not
+   * apply to [Warehouse Sales]
+   */
+  public void testShouldBeFullyJoiningCJ() {
+    verifySameNativeAndNot(
+        "select measures.[warehouse Sales] on 0, "
+        + " nonemptycrossjoin( Gender.[All Gender], "
+        + "product.[product category].members)"
+        + " on 1 "
+        + " from [warehouse and sales]", "", getTestContext());
+  }
+
+
+  public void testMeasureChangesContextOfInapplicableDimension() {
+      verifySameNativeAndNot(
+          "with member [Measures].[allW] as \n"
+          + "'([Measures].[Unit Sales], [Warehouse].[All Warehouses])'\n"
+          + "select NON EMPTY Crossjoin(\n"
+          + "[Warehouse].[State Province].[CA], [Product].[All Products].children) \n"
+          + "ON COLUMNS,\n"
+          + "{ [Measures].[allW]}\n"
+          + "ON ROWS\n"
+          + "from [Warehouse and Sales]", "", getTestContext());
+  }
+
+  public void testMeasureChangesContextOfApplicableDimension() {
+    String query =
+        "with member [Measures].[allW] as \n"
+        + "'([Measures].[Warehouse Sales], [Warehouse].[All Warehouses])'\n"
+        + "select NON EMPTY Crossjoin(\n"
+        + "[Warehouse].[All Warehouses].[USA].Children, [Product].[All Products].children) \n"
+        + "ON COLUMNS,\n"
+        + "{ [Measures].[allW]}\n"
+        + "ON ROWS\n"
+        + "from [Warehouse and Sales]";
+    verifySameNativeAndNot(query, "", getTestContext());
+    assertQueryReturns(
+        query,
+        "Axis #0:\n"
+        + "{}\n"
+        + "Axis #1:\n"
+        + "{[Warehouse].[USA].[CA], [Product].[Drink]}\n"
+        + "{[Warehouse].[USA].[CA], [Product].[Food]}\n"
+        + "{[Warehouse].[USA].[CA], [Product].[Non-Consumable]}\n"
+        + "{[Warehouse].[USA].[OR], [Product].[Drink]}\n"
+        + "{[Warehouse].[USA].[OR], [Product].[Food]}\n"
+        + "{[Warehouse].[USA].[OR], [Product].[Non-Consumable]}\n"
+        + "{[Warehouse].[USA].[WA], [Product].[Drink]}\n"
+        + "{[Warehouse].[USA].[WA], [Product].[Food]}\n"
+        + "{[Warehouse].[USA].[WA], [Product].[Non-Consumable]}\n"
+        + "Axis #2:\n"
+        + "{[Measures].[allW]}\n"
+        + "Row #0: 18,010.602\n"
+        + "Row #0: 141,147.92\n"
+        + "Row #0: 37,612.366\n"
+        + "Row #0: 18,010.602\n"
+        + "Row #0: 141,147.92\n"
+        + "Row #0: 37,612.366\n"
+        + "Row #0: 18,010.602\n"
+        + "Row #0: 141,147.92\n"
+        + "Row #0: 37,612.366\n");
+  }
+
+  public void testNECJWithValidMeasureAndInapplicableDimension() {
+    // with this query the crossjoin optimizer also causes issues if
+    // evaluated non-natively- so both
+    // native on/off will give same results, but wrong unless cjoptimizer
+    // doesn't kick in.
+    String query =
+        "with member [Measures].[validUS] as \n"
+        + "'ValidMeasure([Measures].[Unit Sales])'\n"
+        + "select NON EMPTY Crossjoin(\n"
+        + "{[Warehouse].[USA].children}, [Product].[All Products].children) \n"
+        + "ON COLUMNS,\n"
+        + "{ [Measures].[validUS]}\n"
+        + "ON ROWS\n"
+        + "from [Warehouse and Sales]";
+    assertQueryReturns(
+        query,
+        "Axis #0:\n"
+        + "{}\n"
+        + "Axis #1:\n"
+        + "{[Warehouse].[USA].[CA], [Product].[Drink]}\n"
+        + "{[Warehouse].[USA].[CA], [Product].[Food]}\n"
+        + "{[Warehouse].[USA].[CA], [Product].[Non-Consumable]}\n"
+        + "{[Warehouse].[USA].[OR], [Product].[Drink]}\n"
+        + "{[Warehouse].[USA].[OR], [Product].[Food]}\n"
+        + "{[Warehouse].[USA].[OR], [Product].[Non-Consumable]}\n"
+        + "{[Warehouse].[USA].[WA], [Product].[Drink]}\n"
+        + "{[Warehouse].[USA].[WA], [Product].[Food]}\n"
+        + "{[Warehouse].[USA].[WA], [Product].[Non-Consumable]}\n"
+        + "Axis #2:\n"
+        + "{[Measures].[validUS]}\n"
+        + "Row #0: 24,597\n"
+        + "Row #0: 191,940\n"
+        + "Row #0: 50,236\n"
+        + "Row #0: 24,597\n"
+        + "Row #0: 191,940\n"
+        + "Row #0: 50,236\n"
+        + "Row #0: 24,597\n"
+        + "Row #0: 191,940\n"
+        + "Row #0: 50,236\n");
+  }
+
+  public void testDisjointDimensionCJ() {
+    // No fully joining dimensions.
+    assertQueryReturns(
+        "with member measures.vmWS as 'ValidMeasure(measures.[Warehouse Sales])'"
+        + " select NON EMPTY Crossjoin(\n"
+        + "{[Warehouse].[State Province].members}, {Gender.[All Gender].children} ) \n"
+        + "ON COLUMNS,\n"
+        + "{ [Measures].[Unit Sales], Measures.[vmWS] }\n"
+        + "ON ROWS\n"
+        + "from [Warehouse and Sales]",
+        "Axis #0:\n"
+        + "{}\n"
+        + "Axis #1:\n"
+        + "{[Warehouse].[USA].[CA], [Gender].[F]}\n"
+        + "{[Warehouse].[USA].[CA], [Gender].[M]}\n"
+        + "{[Warehouse].[USA].[OR], [Gender].[F]}\n"
+        + "{[Warehouse].[USA].[OR], [Gender].[M]}\n"
+        + "{[Warehouse].[USA].[WA], [Gender].[F]}\n"
+        + "{[Warehouse].[USA].[WA], [Gender].[M]}\n"
+        + "Axis #2:\n"
+        + "{[Measures].[Unit Sales]}\n"
+        + "{[Measures].[vmWS]}\n"
+        + "Row #0: \n"
+        + "Row #0: \n"
+        + "Row #0: \n"
+        + "Row #0: \n"
+        + "Row #0: \n"
+        + "Row #0: \n"
+        + "Row #1: 57,814.858\n"
+        + "Row #1: 57,814.858\n"
+        + "Row #1: 38,835.053\n"
+        + "Row #1: 38,835.053\n"
+        + "Row #1: 100,120.976\n"
+        + "Row #1: 100,120.976\n");
+  }
+
+  public void testWarehouseForcedToAllLevel() {
+    verifySameNativeAndNot(
+        "with member [Measures].[validUS] as \n"
+        + "'ValidMeasure([Measures].[Unit Sales])'\n"
+        + "select NON EMPTY Crossjoin(\n"
+        + "{[Warehouse].[State Province].[CA],[Warehouse].[State Province].[WA]}, [Product].[All Products].children) \n"
+        + "ON COLUMNS,\n"
+        + "{ [Measures].[validUS]}\n"
+        + "ON ROWS\n"
+        + "from [Warehouse and Sales]", "", getTestContext());
+  }
+
+  public void testMdxCJOfApplicableAndNonApplicable() {
+    assertQueryReturns(
+        "WITH\n"
+        + "MEMBER Measures.[ValidM Unit Sales] as 'ValidMeasure([Measures].[Unit Sales])' "
+        + "SET [*NATIVE_CJ_SET_WITH_SLICER] AS 'NONEMPTYCROSSJOIN([*BASE_MEMBERS__Warehouse_],[*BASE_MEMBERS__Gender_])"
+        + "'\n"
+        + "SET [*NATIVE_CJ_SET] AS '[*NATIVE_CJ_SET_WITH_SLICER]'\n"
+        + "SET [*SORTED_ROW_AXIS] AS 'ORDER([*CJ_ROW_AXIS],[Warehouse].CURRENTMEMBER.ORDERKEY,BASC,ANCESTOR([Warehouse]"
+        + ".CURRENTMEMBER,[Warehouse].[Country]).ORDERKEY,BASC,[Gender].CURRENTMEMBER.ORDERKEY,BASC)'\n"
+        + "SET [*BASE_MEMBERS__Measures_] AS '{[Measures].[ValidM Unit Sales]}'\n"
+        + "SET [*BASE_MEMBERS__Gender_] AS '[Gender].[Gender].MEMBERS'\n"
+        + "SET [*BASE_MEMBERS__Warehouse_] AS '[Warehouse].[USA].Children'\n"
+        + "SET [*CJ_ROW_AXIS] AS 'GENERATE([*NATIVE_CJ_SET], {([Warehouse].CURRENTMEMBER,[Gender].CURRENTMEMBER)})'\n"
+        + "SELECT\n"
+        + "[*BASE_MEMBERS__Measures_] ON COLUMNS\n"
+        + ",NON EMPTY\n"
+        + "[*SORTED_ROW_AXIS] ON ROWS\n"
+        + "FROM [Warehouse and Sales]",
+        "Axis #0:\n"
+        + "{}\n"
+        + "Axis #1:\n"
+        + "{[Measures].[ValidM Unit Sales]}\n"
+        + "Axis #2:\n"
+        + "{[Warehouse].[USA].[CA], [Gender].[F]}\n"
+        + "{[Warehouse].[USA].[CA], [Gender].[M]}\n"
+        + "{[Warehouse].[USA].[OR], [Gender].[F]}\n"
+        + "{[Warehouse].[USA].[OR], [Gender].[M]}\n"
+        + "{[Warehouse].[USA].[WA], [Gender].[F]}\n"
+        + "{[Warehouse].[USA].[WA], [Gender].[M]}\n"
+        + "Row #0: 131,558\n"
+        + "Row #1: 135,215\n"
+        + "Row #2: 131,558\n"
+        + "Row #3: 135,215\n"
+        + "Row #4: 131,558\n"
+        + "Row #5: 135,215\n");
+  }
+
+  public void testAllMemberTupleInapplicableDim() {
+    assertQueryReturns(
+        "WITH\n"
+        + "SET [*NATIVE_CJ_SET_WITH_SLICER] AS 'NONEMPTYCROSSJOIN([*BASE_MEMBERS__Warehouse_],"
+        + "[*BASE_MEMBERS__Gender_])'\n"
+        + "SET [*NATIVE_CJ_SET] AS '[*NATIVE_CJ_SET_WITH_SLICER]'\n"
+        + "SET [*SORTED_ROW_AXIS] AS 'ORDER([*CJ_ROW_AXIS],[Warehouse].CURRENTMEMBER.ORDERKEY,BASC,ANCESTOR"
+        + "([Warehouse].CURRENTMEMBER,[Warehouse].[Country]).ORDERKEY,BASC,[Gender].CURRENTMEMBER.ORDERKEY,BASC)'\n"
+        + "SET [*BASE_MEMBERS__Measures_] AS '{[Measures].[*FORMATTED_MEASURE_0],"
+        + "[Measures].[*CALCULATED_MEASURE_1]}'\n"
+        + "SET [*BASE_MEMBERS__Gender_] AS '[Gender].[Gender].MEMBERS'\n"
+        + "SET [*BASE_MEMBERS__Warehouse_] AS '[Warehouse].[USA].Children'\n"
+        + "SET [*CJ_ROW_AXIS] AS 'GENERATE([*NATIVE_CJ_SET], {([Warehouse].CURRENTMEMBER,[Gender].CURRENTMEMBER)})'\n"
+        + "MEMBER [Measures].[*CALCULATED_MEASURE_1] AS '( [Warehouse].[All Warehouses], [Measures].[Unit Sales] )', "
+        + "SOLVE_ORDER=0\n"
+        + "MEMBER [Measures].[*FORMATTED_MEASURE_0] AS '[Measures].[Unit Sales]', FORMAT_STRING = 'Standard', "
+        + "SOLVE_ORDER=500\n"
+        + "SELECT\n"
+        + "[*BASE_MEMBERS__Measures_] ON COLUMNS\n"
+        + ",NON EMPTY\n"
+        + "[*SORTED_ROW_AXIS] ON ROWS\n"
+        + "FROM [Warehouse and Sales]",
+        "Axis #0:\n"
+        + "{}\n"
+        + "Axis #1:\n"
+        + "{[Measures].[*FORMATTED_MEASURE_0]}\n"
+        + "{[Measures].[*CALCULATED_MEASURE_1]}\n"
+        + "Axis #2:\n"
+        + "{[Warehouse].[USA].[CA], [Gender].[F]}\n"
+        + "{[Warehouse].[USA].[CA], [Gender].[M]}\n"
+        + "{[Warehouse].[USA].[OR], [Gender].[F]}\n"
+        + "{[Warehouse].[USA].[OR], [Gender].[M]}\n"
+        + "{[Warehouse].[USA].[WA], [Gender].[F]}\n"
+        + "{[Warehouse].[USA].[WA], [Gender].[M]}\n"
+        + "Row #0: \n"
+        + "Row #0: 131,558\n"
+        + "Row #1: \n"
+        + "Row #1: 135,215\n"
+        + "Row #2: \n"
+        + "Row #2: 131,558\n"
+        + "Row #3: \n"
+        + "Row #3: 135,215\n"
+        + "Row #4: \n"
+        + "Row #4: 131,558\n"
+        + "Row #5: \n"
+        + "Row #5: 135,215\n");
+  }
+
+  public void testIntermixedDimensionGroupings() {
+    // crossjoin places intermixes applicable and inapplicable
+    // attributes, which
+    // this verifies that the projected crossjoin is in the correct order,
+    // even though the
+    // components may not be evaluated together.  (in this case gender
+    // and marital status are
+    // natively evaluated in a cj, with warehouse evaluated in a separate
+    // group.  The sets need to be reassembled and projected correctly).
+    assertQueryReturns(
+        "with member measures.vmUS as 'ValidMeasure(Measures.[Unit Sales])' "
+        + "select non empty crossjoin(crossjoin(gender.gender.members, warehouse.[USA].[CA]), [marital status].[marital status].members) on 0, "
+        + " measures.vmUS on 1 from [warehouse and sales]",
+        "Axis #0:\n"
+        + "{}\n"
+        + "Axis #1:\n"
+        + "{[Gender].[F], [Warehouse].[USA].[CA], [Marital Status].[M]}\n"
+        + "{[Gender].[F], [Warehouse].[USA].[CA], [Marital Status].[S]}\n"
+        + "{[Gender].[M], [Warehouse].[USA].[CA], [Marital Status].[M]}\n"
+        + "{[Gender].[M], [Warehouse].[USA].[CA], [Marital Status].[S]}\n"
+        + "Axis #2:\n"
+        + "{[Measures].[vmUS]}\n"
+        + "Row #0: 65,336\n"
+        + "Row #0: 66,222\n"
+        + "Row #0: 66,460\n"
+        + "Row #0: 68,755\n");
+  }
+
+}
+
+// End NativeEvalVirtualCubeTest.java

--- a/testsrc/main/mondrian/rolap/NonEmptyTest.java
+++ b/testsrc/main/mondrian/rolap/NonEmptyTest.java
@@ -5,7 +5,7 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2003-2005 Julian Hyde
-// Copyright (C) 2005-2015 Pentaho
+// Copyright (C) 2005-2016 Pentaho
 // All Rights Reserved.
 */
 package mondrian.rolap;
@@ -4024,6 +4024,11 @@ public class NonEmptyTest extends BatchTestCase {
     }
 
     public void testCrossjoinWithTwoDimensionsJoiningToOppositeBaseCubes() {
+        // This test formerly expected an empty result set,
+        // which is actually inconsistent with SSAS.  Since ValidMeasure forces
+        // Warehouse to the [All] level when evaluating the [vm] measure,
+        // the results should include each [warehouse name] member intersected
+        // with the non-empty Gender members.
         assertQueryReturns(
             "with member [Measures].[vm] as 'ValidMeasure([Measures].[Unit Sales])'\n"
             + "select non empty Crossjoin([Warehouse].[Warehouse Name].members, [Gender].[Gender].members) on 0,\n"
@@ -4032,9 +4037,87 @@ public class NonEmptyTest extends BatchTestCase {
             "Axis #0:\n"
             + "{}\n"
             + "Axis #1:\n"
+            + "{[Warehouse].[USA].[CA].[Beverly Hills].[Big  Quality Warehouse], [Gender].[F]}\n"
+            + "{[Warehouse].[USA].[CA].[Beverly Hills].[Big  Quality Warehouse], [Gender].[M]}\n"
+            + "{[Warehouse].[USA].[CA].[Los Angeles].[Artesia Warehousing, Inc.], [Gender].[F]}\n"
+            + "{[Warehouse].[USA].[CA].[Los Angeles].[Artesia Warehousing, Inc.], [Gender].[M]}\n"
+            + "{[Warehouse].[USA].[CA].[San Diego].[Jorgensen Service Storage], [Gender].[F]}\n"
+            + "{[Warehouse].[USA].[CA].[San Diego].[Jorgensen Service Storage], [Gender].[M]}\n"
+            + "{[Warehouse].[USA].[CA].[San Francisco].[Food Service Storage, Inc.], [Gender].[F]}\n"
+            + "{[Warehouse].[USA].[CA].[San Francisco].[Food Service Storage, Inc.], [Gender].[M]}\n"
+            + "{[Warehouse].[USA].[OR].[Portland].[Quality Distribution, Inc.], [Gender].[F]}\n"
+            + "{[Warehouse].[USA].[OR].[Portland].[Quality Distribution, Inc.], [Gender].[M]}\n"
+            + "{[Warehouse].[USA].[OR].[Salem].[Treehouse Distribution], [Gender].[F]}\n"
+            + "{[Warehouse].[USA].[OR].[Salem].[Treehouse Distribution], [Gender].[M]}\n"
+            + "{[Warehouse].[USA].[WA].[Bellingham].[Foster Products], [Gender].[F]}\n"
+            + "{[Warehouse].[USA].[WA].[Bellingham].[Foster Products], [Gender].[M]}\n"
+            + "{[Warehouse].[USA].[WA].[Bremerton].[Destination, Inc.], [Gender].[F]}\n"
+            + "{[Warehouse].[USA].[WA].[Bremerton].[Destination, Inc.], [Gender].[M]}\n"
+            + "{[Warehouse].[USA].[WA].[Seattle].[Quality Warehousing and Trucking], [Gender].[F]}\n"
+            + "{[Warehouse].[USA].[WA].[Seattle].[Quality Warehousing and Trucking], [Gender].[M]}\n"
+            + "{[Warehouse].[USA].[WA].[Spokane].[Jones International], [Gender].[F]}\n"
+            + "{[Warehouse].[USA].[WA].[Spokane].[Jones International], [Gender].[M]}\n"
+            + "{[Warehouse].[USA].[WA].[Tacoma].[Jorge Garcia, Inc.], [Gender].[F]}\n"
+            + "{[Warehouse].[USA].[WA].[Tacoma].[Jorge Garcia, Inc.], [Gender].[M]}\n"
+            + "{[Warehouse].[USA].[WA].[Walla Walla].[Valdez Warehousing], [Gender].[F]}\n"
+            + "{[Warehouse].[USA].[WA].[Walla Walla].[Valdez Warehousing], [Gender].[M]}\n"
+            + "{[Warehouse].[USA].[WA].[Yakima].[Maddock Stored Foods], [Gender].[F]}\n"
+            + "{[Warehouse].[USA].[WA].[Yakima].[Maddock Stored Foods], [Gender].[M]}\n"
             + "Axis #2:\n"
             + "{[Measures].[Units Shipped]}\n"
-            + "{[Measures].[vm]}\n");
+            + "{[Measures].[vm]}\n"
+            + "Row #0: \n"
+            + "Row #0: \n"
+            + "Row #0: \n"
+            + "Row #0: \n"
+            + "Row #0: \n"
+            + "Row #0: \n"
+            + "Row #0: \n"
+            + "Row #0: \n"
+            + "Row #0: \n"
+            + "Row #0: \n"
+            + "Row #0: \n"
+            + "Row #0: \n"
+            + "Row #0: \n"
+            + "Row #0: \n"
+            + "Row #0: \n"
+            + "Row #0: \n"
+            + "Row #0: \n"
+            + "Row #0: \n"
+            + "Row #0: \n"
+            + "Row #0: \n"
+            + "Row #0: \n"
+            + "Row #0: \n"
+            + "Row #0: \n"
+            + "Row #0: \n"
+            + "Row #0: \n"
+            + "Row #0: \n"
+            + "Row #1: 131,558\n"
+            + "Row #1: 135,215\n"
+            + "Row #1: 131,558\n"
+            + "Row #1: 135,215\n"
+            + "Row #1: 131,558\n"
+            + "Row #1: 135,215\n"
+            + "Row #1: 131,558\n"
+            + "Row #1: 135,215\n"
+            + "Row #1: 131,558\n"
+            + "Row #1: 135,215\n"
+            + "Row #1: 131,558\n"
+            + "Row #1: 135,215\n"
+            + "Row #1: 131,558\n"
+            + "Row #1: 135,215\n"
+            + "Row #1: 131,558\n"
+            + "Row #1: 135,215\n"
+            + "Row #1: 131,558\n"
+            + "Row #1: 135,215\n"
+            + "Row #1: 131,558\n"
+            + "Row #1: 135,215\n"
+            + "Row #1: 131,558\n"
+            + "Row #1: 135,215\n"
+            + "Row #1: 131,558\n"
+            + "Row #1: 135,215\n"
+            + "Row #1: 131,558\n"
+            + "Row #1: 135,215\n");
     }
 
     public void testCrossjoinWithOneDimensionThatDoesNotJoinToBothBaseCubes() {

--- a/testsrc/main/mondrian/test/Main.java
+++ b/testsrc/main/mondrian/test/Main.java
@@ -387,6 +387,7 @@ public class Main extends TestSuite {
             addTest(suite, ExplicitRecognizerTest.class);
             addTest(suite, AggregationOverAggTableTest.class);
             addTest(suite, XmlUtilTest.class);
+            addTest(suite, NativeEvalVirtualCubeTest.class);
             addTest(suite, NamespaceContextImplTest.class);
             addTest(suite, CancellationTest.class);
 


### PR DESCRIPTION
Adding support for native evaluation of sets in the context of a
virtual cube in which no cubes "fully join".  That is, if there is no
cube or cubes which are applicable to all dimensions in the native
targets.  For example, with a crossjoin of Warehouse and Gender, no
single cube joins to both.  Formerly native eval logic depended on the
presence of one or more fully joining cubes in order to find tuples,
with the assumption that the absence of a fully joining cube implies
that the resulting set will be empty.  That assumption is incorrect
when ValidMeasure is use (or other MDX expressions which changes
dimensional context).

This commit takes the approach of "grouping" native targets based on
their applicable cubes.  So with the above example, Gender and
Warehouse are grouped and evaluated separately, then crossjoined after
the fact.  This is more expensive than the former logic, which
executed a single UNION'd SQL query with virtual cubes, so to avoid
unnecessary execution this first checks whether one or more
measures could shift context.  Otherwise, if there is no fully joining
cube, then it's safe to return an empty set.

http://jira.pentaho.com/browse/MONDRIAN-1599
http://jira.pentaho.com/browse/MONDRIAN-2280