### PR TITLE
[BACKLOG-10323] Standardizing on javassist version 3.20.0-GA

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -334,7 +334,7 @@ demo/FoodMartCreateData.sql"/>
 
       <!-- Workbench dependencies to workbench/plugins -->
       <ivy:resolve file="workbench/ivy.xml"/>
-      <ivy:retrieve symlink="${symlink}" type="jar"
+      <ivy:retrieve symlink="${symlink}" type="jar, bundle"
           pattern="${wb.plugins.dir}/[module].[ext]"/>
       <ivy:retrieve symlink="${symlink}" type="source,javadoc"
           pattern="${wb.plugins.dir}/[module]-[type].[ext]"/>


### PR DESCRIPTION
        - The Javassist version 3.20.0-GA is stored as bundle in maven
      	   repo whereas javassist version 3.12.1.GA was stored as jar.
	   Changing the build.xml to use type as either jar or bundle while
	   retrieving from repo so that it can retrieve the new version of javassist.