### PR TITLE
[TEST] Fixes SegmentHeader portability issues across JVMs. The column…

### DIFF
--- a/testsrc/main/mondrian/rolap/CacheControlTest.ref.xml
+++ b/testsrc/main/mondrian/rolap/CacheControlTest.ref.xml
@@ -9,11 +9,11 @@ Checksum:[7b4af973b0d21f364b0a746f5565cb03]
 Cube:[Sales]
 Measure:[Unit Sales]
 Axes:[
-    {time_by_day.the_year=('1997')}
-    {customer.gender=('M')}]
+    {customer.gender=('M')}
+    {time_by_day.the_year=('1997')}]
 Excluded Regions:[]
 Compound Predicates:[]
-ID:[f357b0fe61c757fc0eb38052bcbb30f705ed5ab187e90183ef250e61d2dda8e6]
+ID:[956eb6693e4890a305b086aab9fa5f3b33f541e8eb1321e2e4c5f01cff475fa4]
 
 
 Cache state after flush:
@@ -23,11 +23,11 @@ Checksum:[7b4af973b0d21f364b0a746f5565cb03]
 Cube:[Sales]
 Measure:[Unit Sales]
 Axes:[
-    {time_by_day.the_year=('1997')}
-    {customer.gender=('M')}]
+    {customer.gender=('M')}
+    {time_by_day.the_year=('1997')}]
 Excluded Regions:[]
 Compound Predicates:[]
-ID:[f357b0fe61c757fc0eb38052bcbb30f705ed5ab187e90183ef250e61d2dda8e6]
+ID:[956eb6693e4890a305b086aab9fa5f3b33f541e8eb1321e2e4c5f01cff475fa4]
 
 
 ]]>
@@ -40,11 +40,11 @@ Checksum:[7b4af973b0d21f364b0a746f5565cb03]
 Cube:[Sales]
 Measure:[Unit Sales]
 Axes:[
-    {time_by_day.the_year=('1997')}
-    {customer.gender=('M')}]
+    {customer.gender=('M')}
+    {time_by_day.the_year=('1997')}]
 Excluded Regions:[]
 Compound Predicates:[]
-ID:[f357b0fe61c757fc0eb38052bcbb30f705ed5ab187e90183ef250e61d2dda8e6]
+ID:[956eb6693e4890a305b086aab9fa5f3b33f541e8eb1321e2e4c5f01cff475fa4]
 
 
 discard segment - it cannot be constrained and maintain consistency:
@@ -54,11 +54,11 @@ Checksum:[7b4af973b0d21f364b0a746f5565cb03]
 Cube:[Sales]
 Measure:[Unit Sales]
 Axes:[
-    {time_by_day.the_year=('1997')}
-    {customer.gender=('M')}]
+    {customer.gender=('M')}
+    {time_by_day.the_year=('1997')}]
 Excluded Regions:[]
 Compound Predicates:[]
-ID:[f357b0fe61c757fc0eb38052bcbb30f705ed5ab187e90183ef250e61d2dda8e6]
+ID:[956eb6693e4890a305b086aab9fa5f3b33f541e8eb1321e2e4c5f01cff475fa4]
 
 Cache state after flush:
 
@@ -140,12 +140,12 @@ Checksum:[7b4af973b0d21f364b0a746f5565cb03]
 Cube:[Sales]
 Measure:[Unit Sales]
 Axes:[
-    {time_by_day.the_year=(*)}
+    {product_class.product_family=(*)}
     {time_by_day.quarter=(*)}
-    {product_class.product_family=(*)}]
+    {time_by_day.the_year=(*)}]
 Excluded Regions:[]
 Compound Predicates:[]
-ID:[3f56e62eefe37a256c465b15833d8e8ceaefe459a47bc4993f5c29a35841e691]
+ID:[81b691ea51d52148d99bccac888d5eebc210cfd1a3424b4f59b2ad59323da286]
 
 *Segment Header
 Schema:[FoodMart]
@@ -153,25 +153,25 @@ Checksum:[7b4af973b0d21f364b0a746f5565cb03]
 Cube:[Sales]
 Measure:[Unit Sales]
 Axes:[
-    {time_by_day.the_year=(*)}
-    {product_class.product_family=(*)}]
-Excluded Regions:[]
-Compound Predicates:[]
-ID:[4e39edcfd80d58026f86a65910eeb6f52b42c1b1e5ebb42aad7330c42533cb91]
-
-*Segment Header
-Schema:[FoodMart]
-Checksum:[7b4af973b0d21f364b0a746f5565cb03]
-Cube:[Sales]
-Measure:[Unit Sales]
-Axes:[
-    {time_by_day.the_year=(*)}
-    {time_by_day.quarter=(*)}
+    {product_class.product_family=(*)}
     {time_by_day.month_of_year=(*)}
-    {product_class.product_family=(*)}]
+    {time_by_day.quarter=(*)}
+    {time_by_day.the_year=(*)}]
 Excluded Regions:[]
 Compound Predicates:[]
-ID:[553c83653cceb316152659fc76d70c1dd136d43bd4d6bde9d70182a9bb156a0e]
+ID:[ef558bc1e9afbf7d47363c3bcd8d29603c39d9a81e983c114d840438cc0fdf8d]
+
+*Segment Header
+Schema:[FoodMart]
+Checksum:[7b4af973b0d21f364b0a746f5565cb03]
+Cube:[Sales]
+Measure:[Unit Sales]
+Axes:[
+    {product_class.product_family=(*)}
+    {time_by_day.the_year=(*)}]
+Excluded Regions:[]
+Compound Predicates:[]
+ID:[7b0d06cc76ba0f99c3e25b0ebbc7628821a71d016797838f8890c8b6295f403c]
 
 
 Cache state after flush:
