### PR TITLE
[BACKLOG-12329] There is no connection to Pentaho Data Services in Schema Workbench in 7.1-QAT #66 build but it used to be in 7.0

### DIFF
--- a/assemblies/psw-ce/src/assembly/assembly.xml
+++ b/assemblies/psw-ce/src/assembly/assembly.xml
@@ -36,6 +36,18 @@
             <includes>
                 <include>*:*:jar</include>
             </includes>
+            <excludes>
+                <exclude>*:pdi-dataservice-client-plugin:jar</exclude>
+            </excludes>
+        </dependencySet>
+        <dependencySet>
+            <outputDirectory>schema-workbench/plugins</outputDirectory>
+            <scope>runtime</scope>
+            <useTransitiveDependencies>true</useTransitiveDependencies>
+            <outputFileNameMapping>${artifact.artifactId}.${artifact.extension}</outputFileNameMapping>
+            <includes>
+                <include>*:pdi-dataservice-client-plugin:jar</include>
+            </includes>
         </dependencySet>
     </dependencySets>
 </assembly>


### PR DESCRIPTION
@kurtwalker @mkambol 
PSW assembly differs from the pre-maven one, moved pdi-dataservice-client jar back to plugins.
@kurtwalker please check for other libraries as other areas might be affected by the migration