### PR TITLE
[MONDRIAN-2285] Native filter with aggregate tables causes NPE when N…

### DIFF
--- a/mondrian/src/main/java/mondrian/rolap/SqlTupleReader.java
+++ b/mondrian/src/main/java/mondrian/rolap/SqlTupleReader.java
@@ -1787,6 +1787,12 @@ public class SqlTupleReader implements TupleReader {
                             // target group.
                             continue;
                         }
+                        // member constraint with name columns in agg table is not supported
+                        if (arg instanceof MemberListCrossJoinArg) {
+                            if (level.getNameExp() != null && !Util.equals(level.getNameExp(), level.getKeyExp())) {
+                                return null;
+                            }
+                        }
                         levelBitKey.set(column.getBitPosition());
                     }
                 }


### PR DESCRIPTION
[MONDRIAN-2285] Native filter with aggregate tables causes NPE when Name column is not the same as key column