@@ -181,43 +181,43 @@ Checksum:[7b4af973b0d21f364b0a746f5565cb03]
 Cube:[Sales]
 Measure:[Unit Sales]
 Axes:[
-    {time_by_day.the_year=(*)}
-    {product_class.product_family=(*)}]
-Excluded Regions:[
-    {time_by_day.the_year=('1997')}]
-Compound Predicates:[]
-ID:[ce10f2a556362bcb0e55c45ac7e4a9639a8e86c316edfc7dfa89a5ffca606d91]
-
-*Segment Header
-Schema:[FoodMart]
-Checksum:[7b4af973b0d21f364b0a746f5565cb03]
-Cube:[Sales]
-Measure:[Unit Sales]
-Axes:[
-    {time_by_day.the_year=(*)}
-    {time_by_day.quarter=(*)}
-    {product_class.product_family=(*)}]
-Excluded Regions:[
-    {time_by_day.quarter=('Q1')}
-    {time_by_day.the_year=('1997')}]
-Compound Predicates:[]
-ID:[6adbb9ef03f10010c9a80c0ea73149b5ae6bc08efe7d4a9a69a603a6bab86745]
-
-*Segment Header
-Schema:[FoodMart]
-Checksum:[7b4af973b0d21f364b0a746f5565cb03]
-Cube:[Sales]
-Measure:[Unit Sales]
-Axes:[
-    {time_by_day.the_year=(*)}
-    {time_by_day.quarter=(*)}
+    {product_class.product_family=(*)}
     {time_by_day.month_of_year=(*)}
-    {product_class.product_family=(*)}]
+    {time_by_day.quarter=(*)}
+    {time_by_day.the_year=(*)}]
 Excluded Regions:[
     {time_by_day.quarter=('Q1')}
     {time_by_day.the_year=('1997')}]
 Compound Predicates:[]
-ID:[6e89fb579e87b09bc5d74b9e56a3290122c6d8ff0bb37fbe2f31cafb7aef76fb]
+ID:[002fab10bc71f5350a7079b510ab6a9880a5f11b7802f7e7051fae302b494068]
+
+*Segment Header
+Schema:[FoodMart]
+Checksum:[7b4af973b0d21f364b0a746f5565cb03]
+Cube:[Sales]
+Measure:[Unit Sales]
+Axes:[
+    {product_class.product_family=(*)}
+    {time_by_day.quarter=(*)}
+    {time_by_day.the_year=(*)}]
+Excluded Regions:[
+    {time_by_day.quarter=('Q1')}
+    {time_by_day.the_year=('1997')}]
+Compound Predicates:[]
+ID:[244028151f86c43b72c05871247738d7d06f68586b11ea87bc461b0274d698e4]
+
+*Segment Header
+Schema:[FoodMart]
+Checksum:[7b4af973b0d21f364b0a746f5565cb03]
+Cube:[Sales]
+Measure:[Unit Sales]
+Axes:[
+    {product_class.product_family=(*)}
+    {time_by_day.the_year=(*)}]
+Excluded Regions:[
+    {time_by_day.the_year=('1997')}]
+Compound Predicates:[]
+ID:[4eb7b262fac67f22febb8769a7f463ee50ea9e7c06d36389d2d3f99d8023b301]
 
 
 ]]>
@@ -230,43 +230,43 @@ Checksum:[7b4af973b0d21f364b0a746f5565cb03]
 Cube:[Sales]
 Measure:[Unit Sales]
 Axes:[
-    {time_by_day.the_year=(*)}
-    {product_class.product_family=(*)}]
-Excluded Regions:[
-    {time_by_day.the_year=('1997')}]
-Compound Predicates:[]
-ID:[ce10f2a556362bcb0e55c45ac7e4a9639a8e86c316edfc7dfa89a5ffca606d91]
-
-*Segment Header
-Schema:[FoodMart]
-Checksum:[7b4af973b0d21f364b0a746f5565cb03]
-Cube:[Sales]
-Measure:[Unit Sales]
-Axes:[
-    {time_by_day.the_year=(*)}
-    {time_by_day.quarter=(*)}
-    {product_class.product_family=(*)}]
-Excluded Regions:[
-    {time_by_day.quarter=('Q1')}
-    {time_by_day.the_year=('1997')}]
-Compound Predicates:[]
-ID:[6adbb9ef03f10010c9a80c0ea73149b5ae6bc08efe7d4a9a69a603a6bab86745]
-
-*Segment Header
-Schema:[FoodMart]
-Checksum:[7b4af973b0d21f364b0a746f5565cb03]
-Cube:[Sales]
-Measure:[Unit Sales]
-Axes:[
-    {time_by_day.the_year=(*)}
-    {time_by_day.quarter=(*)}
+    {product_class.product_family=(*)}
     {time_by_day.month_of_year=(*)}
-    {product_class.product_family=(*)}]
+    {time_by_day.quarter=(*)}
+    {time_by_day.the_year=(*)}]
 Excluded Regions:[
     {time_by_day.quarter=('Q1')}
     {time_by_day.the_year=('1997')}]
 Compound Predicates:[]
-ID:[6e89fb579e87b09bc5d74b9e56a3290122c6d8ff0bb37fbe2f31cafb7aef76fb]
+ID:[002fab10bc71f5350a7079b510ab6a9880a5f11b7802f7e7051fae302b494068]
+
+*Segment Header
+Schema:[FoodMart]
+Checksum:[7b4af973b0d21f364b0a746f5565cb03]
+Cube:[Sales]
+Measure:[Unit Sales]
+Axes:[
+    {product_class.product_family=(*)}
+    {time_by_day.quarter=(*)}
+    {time_by_day.the_year=(*)}]
+Excluded Regions:[
+    {time_by_day.quarter=('Q1')}
+    {time_by_day.the_year=('1997')}]
+Compound Predicates:[]
+ID:[244028151f86c43b72c05871247738d7d06f68586b11ea87bc461b0274d698e4]
+
+*Segment Header
+Schema:[FoodMart]
+Checksum:[7b4af973b0d21f364b0a746f5565cb03]
+Cube:[Sales]
+Measure:[Unit Sales]
+Axes:[
+    {product_class.product_family=(*)}
+    {time_by_day.the_year=(*)}]
+Excluded Regions:[
+    {time_by_day.the_year=('1997')}]
+Compound Predicates:[]
+ID:[4eb7b262fac67f22febb8769a7f463ee50ea9e7c06d36389d2d3f99d8023b301]
 
 
 Cache state after flush:
