### PR TITLE
[MONDRIAN-2280]  Virt Cube MDX mishandled w/ non-joining dims

### DIFF
--- a/src/main/mondrian/rolap/SqlTupleReader.java
+++ b/src/main/mondrian/rolap/SqlTupleReader.java
@@ -372,7 +372,37 @@ public class SqlTupleReader implements TupleReader {
                 key.add(target.getLevel());
             }
         }
+        if (constraint.getEvaluator() != null) {
+            addTargetGroupsToKey(key);
+        }
         return key;
+    }
+
+  /**
+   * adds target group info to cacheKey if split target
+   * groups are needed for this query.
+   */
+   private void addTargetGroupsToKey(List<Object> cacheKey) {
+        List<List<TargetBase>> targetGroups = groupTargets(
+            targets,
+            constraint.getEvaluator().getQuery());
+        if (targetGroups.size() > 1) {
+            cacheKey.add(targetsToLevels(targetGroups));
+        }
+    }
+
+    private List<List<RolapLevel>> targetsToLevels(
+        List<List<TargetBase>> targetGroups)
+    {
+        List<List<RolapLevel>> groupedLevelList = new ArrayList<>();
+        for (List<TargetBase> targets : targetGroups) {
+            List<RolapLevel> levels = new ArrayList<>();
+            for (TargetBase target : targets) {
+                levels.add(target.getLevel());
+            }
+            groupedLevelList.add(levels);
+        }
+        return groupedLevelList;
     }
 
     /**


### PR DESCRIPTION
The change for target grouping in SqlTupleReader (introduced with
5ee54f93) did not update the cache key generated for tuples, which
left the possibility that incorrect tuples would be retrieved from cache
if the target grouping for a query varied.

http://jira.pentaho.com/browse/MONDRIAN-1599
http://jira.pentaho.com/browse/MONDRIAN-2280

@lucboudreau 