### PR TITLE
[CLEANUP] - resources should write to generated instead of target

### DIFF
--- a/mondrian/build.xml
+++ b/mondrian/build.xml
@@ -47,7 +47,7 @@
     <resgen
         srcdir="${java.dir}"
         destdir="${generated.java.dir}"
-        resdir="${classes.dir}"
+        resdir="${generated.resources.dir}"
         style="functor"
         locales="en_US,de_DE,de,es_ES">
       <include name="mondrian/resource/MondrianResource.xml"/>


### PR DESCRIPTION
This helps if you want intellij to compile to it's own out directory instead of target.