@@ -276,15 +276,15 @@ Checksum:[7b4af973b0d21f364b0a746f5565cb03]
 Cube:[Sales]
 Measure:[Unit Sales]
 Axes:[
-    {time_by_day.the_year=(*)}
-    {time_by_day.quarter=(*)}
+    {product_class.product_family=(*)}
     {time_by_day.month_of_year=(*)}
-    {product_class.product_family=(*)}]
+    {time_by_day.quarter=(*)}
+    {time_by_day.the_year=(*)}]
 Excluded Regions:[
-    {time_by_day.the_year=('1997')}
-    {time_by_day.quarter=('Q1')}]
+    {time_by_day.quarter=('Q1')}
+    {time_by_day.the_year=('1997')}]
 Compound Predicates:[]
-ID:[a9dc097cb9ab0675a75af4bba24b00a8864bd2e48be7995a25ee1df9583228ad]
+ID:[002fab10bc71f5350a7079b510ab6a9880a5f11b7802f7e7051fae302b494068]
 
 *Segment Header
 Schema:[FoodMart]
@@ -292,27 +292,27 @@ Checksum:[7b4af973b0d21f364b0a746f5565cb03]
 Cube:[Sales]
 Measure:[Unit Sales]
 Axes:[
-    {time_by_day.the_year=(*)}
-    {product_class.product_family=(*)}]
+    {product_class.product_family=(*)}
+    {time_by_day.quarter=(*)}
+    {time_by_day.the_year=(*)}]
+Excluded Regions:[
+    {time_by_day.quarter=('Q1')}
+    {time_by_day.the_year=('1997')}]
+Compound Predicates:[]
+ID:[244028151f86c43b72c05871247738d7d06f68586b11ea87bc461b0274d698e4]
+
+*Segment Header
+Schema:[FoodMart]
+Checksum:[7b4af973b0d21f364b0a746f5565cb03]
+Cube:[Sales]
+Measure:[Unit Sales]
+Axes:[
+    {product_class.product_family=(*)}
+    {time_by_day.the_year=(*)}]
 Excluded Regions:[
     {time_by_day.the_year=('1997')}]
 Compound Predicates:[]
-ID:[ce10f2a556362bcb0e55c45ac7e4a9639a8e86c316edfc7dfa89a5ffca606d91]
-
-*Segment Header
-Schema:[FoodMart]
-Checksum:[7b4af973b0d21f364b0a746f5565cb03]
-Cube:[Sales]
-Measure:[Unit Sales]
-Axes:[
-    {time_by_day.the_year=(*)}
-    {time_by_day.quarter=(*)}
-    {product_class.product_family=(*)}]
-Excluded Regions:[
-    {time_by_day.the_year=('1997')}
-    {time_by_day.quarter=('Q1')}]
-Compound Predicates:[]
-ID:[05582bf973493f48952432d4a37c583e2e84e3e9c17928dbbc8b576e35f2fccd]
+ID:[4eb7b262fac67f22febb8769a7f463ee50ea9e7c06d36389d2d3f99d8023b301]
 
 
 ]]>
@@ -325,15 +325,15 @@ Checksum:[7b4af973b0d21f364b0a746f5565cb03]
 Cube:[Sales]
 Measure:[Unit Sales]
 Axes:[
-    {time_by_day.the_year=(*)}
-    {time_by_day.quarter=(*)}
+    {product_class.product_family=(*)}
     {time_by_day.month_of_year=(*)}
-    {product_class.product_family=(*)}]
+    {time_by_day.quarter=(*)}
+    {time_by_day.the_year=(*)}]
 Excluded Regions:[
-    {time_by_day.the_year=('1997')}
-    {time_by_day.quarter=('Q1')}]
+    {time_by_day.quarter=('Q1')}
+    {time_by_day.the_year=('1997')}]
 Compound Predicates:[]
-ID:[a9dc097cb9ab0675a75af4bba24b00a8864bd2e48be7995a25ee1df9583228ad]
+ID:[002fab10bc71f5350a7079b510ab6a9880a5f11b7802f7e7051fae302b494068]
 
 *Segment Header
 Schema:[FoodMart]
@@ -341,27 +341,27 @@ Checksum:[7b4af973b0d21f364b0a746f5565cb03]
 Cube:[Sales]
 Measure:[Unit Sales]
 Axes:[
-    {time_by_day.the_year=(*)}
-    {product_class.product_family=(*)}]
+    {product_class.product_family=(*)}
+    {time_by_day.quarter=(*)}
+    {time_by_day.the_year=(*)}]
+Excluded Regions:[
+    {time_by_day.quarter=('Q1')}
+    {time_by_day.the_year=('1997')}]
+Compound Predicates:[]
+ID:[244028151f86c43b72c05871247738d7d06f68586b11ea87bc461b0274d698e4]
+
+*Segment Header
+Schema:[FoodMart]
+Checksum:[7b4af973b0d21f364b0a746f5565cb03]
+Cube:[Sales]
+Measure:[Unit Sales]
+Axes:[
+    {product_class.product_family=(*)}
+    {time_by_day.the_year=(*)}]
 Excluded Regions:[
     {time_by_day.the_year=('1997')}]
 Compound Predicates:[]
-ID:[ce10f2a556362bcb0e55c45ac7e4a9639a8e86c316edfc7dfa89a5ffca606d91]
-
-*Segment Header
-Schema:[FoodMart]
-Checksum:[7b4af973b0d21f364b0a746f5565cb03]
-Cube:[Sales]
-Measure:[Unit Sales]
-Axes:[
-    {time_by_day.the_year=(*)}
-    {time_by_day.quarter=(*)}
-    {product_class.product_family=(*)}]
-Excluded Regions:[
-    {time_by_day.the_year=('1997')}
-    {time_by_day.quarter=('Q1')}]
-Compound Predicates:[]
-ID:[05582bf973493f48952432d4a37c583e2e84e3e9c17928dbbc8b576e35f2fccd]
+ID:[4eb7b262fac67f22febb8769a7f463ee50ea9e7c06d36389d2d3f99d8023b301]
 
 
 Cache state after flush:
