### PR TITLE
[BACKLOG-10022] - Fix for Mac issue where Thread.currentThread().getContextClassLoader() can return null

### DIFF
--- a/src/main/mondrian/util/ClassResolver.java
+++ b/src/main/mondrian/util/ClassResolver.java
@@ -51,7 +51,8 @@ public interface ClassResolver {
      * {@link Thread#getContextClassLoader()} on the current thread. */
     class ThreadContextClassResolver extends AbstractClassResolver {
         protected ClassLoader getClassLoader() {
-            return Thread.currentThread().getContextClassLoader();
+            ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+            return contextClassLoader != null ? contextClassLoader : getClass().getClassLoader();
         }
     }
 


### PR DESCRIPTION
[BACKLOG-10022] - Fix for Mac issue where Thread.currentThread().getContextClassLoader() can return null. Found while working on getting analyzer running in osgi (on mac).

This is a common problem that we run into on mac. we can't be certain that Thread.currentThread().getContextClassLoader() will return a non-null value.