### PR TITLE
Fix for jira issue MONDRIAN-2542

### DIFF
--- a/mondrian/src/main/java/mondrian/rolap/RolapConnection.java
+++ b/mondrian/src/main/java/mondrian/rolap/RolapConnection.java
@@ -532,7 +532,9 @@ public class RolapConnection extends ConnectionBase {
     }
 
     public String getConnectString() {
-        return connectInfo.toString();
+        final Util.PropertyList connectInfoClone = connectInfo.clone();
+        connectInfoClone.remove(RolapConnectionProperties.JdbcPassword.name());
+        return connectInfoClone.toString();
     }
 
     public String getCatalogName() {


### PR DESCRIPTION
Prevent logging of JdbcPassword when there is a
MemoryLimitExceededException.