@@ -371,43 +371,43 @@ Checksum:[7b4af973b0d21f364b0a746f5565cb03]
 Cube:[Sales]
 Measure:[Unit Sales]
 Axes:[
-    {time_by_day.the_year=(*)}
-    {product_class.product_family=(*)}]
-Excluded Regions:[
-    {time_by_day.the_year=('1997')}]
-Compound Predicates:[]
-ID:[ce10f2a556362bcb0e55c45ac7e4a9639a8e86c316edfc7dfa89a5ffca606d91]
-
-*Segment Header
-Schema:[FoodMart]
-Checksum:[7b4af973b0d21f364b0a746f5565cb03]
-Cube:[Sales]
-Measure:[Unit Sales]
-Axes:[
-    {time_by_day.the_year=(*)}
-    {time_by_day.quarter=(*)}
-    {product_class.product_family=(*)}]
-Excluded Regions:[
-    {time_by_day.quarter=('Q1')}
-    {time_by_day.the_year=('1997')}]
-Compound Predicates:[]
-ID:[6adbb9ef03f10010c9a80c0ea73149b5ae6bc08efe7d4a9a69a603a6bab86745]
-
-*Segment Header
-Schema:[FoodMart]
-Checksum:[7b4af973b0d21f364b0a746f5565cb03]
-Cube:[Sales]
-Measure:[Unit Sales]
-Axes:[
-    {time_by_day.the_year=(*)}
-    {time_by_day.quarter=(*)}
+    {product_class.product_family=(*)}
     {time_by_day.month_of_year=(*)}
-    {product_class.product_family=(*)}]
+    {time_by_day.quarter=(*)}
+    {time_by_day.the_year=(*)}]
 Excluded Regions:[
     {time_by_day.quarter=('Q1')}
     {time_by_day.the_year=('1997')}]
 Compound Predicates:[]
-ID:[6e89fb579e87b09bc5d74b9e56a3290122c6d8ff0bb37fbe2f31cafb7aef76fb]
+ID:[002fab10bc71f5350a7079b510ab6a9880a5f11b7802f7e7051fae302b494068]
+
+*Segment Header
+Schema:[FoodMart]
+Checksum:[7b4af973b0d21f364b0a746f5565cb03]
+Cube:[Sales]
+Measure:[Unit Sales]
+Axes:[
+    {product_class.product_family=(*)}
+    {time_by_day.quarter=(*)}
+    {time_by_day.the_year=(*)}]
+Excluded Regions:[
+    {time_by_day.quarter=('Q1')}
+    {time_by_day.the_year=('1997')}]
+Compound Predicates:[]
+ID:[244028151f86c43b72c05871247738d7d06f68586b11ea87bc461b0274d698e4]
+
+*Segment Header
+Schema:[FoodMart]
+Checksum:[7b4af973b0d21f364b0a746f5565cb03]
+Cube:[Sales]
+Measure:[Unit Sales]
+Axes:[
+    {product_class.product_family=(*)}
+    {time_by_day.the_year=(*)}]
+Excluded Regions:[
+    {time_by_day.the_year=('1997')}]
+Compound Predicates:[]
+ID:[4eb7b262fac67f22febb8769a7f463ee50ea9e7c06d36389d2d3f99d8023b301]
 
 
 ]]>
@@ -420,74 +420,44 @@ Checksum:[7b4af973b0d21f364b0a746f5565cb03]
 Cube:[Sales]
 Measure:[Unit Sales]
 Axes:[
-    {time_by_day.the_year=(*)}
-    {product_class.product_family=(*)}]
-Excluded Regions:[
-    {time_by_day.the_year=('1997')}]
-Compound Predicates:[]
-ID:[ce10f2a556362bcb0e55c45ac7e4a9639a8e86c316edfc7dfa89a5ffca606d91]
-
-*Segment Header
-Schema:[FoodMart]
-Checksum:[7b4af973b0d21f364b0a746f5565cb03]
-Cube:[Sales]
-Measure:[Unit Sales]
-Axes:[
-    {time_by_day.the_year=(*)}
-    {time_by_day.quarter=(*)}
-    {product_class.product_family=(*)}]
-Excluded Regions:[
-    {time_by_day.quarter=('Q1')}
-    {time_by_day.the_year=('1997')}]
-Compound Predicates:[]
-ID:[6adbb9ef03f10010c9a80c0ea73149b5ae6bc08efe7d4a9a69a603a6bab86745]
-
-*Segment Header
-Schema:[FoodMart]
-Checksum:[7b4af973b0d21f364b0a746f5565cb03]
-Cube:[Sales]
-Measure:[Unit Sales]
-Axes:[
-    {time_by_day.the_year=(*)}
-    {time_by_day.quarter=(*)}
+    {product_class.product_family=(*)}
     {time_by_day.month_of_year=(*)}
-    {product_class.product_family=(*)}]
+    {time_by_day.quarter=(*)}
+    {time_by_day.the_year=(*)}]
 Excluded Regions:[
     {time_by_day.quarter=('Q1')}
     {time_by_day.the_year=('1997')}]
 Compound Predicates:[]
-ID:[6e89fb579e87b09bc5d74b9e56a3290122c6d8ff0bb37fbe2f31cafb7aef76fb]
+ID:[002fab10bc71f5350a7079b510ab6a9880a5f11b7802f7e7051fae302b494068]
 
-
-discard segment - it cannot be constrained and maintain consistency:
 *Segment Header
 Schema:[FoodMart]
 Checksum:[7b4af973b0d21f364b0a746f5565cb03]
 Cube:[Sales]
 Measure:[Unit Sales]
 Axes:[
-    {time_by_day.the_year=(*)}
-    {product_class.product_family=(*)}]
-Excluded Regions:[
-    {time_by_day.the_year=('1997')}]
-Compound Predicates:[]
-ID:[ce10f2a556362bcb0e55c45ac7e4a9639a8e86c316edfc7dfa89a5ffca606d91]
-
-discard segment - it cannot be constrained and maintain consistency:
-*Segment Header
-Schema:[FoodMart]
-Checksum:[7b4af973b0d21f364b0a746f5565cb03]
-Cube:[Sales]
-Measure:[Unit Sales]
-Axes:[
-    {time_by_day.the_year=(*)}
+    {product_class.product_family=(*)}
     {time_by_day.quarter=(*)}
-    {product_class.product_family=(*)}]
+    {time_by_day.the_year=(*)}]
 Excluded Regions:[
     {time_by_day.quarter=('Q1')}
     {time_by_day.the_year=('1997')}]
 Compound Predicates:[]
