### PR TITLE
[ENGOPS-2734] Use the 7.1-SNAPSHOT parent pom to fix sonar properties.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.pentaho</groupId>
     <artifactId>pentaho-ce-jar-parent-pom</artifactId>
-    <version>2.0.4</version>
+    <version>7.1-SNAPSHOT</version>
   </parent>
 
   <groupId>pentaho</groupId>


### PR DESCRIPTION
In the 2.0.4 version of pentaho-ce-jar-parent-pom, the sonar properties are defined in the "sonar" Maven profile. In order for them to be overriden by the Jenkins job, they need to be defined global to the profile. The 7.1-SNAPSHOT version of pentaho-ce-jar-parent-pom defines the properties globally.

Contact me or @smaring for more details.