### PR TITLE
[SP-2822] - Backport of PPP-3536 - Use of vulnerable component  org.c…

### DIFF
--- a/workbench/ivy.xml
+++ b/workbench/ivy.xml
@@ -30,7 +30,7 @@
         <dependency org="jaxen" name="jaxen" rev="1.1.1"/>
         <dependency org="dom4j" name="dom4j" rev="1.6.1"/>
         <dependency org="junit" name="junit" rev="4.0"/>
-        <dependency org="org.codehaus.groovy" name="groovy-all" rev="1.5.6" transitive="false"/>
+        <dependency org="org.codehaus.groovy" name="groovy-all" rev="2.4.7" transitive="false"/>
 
         <dependency org="pentaho" name="pentaho-xul-core" rev="${dependency.pentaho-xul.revision}" changing="true" />
         <dependency org="pentaho" name="pentaho-xul-swing" rev="${dependency.pentaho-xul.revision}" changing="true" />


### PR DESCRIPTION
…odehaus.groovy v.1.8.0 CVE-2015-3253 (5.4 Suite)

@pamval, @mchen-len-son, here is the backport of https://github.com/pentaho/mondrian/pull/740/files to 5.4. Thanks.