-ID:[6adbb9ef03f10010c9a80c0ea73149b5ae6bc08efe7d4a9a69a603a6bab86745]
+ID:[244028151f86c43b72c05871247738d7d06f68586b11ea87bc461b0274d698e4]
+
+*Segment Header
+Schema:[FoodMart]
+Checksum:[7b4af973b0d21f364b0a746f5565cb03]
+Cube:[Sales]
+Measure:[Unit Sales]
+Axes:[
+    {product_class.product_family=(*)}
+    {time_by_day.the_year=(*)}]
+Excluded Regions:[
+    {time_by_day.the_year=('1997')}]
+Compound Predicates:[]
+ID:[4eb7b262fac67f22febb8769a7f463ee50ea9e7c06d36389d2d3f99d8023b301]
+
 
 discard segment - it cannot be constrained and maintain consistency:
 *Segment Header
@@ -496,15 +466,45 @@ Checksum:[7b4af973b0d21f364b0a746f5565cb03]
 Cube:[Sales]
 Measure:[Unit Sales]
 Axes:[
-    {time_by_day.the_year=(*)}
-    {time_by_day.quarter=(*)}
+    {product_class.product_family=(*)}
     {time_by_day.month_of_year=(*)}
-    {product_class.product_family=(*)}]
+    {time_by_day.quarter=(*)}
+    {time_by_day.the_year=(*)}]
 Excluded Regions:[
     {time_by_day.quarter=('Q1')}
     {time_by_day.the_year=('1997')}]
 Compound Predicates:[]
-ID:[6e89fb579e87b09bc5d74b9e56a3290122c6d8ff0bb37fbe2f31cafb7aef76fb]
+ID:[002fab10bc71f5350a7079b510ab6a9880a5f11b7802f7e7051fae302b494068]
+
+discard segment - it cannot be constrained and maintain consistency:
+*Segment Header
+Schema:[FoodMart]
+Checksum:[7b4af973b0d21f364b0a746f5565cb03]
+Cube:[Sales]
+Measure:[Unit Sales]
+Axes:[
+    {product_class.product_family=(*)}
+    {time_by_day.quarter=(*)}
+    {time_by_day.the_year=(*)}]
+Excluded Regions:[
+    {time_by_day.quarter=('Q1')}
+    {time_by_day.the_year=('1997')}]
+Compound Predicates:[]
+ID:[244028151f86c43b72c05871247738d7d06f68586b11ea87bc461b0274d698e4]
+
+discard segment - it cannot be constrained and maintain consistency:
+*Segment Header
+Schema:[FoodMart]
+Checksum:[7b4af973b0d21f364b0a746f5565cb03]
+Cube:[Sales]
+Measure:[Unit Sales]
+Axes:[
+    {product_class.product_family=(*)}
+    {time_by_day.the_year=(*)}]
+Excluded Regions:[
+    {time_by_day.the_year=('1997')}]
+Compound Predicates:[]
+ID:[4eb7b262fac67f22febb8769a7f463ee50ea9e7c06d36389d2d3f99d8023b301]
 
 Cache state after flush:
 
@@ -522,12 +522,12 @@ Checksum:[7b4af973b0d21f364b0a746f5565cb03]
 Cube:[Sales]
 Measure:[Unit Sales]
 Axes:[
-    {time_by_day.the_year=(*)}
+    {product_class.product_family=(*)}
     {time_by_day.quarter=(*)}
-    {product_class.product_family=(*)}]
+    {time_by_day.the_year=(*)}]
 Excluded Regions:[]
 Compound Predicates:[]
-ID:[3f56e62eefe37a256c465b15833d8e8ceaefe459a47bc4993f5c29a35841e691]
+ID:[81b691ea51d52148d99bccac888d5eebc210cfd1a3424b4f59b2ad59323da286]
 
 *Segment Header
 Schema:[FoodMart]
@@ -535,25 +535,25 @@ Checksum:[7b4af973b0d21f364b0a746f5565cb03]
 Cube:[Sales]
 Measure:[Unit Sales]
 Axes:[
-    {time_by_day.the_year=(*)}
-    {product_class.product_family=(*)}]
-Excluded Regions:[]
-Compound Predicates:[]
-ID:[4e39edcfd80d58026f86a65910eeb6f52b42c1b1e5ebb42aad7330c42533cb91]
-
-*Segment Header
-Schema:[FoodMart]
-Checksum:[7b4af973b0d21f364b0a746f5565cb03]
-Cube:[Sales]
-Measure:[Unit Sales]
-Axes:[
-    {time_by_day.the_year=(*)}
-    {time_by_day.quarter=(*)}
+    {product_class.product_family=(*)}
     {time_by_day.month_of_year=(*)}
-    {product_class.product_family=(*)}]
+    {time_by_day.quarter=(*)}
+    {time_by_day.the_year=(*)}]
 Excluded Regions:[]
 Compound Predicates:[]
-ID:[553c83653cceb316152659fc76d70c1dd136d43bd4d6bde9d70182a9bb156a0e]
+ID:[ef558bc1e9afbf7d47363c3bcd8d29603c39d9a81e983c114d840438cc0fdf8d]
+
+*Segment Header
+Schema:[FoodMart]
+Checksum:[7b4af973b0d21f364b0a746f5565cb03]
+Cube:[Sales]
+Measure:[Unit Sales]
+Axes:[
+    {product_class.product_family=(*)}
+    {time_by_day.the_year=(*)}]
+Excluded Regions:[]
+Compound Predicates:[]
+ID:[7b0d06cc76ba0f99c3e25b0ebbc7628821a71d016797838f8890c8b6295f403c]
 
 
 Cache state after flush:
@@ -563,46 +563,46 @@ Checksum:[7b4af973b0d21f364b0a746f5565cb03]
 Cube:[Sales]
 Measure:[Unit Sales]
 Axes:[
-    {time_by_day.the_year=(*)}
-    {time_by_day.quarter=(*)}
-    {time_by_day.month_of_year=(*)}
-    {product_class.product_family=(*)}]
-Excluded Regions:[
-    {product_class.product_family=('Drink')}
-    {time_by_day.the_year=('1997')}
-    {time_by_day.quarter=('Q1')}]
-Compound Predicates:[]
-ID:[911252fd235d00f61ef86e00e0ff75ac00d15f89c712849c82afa4a2c15ef3c5]
-
-*Segment Header
-Schema:[FoodMart]
-Checksum:[7b4af973b0d21f364b0a746f5565cb03]
-Cube:[Sales]
-Measure:[Unit Sales]
-Axes:[
-    {time_by_day.the_year=(*)}
-    {time_by_day.quarter=(*)}
-    {product_class.product_family=(*)}]
-Excluded Regions:[
-    {product_class.product_family=('Drink')}
-    {time_by_day.the_year=('1997')}
-    {time_by_day.quarter=('Q1')}]
-Compound Predicates:[]
-ID:[920401958a06f450aca08b3b3b29e16f9a0b5c7c67d466df5af609e6db3d669e]
-
-*Segment Header
-Schema:[FoodMart]
-Checksum:[7b4af973b0d21f364b0a746f5565cb03]
-Cube:[Sales]
-Measure:[Unit Sales]
-Axes:[
-    {time_by_day.the_year=(*)}
-    {product_class.product_family=(*)}]
+    {product_class.product_family=(*)}
+    {time_by_day.the_year=(*)}]
 Excluded Regions:[
     {product_class.product_family=('Drink')}
     {time_by_day.the_year=('1997')}]
 Compound Predicates:[]
-ID:[16a470a7930f93300aa03b44712682f4a180b5cb100a32d415341b5d228e40e6]
+ID:[adde715410ed9f3482291e1ca32a1f084db1970c54716772e50f18716ec3b0b6]
+
+*Segment Header
+Schema:[FoodMart]
+Checksum:[7b4af973b0d21f364b0a746f5565cb03]
+Cube:[Sales]
+Measure:[Unit Sales]
+Axes:[
+    {product_class.product_family=(*)}
+    {time_by_day.quarter=(*)}
+    {time_by_day.the_year=(*)}]
+Excluded Regions:[
+    {product_class.product_family=('Drink')}
+    {time_by_day.quarter=('Q1')}
+    {time_by_day.the_year=('1997')}]
+Compound Predicates:[]
+ID:[b5146db3e25024409645144b184d39e2ebed5523f3d524df73d68553acbea3d9]
+
+*Segment Header
+Schema:[FoodMart]
+Checksum:[7b4af973b0d21f364b0a746f5565cb03]
+Cube:[Sales]
+Measure:[Unit Sales]
+Axes:[
+    {product_class.product_family=(*)}
+    {time_by_day.month_of_year=(*)}
+    {time_by_day.quarter=(*)}
+    {time_by_day.the_year=(*)}]
+Excluded Regions:[
+    {product_class.product_family=('Drink')}
+    {time_by_day.quarter=('Q1')}
+    {time_by_day.the_year=('1997')}]
+Compound Predicates:[]
+ID:[599c9e8f9e75797ca787539c79000e1e5999cf5d24242ad4a03a2bacac08904e]
 
 
 ]]>
@@ -614,73 +614,13 @@ Checksum:[7b4af973b0d21f364b0a746f5565cb03]
 Cube:[Sales]
 Measure:[Unit Sales]
 Axes:[
-    {time_by_day.the_year=(*)}
-    {time_by_day.quarter=(*)}
-    {time_by_day.month_of_year=(*)}
-    {product_class.product_family=(*)}]
-Excluded Regions:[
-    {product_class.product_family=('Drink')}
-    {time_by_day.the_year=('1997')}
-    {time_by_day.quarter=('Q1')}]
-Compound Predicates:[]
-ID:[911252fd235d00f61ef86e00e0ff75ac00d15f89c712849c82afa4a2c15ef3c5]
-
-*Segment Header
-Schema:[FoodMart]
-Checksum:[7b4af973b0d21f364b0a746f5565cb03]
-Cube:[Sales]
-Measure:[Unit Sales]
-Axes:[
-    {time_by_day.the_year=(*)}
-    {time_by_day.quarter=(*)}
-    {time_by_day.month_of_year=(*)}
-    {product_class.product_family=(*)}]
-Excluded Regions:[]
-Compound Predicates:[]
-ID:[553c83653cceb316152659fc76d70c1dd136d43bd4d6bde9d70182a9bb156a0e]
-
-*Segment Header
-Schema:[FoodMart]
-Checksum:[7b4af973b0d21f364b0a746f5565cb03]
-Cube:[Sales]
-Measure:[Unit Sales]
-Axes:[
-    {time_by_day.the_year=(*)}
-    {time_by_day.quarter=(*)}
-    {product_class.product_family=(*)}]
-Excluded Regions:[
-    {product_class.product_family=('Drink')}
-    {time_by_day.the_year=('1997')}
-    {time_by_day.quarter=('Q1')}]
-Compound Predicates:[]
-ID:[920401958a06f450aca08b3b3b29e16f9a0b5c7c67d466df5af609e6db3d669e]
-
-*Segment Header
-Schema:[FoodMart]
-Checksum:[7b4af973b0d21f364b0a746f5565cb03]
-Cube:[Sales]
-Measure:[Unit Sales]
-Axes:[
-    {time_by_day.the_year=(*)}
-    {time_by_day.quarter=(*)}
-    {product_class.product_family=(*)}]
-Excluded Regions:[]
-Compound Predicates:[]
-ID:[3f56e62eefe37a256c465b15833d8e8ceaefe459a47bc4993f5c29a35841e691]
-
-*Segment Header
-Schema:[FoodMart]
-Checksum:[7b4af973b0d21f364b0a746f5565cb03]
-Cube:[Sales]
-Measure:[Unit Sales]
-Axes:[
-    {time_by_day.the_year=(*)}
-    {product_class.product_family=(*)}]
+    {product_class.product_family=(*)}
+    {time_by_day.the_year=(*)}]
 Excluded Regions:[
     {product_class.product_family=('Drink')}
     {time_by_day.the_year=('1997')}]
 Compound Predicates:[]
-ID:[16a470a7930f93300aa03b44712682f4a180b5cb100a32d415341b5d228e40e6]
+ID:[adde715410ed9f3482291e1ca32a1f084db1970c54716772e50f18716ec3b0b6]
 
 *Segment Header
 Schema:[FoodMart]
@@ -688,11 +628,71 @@ Checksum:[7b4af973b0d21f364b0a746f5565cb03]
 Cube:[Sales]
 Measure:[Unit Sales]
 Axes:[
-    {time_by_day.the_year=(*)}
-    {product_class.product_family=(*)}]
+    {product_class.product_family=(*)}
+    {time_by_day.the_year=(*)}]
 Excluded Regions:[]
 Compound Predicates:[]
-ID:[4e39edcfd80d58026f86a65910eeb6f52b42c1b1e5ebb42aad7330c42533cb91]
+ID:[7b0d06cc76ba0f99c3e25b0ebbc7628821a71d016797838f8890c8b6295f403c]
+
+*Segment Header
+Schema:[FoodMart]
+Checksum:[7b4af973b0d21f364b0a746f5565cb03]
+Cube:[Sales]
+Measure:[Unit Sales]
+Axes:[
+    {product_class.product_family=(*)}
+    {time_by_day.quarter=(*)}
+    {time_by_day.the_year=(*)}]
+Excluded Regions:[]
+Compound Predicates:[]
+ID:[81b691ea51d52148d99bccac888d5eebc210cfd1a3424b4f59b2ad59323da286]
+
+*Segment Header
+Schema:[FoodMart]
+Checksum:[7b4af973b0d21f364b0a746f5565cb03]
+Cube:[Sales]
+Measure:[Unit Sales]
+Axes:[
+    {product_class.product_family=(*)}
+    {time_by_day.quarter=(*)}
+    {time_by_day.the_year=(*)}]
+Excluded Regions:[
+    {product_class.product_family=('Drink')}
+    {time_by_day.quarter=('Q1')}
+    {time_by_day.the_year=('1997')}]
+Compound Predicates:[]
+ID:[b5146db3e25024409645144b184d39e2ebed5523f3d524df73d68553acbea3d9]
+
+*Segment Header
+Schema:[FoodMart]
+Checksum:[7b4af973b0d21f364b0a746f5565cb03]
+Cube:[Sales]
+Measure:[Unit Sales]
+Axes:[
+    {product_class.product_family=(*)}
+    {time_by_day.month_of_year=(*)}
+    {time_by_day.quarter=(*)}
+    {time_by_day.the_year=(*)}]
+Excluded Regions:[]
+Compound Predicates:[]
+ID:[ef558bc1e9afbf7d47363c3bcd8d29603c39d9a81e983c114d840438cc0fdf8d]
+
+*Segment Header
+Schema:[FoodMart]
+Checksum:[7b4af973b0d21f364b0a746f5565cb03]
+Cube:[Sales]
+Measure:[Unit Sales]
+Axes:[
+    {product_class.product_family=(*)}
+    {time_by_day.month_of_year=(*)}
+    {time_by_day.quarter=(*)}
+    {time_by_day.the_year=(*)}]
+Excluded Regions:[
+    {product_class.product_family=('Drink')}
+    {time_by_day.quarter=('Q1')}
+    {time_by_day.the_year=('1997')}]
+Compound Predicates:[]
+ID:[599c9e8f9e75797ca787539c79000e1e5999cf5d24242ad4a03a2bacac08904e]
 
 ]]>
         </Resource>
@@ -706,12 +706,12 @@ Checksum:[7b4af973b0d21f364b0a746f5565cb03]
 Cube:[Sales]
 Measure:[Unit Sales]
 Axes:[
-    {time_by_day.the_year=(*)}
+    {product_class.product_family=(*)}
     {time_by_day.quarter=(*)}
-    {product_class.product_family=(*)}]
+    {time_by_day.the_year=(*)}]
 Excluded Regions:[]
 Compound Predicates:[]
-ID:[3f56e62eefe37a256c465b15833d8e8ceaefe459a47bc4993f5c29a35841e691]
+ID:[81b691ea51d52148d99bccac888d5eebc210cfd1a3424b4f59b2ad59323da286]
 
 *Segment Header
 Schema:[FoodMart]
@@ -719,40 +719,26 @@ Checksum:[7b4af973b0d21f364b0a746f5565cb03]
 Cube:[Sales]
 Measure:[Unit Sales]
 Axes:[
-    {time_by_day.the_year=(*)}
-    {product_class.product_family=(*)}]
-Excluded Regions:[]
-Compound Predicates:[]
-ID:[4e39edcfd80d58026f86a65910eeb6f52b42c1b1e5ebb42aad7330c42533cb91]
-
-*Segment Header
-Schema:[FoodMart]
-Checksum:[7b4af973b0d21f364b0a746f5565cb03]
-Cube:[Sales]
-Measure:[Unit Sales]
-Axes:[
-    {time_by_day.the_year=(*)}
-    {time_by_day.quarter=(*)}
+    {product_class.product_family=(*)}
     {time_by_day.month_of_year=(*)}
-    {product_class.product_family=(*)}]
-Excluded Regions:[]
-Compound Predicates:[]
-ID:[553c83653cceb316152659fc76d70c1dd136d43bd4d6bde9d70182a9bb156a0e]
-
-
-discard segment - it cannot be constrained and maintain consistency:
-*Segment Header
-Schema:[FoodMart]
-Checksum:[7b4af973b0d21f364b0a746f5565cb03]
-Cube:[Sales]
-Measure:[Unit Sales]
-Axes:[
-    {time_by_day.the_year=(*)}
     {time_by_day.quarter=(*)}
-    {product_class.product_family=(*)}]
+    {time_by_day.the_year=(*)}]
 Excluded Regions:[]
 Compound Predicates:[]
-ID:[3f56e62eefe37a256c465b15833d8e8ceaefe459a47bc4993f5c29a35841e691]
+ID:[ef558bc1e9afbf7d47363c3bcd8d29603c39d9a81e983c114d840438cc0fdf8d]
+
+*Segment Header
+Schema:[FoodMart]
+Checksum:[7b4af973b0d21f364b0a746f5565cb03]
+Cube:[Sales]
+Measure:[Unit Sales]
+Axes:[
+    {product_class.product_family=(*)}
+    {time_by_day.the_year=(*)}]
+Excluded Regions:[]
+Compound Predicates:[]
+ID:[7b0d06cc76ba0f99c3e25b0ebbc7628821a71d016797838f8890c8b6295f403c]
+
 
 discard segment - it cannot be constrained and maintain consistency:
 *Segment Header
@@ -761,26 +747,40 @@ Checksum:[7b4af973b0d21f364b0a746f5565cb03]
 Cube:[Sales]
 Measure:[Unit Sales]
 Axes:[
-    {time_by_day.the_year=(*)}
-    {product_class.product_family=(*)}]
-Excluded Regions:[]
-Compound Predicates:[]
-ID:[4e39edcfd80d58026f86a65910eeb6f52b42c1b1e5ebb42aad7330c42533cb91]
-
-discard segment - it cannot be constrained and maintain consistency:
-*Segment Header
-Schema:[FoodMart]
-Checksum:[7b4af973b0d21f364b0a746f5565cb03]
-Cube:[Sales]
-Measure:[Unit Sales]
-Axes:[
-    {time_by_day.the_year=(*)}
+    {product_class.product_family=(*)}
     {time_by_day.quarter=(*)}
+    {time_by_day.the_year=(*)}]
+Excluded Regions:[]
+Compound Predicates:[]
+ID:[81b691ea51d52148d99bccac888d5eebc210cfd1a3424b4f59b2ad59323da286]
+
+discard segment - it cannot be constrained and maintain consistency:
+*Segment Header
+Schema:[FoodMart]
+Checksum:[7b4af973b0d21f364b0a746f5565cb03]
+Cube:[Sales]
+Measure:[Unit Sales]
+Axes:[
+    {product_class.product_family=(*)}
     {time_by_day.month_of_year=(*)}
-    {product_class.product_family=(*)}]
+    {time_by_day.quarter=(*)}
+    {time_by_day.the_year=(*)}]
 Excluded Regions:[]
 Compound Predicates:[]
-ID:[553c83653cceb316152659fc76d70c1dd136d43bd4d6bde9d70182a9bb156a0e]
+ID:[ef558bc1e9afbf7d47363c3bcd8d29603c39d9a81e983c114d840438cc0fdf8d]
+
+discard segment - it cannot be constrained and maintain consistency:
+*Segment Header
+Schema:[FoodMart]
+Checksum:[7b4af973b0d21f364b0a746f5565cb03]
+Cube:[Sales]
+Measure:[Unit Sales]
+Axes:[
+    {product_class.product_family=(*)}
+    {time_by_day.the_year=(*)}]
+Excluded Regions:[]
+Compound Predicates:[]
+ID:[7b0d06cc76ba0f99c3e25b0ebbc7628821a71d016797838f8890c8b6295f403c]
 
 Cache state after flush:
 
@@ -800,12 +800,12 @@ Checksum:[7b4af973b0d21f364b0a746f5565cb03]
 Cube:[Sales]
 Measure:[Unit Sales]
 Axes:[
-    {time_by_day.the_year=(*)}
+    {product_class.product_family=(*)}
     {time_by_day.quarter=(*)}
-    {product_class.product_family=(*)}]
+    {time_by_day.the_year=(*)}]
 Excluded Regions:[]
 Compound Predicates:[]
-ID:[3f56e62eefe37a256c465b15833d8e8ceaefe459a47bc4993f5c29a35841e691]
+ID:[81b691ea51d52148d99bccac888d5eebc210cfd1a3424b4f59b2ad59323da286]
 
 *Segment Header
 Schema:[FoodMart]
@@ -813,25 +813,25 @@ Checksum:[7b4af973b0d21f364b0a746f5565cb03]
 Cube:[Sales]
 Measure:[Unit Sales]
 Axes:[
-    {time_by_day.the_year=(*)}
-    {product_class.product_family=(*)}]
-Excluded Regions:[]
-Compound Predicates:[]
-ID:[4e39edcfd80d58026f86a65910eeb6f52b42c1b1e5ebb42aad7330c42533cb91]
-
-*Segment Header
-Schema:[FoodMart]
-Checksum:[7b4af973b0d21f364b0a746f5565cb03]
-Cube:[Sales]
-Measure:[Unit Sales]
-Axes:[
-    {time_by_day.the_year=(*)}
-    {time_by_day.quarter=(*)}
+    {product_class.product_family=(*)}
     {time_by_day.month_of_year=(*)}
-    {product_class.product_family=(*)}]
+    {time_by_day.quarter=(*)}
+    {time_by_day.the_year=(*)}]
 Excluded Regions:[]
 Compound Predicates:[]
-ID:[553c83653cceb316152659fc76d70c1dd136d43bd4d6bde9d70182a9bb156a0e]
+ID:[ef558bc1e9afbf7d47363c3bcd8d29603c39d9a81e983c114d840438cc0fdf8d]
+
+*Segment Header
+Schema:[FoodMart]
+Checksum:[7b4af973b0d21f364b0a746f5565cb03]
+Cube:[Sales]
+Measure:[Unit Sales]
+Axes:[
+    {product_class.product_family=(*)}
+    {time_by_day.the_year=(*)}]
+Excluded Regions:[]
+Compound Predicates:[]
+ID:[7b0d06cc76ba0f99c3e25b0ebbc7628821a71d016797838f8890c8b6295f403c]
 
 ]]>
         </Resource>


### PR DESCRIPTION
…s and regions are now sorted when building the hash code and ID, thus allowing different JVMs sharing the same cache. We can't sort the columns directly, as they are populated according to SQL specs, and must always stay in sync with the SegmentDataset it represents, but we sort when displaying a string representation, or calculating hashes, which happens only once per header's lifespan.