### PR TITLE
[SP-3344] Backport of MONDRIAN-2399 - No way to use an AvgFromSum cal…

### DIFF
--- a/src/main/mondrian/gui/SchemaExplorer.java
+++ b/src/main/mondrian/gui/SchemaExplorer.java
@@ -5,10 +5,11 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2002-2005 Julian Hyde
-// Copyright (C) 2005-2015 Pentaho and others
+// Copyright (C) 2005-2017 Pentaho and others
 // Copyright (C) 2006-2007 CINCOM SYSTEMS, INC.
 // All Rights Reserved.
 */
+
 package mondrian.gui;
 
 import org.apache.log4j.Logger;
@@ -5095,7 +5096,7 @@ public class SchemaExplorer
     static final String[] DEF_AGG_EXCLUDE = {"pattern", "name", "ignorecase"};
     static final String[] DEF_AGG_IGNORE_COLUMN = {"column"};
     static final String[] DEF_AGG_FOREIGN_KEY = {"factColumn", "aggColumn"};
-    static final String[] DEF_AGG_MEASURE = {"column", "name"};
+    static final String[] DEF_AGG_MEASURE = {"column", "name", "rollupType"};
     static final String[] DEF_AGG_LEVEL = {
         "column",
         "name",

--- a/src/main/mondrian/olap/Mondrian.xml
+++ b/src/main/mondrian/olap/Mondrian.xml
@@ -1934,12 +1934,21 @@ Revision is $Id$
                 The name of the Cube measure.
             </Doc>
         </Attribute>
+        <Attribute name="rollupType" required="false">
+            <Doc>
+                Explicitly define rollup type. Available types: AvgFromSum, AvgFromAvg, SumFromAvg.
+                Will be ignored if wrong type is chosen.
+            </Doc>
+        </Attribute>
         <Code>
             public String getNameAttribute() {
                 return name;
             }
             public String getColumn() {
                 return column;
+            }
+            public String getRollupType() {
+                return rollupType;
             }
         </Code>
     </Element>

--- a/src/main/mondrian/olap/Mondrian_SW.xml
+++ b/src/main/mondrian/olap/Mondrian_SW.xml
@@ -1978,12 +1978,21 @@
                 The name of the Cube measure.
             </Doc>
         </Attribute>
+        <Attribute name="rollupType" required="false">
+            <Doc>
+                Explicitly define rollup type. Available types: AvgFromSum, AvgFromAvg, SumFromAvg.
+                Will be ignored if wrong type is chosen.
+            </Doc>
+        </Attribute>
         <Code>
             public String getNameAttribute() {
                 return name;
             }
             public String getColumn() {
                 return column;
+            }
+            public String getRollupType() {
+                return rollupType;
             }
         </Code>
     </Element>

--- a/src/main/mondrian/rolap/aggmatcher/ExplicitRecognizer.java
+++ b/src/main/mondrian/rolap/aggmatcher/ExplicitRecognizer.java
@@ -5,7 +5,7 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2005-2005 Julian Hyde
-// Copyright (C) 2005-2015 Pentaho and others
+// Copyright (C) 2005-2017 Pentaho and others
 // All Rights Reserved.
 */
 package mondrian.rolap.aggmatcher;
@@ -177,11 +177,22 @@ class ExplicitRecognizer extends Recognizer {
             aggColumn.newUsage(JdbcSchema.UsageType.MEASURE);
 
         aggUsage.setSymbolicName(measure.getSymbolicName());
-        RolapAggregator ra = (factAgg == null)
+
+        ExplicitRules.TableDef.RollupType explicitRollupType = measure
+                .getExplicitRollupType();
+        RolapAggregator ra = null;
+
+        // precedence to the explicitly defined rollup type
+        if (explicitRollupType != null) {
+            String factCountExpr = getFactCountExpr(aggUsage);
+            ra = explicitRollupType.getAggregator(factCountExpr);
+        } else {
+            ra = (factAgg == null)
                     ? convertAggregator(aggUsage, rm.getAggregator())
                     : convertAggregator(aggUsage, factAgg, rm.getAggregator());
-        aggUsage.setAggregator(ra);
+        }
 
+        aggUsage.setAggregator(ra);
         aggUsage.rMeasure = rm;
     }
 

--- a/src/main/mondrian/rolap/aggmatcher/Recognizer.java
+++ b/src/main/mondrian/rolap/aggmatcher/Recognizer.java
@@ -5,9 +5,10 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2005-2005 Julian Hyde
-// Copyright (C) 2005-2015 Pentaho and others
+// Copyright (C) 2005-2017 Pentaho and others
 // All Rights Reserved.
 */
+
 package mondrian.rolap.aggmatcher;
 
 import mondrian.olap.*;
@@ -16,6 +17,7 @@ import mondrian.resource.MondrianResource;
 import mondrian.rolap.*;
 import mondrian.rolap.sql.SqlQuery;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 
 import java.util.*;
@@ -888,7 +890,7 @@ abstract class Recognizer {
      * @param aggUsage Aggregate table column usage
      * @return The name of the column which holds the fact count.
      */
-    private String getFactCountExpr(
+    protected String getFactCountExpr(
         final JdbcSchema.Table.Column.Usage aggUsage)
     {
         // get the fact count column name.

--- a/testsrc/main/mondrian/test/BasicQueryTest.java
+++ b/testsrc/main/mondrian/test/BasicQueryTest.java
@@ -3494,6 +3494,281 @@ public class BasicQueryTest extends FoodMartTestCase {
         testContext.executeQuery( mdx );
     }
 
+    public void testRollupAvgFromSum() {
+        String mdx = ""
+                + "select\n"
+                + "[Measures].[Unit Sales] on columns,\n"
+                + "Descendants([Time].[1997], [Time].[Quarter]) on rows\n"
+                + "from [Sales]";
+
+        String schema = ""
+                + "<?xml version=\"1.0\"?>\n"
+                + "<Schema name=\"FoodMart 2399 Rollup Type\">\n"
+                + "<Cube name=\"Sales\" defaultMeasure=\"Unit Sales\">\n"
+                + "  <Table name=\"sales_fact_1997\">\n"
+                + "<AggExclude name=\"agg_c_14_sales_fact_1997\" />\n"
+                + "<AggExclude name=\"agg_g_ms_pcat_sales_fact_1997\" />\n"
+                + "    <AggExclude name=\"agg_l_03_sales_fact_1997\" />\n"
+                + "<AggExclude name=\"agg_l_04_sales_fact_1997\" />\n"
+                + "<AggExclude name=\"agg_l_05_sales_fact_1997\" />\n"
+                + "<AggExclude name=\"agg_lc_06_sales_fact_1997\" />\n"
+                + "<AggExclude name=\"agg_lc_100_sales_fact_1997\" />\n"
+                + "    <AggExclude name=\"agg_ll_01_sales_fact_1997\" />\n"
+                + "    <AggExclude name=\"agg_pl_01_sales_fact_1997\" />\n"
+                + "<AggExclude name=\"agg_c_special_sales_fact_1997\" />\n"
+                + "    <AggName name=\"agg_c_10_sales_fact_1997\">\n"
+                + "        <AggFactCount column=\"FACT_COUNT\"/>\n"
+                + "        <AggMeasure name=\"[Measures].[Unit Sales]\" column=\"UNIT_SALES\" rollupType=\"AvgFromSum\" />\n"
+                + "        <AggLevel name=\"[Time].[Year]\" column=\"THE_YEAR\" />\n"
+                + "        <AggLevel name=\"[Time].[Quarter]\" column=\"QUARTER\" />\n"
+                + "    </AggName>\n"
+                + "  </Table>\n"
+                + "  <Dimension name=\"Time\" type=\"TimeDimension\" foreignKey=\"time_id\">\n"
+                + "    <Hierarchy hasAll=\"false\" primaryKey=\"time_id\">\n"
+                + "      <Table name=\"time_by_day\"/>\n"
+                + "      <Level name=\"Year\" column=\"the_year\" type=\"Numeric\" uniqueMembers=\"true\"\n"
+                + "          levelType=\"TimeYears\"/>\n"
+                + "      <Level name=\"Quarter\" column=\"quarter\" uniqueMembers=\"false\"\n"
+                + "          levelType=\"TimeQuarters\"/>\n"
+                + "    </Hierarchy>\n"
+                + "  </Dimension>\n"
+                + "  <Measure name=\"Unit Sales\" column=\"unit_sales\" aggregator=\"avg\" />\n"
+                + "</Cube>\n"
+                + "</Schema>";
+
+        TestContext testContext = TestContext
+                .instance()
+                .withFreshConnection()
+                .withSchema(schema);
+        propSaver.set(props.UseAggregates, true);
+        propSaver.set(props.ReadAggregates, true);
+
+        String desiredResult = ""
+                + "Axis #0:\n"
+                + "{}\n"
+                + "Axis #1:\n"
+                + "{[Measures].[Unit Sales]}\n"
+                + "Axis #2:\n"
+                + "{[Time].[1997].[Q1]}\n"
+                + "{[Time].[1997].[Q2]}\n"
+                + "{[Time].[1997].[Q3]}\n"
+                + "{[Time].[1997].[Q4]}\n"
+                + "Row #0: 3.071\n"
+                + "Row #1: 3.074\n"
+                + "Row #2: 3.069\n"
+                + "Row #3: 3.074\n";
+
+        testContext.assertQueryReturns(mdx, desiredResult );
+
+        // check that consistent with fact table
+        propSaver.set(props.UseAggregates, false);
+        propSaver.set(props.ReadAggregates, false);
+
+        testContext.withFreshConnection()
+                .assertQueryReturns(mdx, desiredResult);
+    }
+
+    public void testRollupAvgFromAvg() {
+        String mdx = ""
+                + "select\n"
+                + "[Measures].[Unit Sales] on columns,\n"
+                + "Descendants([Time].[1997], [Time].[Quarter]) on rows\n"
+                + "from [Sales]";
+
+        String schema = ""
+                + "<?xml version=\"1.0\"?>\n"
+                + "<Schema name=\"FoodMart 2399 Rollup Type\">\n"
+                + "<Cube name=\"Sales\" defaultMeasure=\"Unit Sales\">\n"
+                + "  <Table name=\"sales_fact_1997\">\n"
+                + "<AggExclude name=\"agg_c_14_sales_fact_1997\" />\n"
+                + "<AggExclude name=\"agg_g_ms_pcat_sales_fact_1997\" />\n"
+                + "    <AggExclude name=\"agg_l_03_sales_fact_1997\" />\n"
+                + "<AggExclude name=\"agg_l_04_sales_fact_1997\" />\n"
+                + "<AggExclude name=\"agg_l_05_sales_fact_1997\" />\n"
+                + "<AggExclude name=\"agg_lc_06_sales_fact_1997\" />\n"
+                + "<AggExclude name=\"agg_lc_100_sales_fact_1997\" />\n"
+                + "    <AggExclude name=\"agg_ll_01_sales_fact_1997\" />\n"
+                + "    <AggExclude name=\"agg_pl_01_sales_fact_1997\" />\n"
+                + "<AggExclude name=\"agg_c_special_sales_fact_1997\" />\n"
+                + "    <AggName name=\"agg_c_10_sales_fact_1997\">\n"
+                + "        <AggFactCount column=\"FACT_COUNT\"/>\n"
+                + "        <AggMeasure name=\"[Measures].[Unit Sales]\" column=\"UNIT_SALES\" rollupType=\"AvgFromAvg\" />\n"
+                + "        <AggLevel name=\"[Time].[Year]\" column=\"THE_YEAR\" />\n"
+                + "        <AggLevel name=\"[Time].[Quarter]\" column=\"QUARTER\" />\n"
+                + "    </AggName>\n"
+                + "  </Table>\n"
+                + "  <Dimension name=\"Time\" type=\"TimeDimension\" foreignKey=\"time_id\">\n"
+                + "    <Hierarchy hasAll=\"false\" primaryKey=\"time_id\">\n"
+                + "      <Table name=\"time_by_day\"/>\n"
+                + "      <Level name=\"Year\" column=\"the_year\" type=\"Numeric\" uniqueMembers=\"true\"\n"
+                + "          levelType=\"TimeYears\"/>\n"
+                + "      <Level name=\"Quarter\" column=\"quarter\" uniqueMembers=\"false\"\n"
+                + "          levelType=\"TimeQuarters\"/>\n"
+                + "    </Hierarchy>\n"
+                + "  </Dimension>\n"
+                + "  <Measure name=\"Unit Sales\" column=\"unit_sales\" aggregator=\"avg\" />\n"
+                + "</Cube>\n"
+                + "</Schema>";
+
+        TestContext testContext = TestContext
+                .instance()
+                .withFreshConnection()
+                .withSchema(schema);
+        propSaver.set(props.UseAggregates, true);
+        propSaver.set(props.ReadAggregates, true);
+
+        String desiredResult = ""
+                + "Axis #0:\n"
+                + "{}\n"
+                + "Axis #1:\n"
+                + "{[Measures].[Unit Sales]}\n"
+                + "Axis #2:\n"
+                + "{[Time].[1997].[Q1]}\n"
+                + "{[Time].[1997].[Q2]}\n"
+                + "{[Time].[1997].[Q3]}\n"
+                + "{[Time].[1997].[Q4]}\n"
+                + "Row #0: 22,157.417\n"
+                + "Row #1: 20,880.448\n"
+                + "Row #2: 22,036.988\n"
+                + "Row #3: 24,368.758\n";
+
+        testContext.assertQueryReturns(mdx, desiredResult );
+    }
+
+    public void testRollupSumFromAvg() {
+        String mdx = ""
+                + "select\n"
+                + "[Measures].[Unit Sales] on columns,\n"
+                + "Descendants([Time].[1997], [Time].[Quarter]) on rows\n"
+                + "from [Sales]";
+
+        String schema = ""
+                + "<?xml version=\"1.0\"?>\n"
+                + "<Schema name=\"FoodMart 2399 Rollup Type\">\n"
+                + "<Cube name=\"Sales\" defaultMeasure=\"Unit Sales\">\n"
+                + "  <Table name=\"sales_fact_1997\">\n"
+                + "<AggExclude name=\"agg_c_14_sales_fact_1997\" />\n"
+                + "<AggExclude name=\"agg_g_ms_pcat_sales_fact_1997\" />\n"
+                + "    <AggExclude name=\"agg_l_03_sales_fact_1997\" />\n"
+                + "<AggExclude name=\"agg_l_04_sales_fact_1997\" />\n"
+                + "<AggExclude name=\"agg_l_05_sales_fact_1997\" />\n"
+                + "<AggExclude name=\"agg_lc_06_sales_fact_1997\" />\n"
+                + "<AggExclude name=\"agg_lc_100_sales_fact_1997\" />\n"
+                + "    <AggExclude name=\"agg_ll_01_sales_fact_1997\" />\n"
+                + "    <AggExclude name=\"agg_pl_01_sales_fact_1997\" />\n"
+                + "<AggExclude name=\"agg_c_special_sales_fact_1997\" />\n"
+                + "    <AggName name=\"agg_c_10_sales_fact_1997\">\n"
+                + "        <AggFactCount column=\"FACT_COUNT\"/>\n"
+                + "        <AggMeasure name=\"[Measures].[Unit Sales]\" column=\"UNIT_SALES\" rollupType=\"SumFromAvg\" />\n"
+                + "        <AggLevel name=\"[Time].[Year]\" column=\"THE_YEAR\" />\n"
+                + "        <AggLevel name=\"[Time].[Quarter]\" column=\"QUARTER\" />\n"
+                + "    </AggName>\n"
+                + "  </Table>\n"
+                + "  <Dimension name=\"Time\" type=\"TimeDimension\" foreignKey=\"time_id\">\n"
+                + "    <Hierarchy hasAll=\"false\" primaryKey=\"time_id\">\n"
+                + "      <Table name=\"time_by_day\"/>\n"
+                + "      <Level name=\"Year\" column=\"the_year\" type=\"Numeric\" uniqueMembers=\"true\"\n"
+                + "          levelType=\"TimeYears\"/>\n"
+                + "      <Level name=\"Quarter\" column=\"quarter\" uniqueMembers=\"false\"\n"
+                + "          levelType=\"TimeQuarters\"/>\n"
+                + "    </Hierarchy>\n"
+                + "  </Dimension>\n"
+                + "  <Measure name=\"Unit Sales\" column=\"unit_sales\" aggregator=\"avg\" />\n"
+                + "</Cube>\n"
+                + "</Schema>";
+
+        TestContext testContext = TestContext
+                .instance()
+                .withFreshConnection()
+                .withSchema(schema);
+        propSaver.set(props.UseAggregates, true);
+        propSaver.set(props.ReadAggregates, true);
+
+        String desiredResult = ""
+                + "Axis #0:\n"
+                + "{}\n"
+                + "Axis #1:\n"
+                + "{[Measures].[Unit Sales]}\n"
+                + "Axis #2:\n"
+                + "{[Time].[1997].[Q1]}\n"
+                + "{[Time].[1997].[Q2]}\n"
+                + "{[Time].[1997].[Q3]}\n"
+                + "{[Time].[1997].[Q4]}\n"
+                + "Row #0: 478,334,320\n"
+                + "Row #1: 425,292,956\n"
+                + "Row #2: 472,759,506\n"
+                + "Row #3: 570,911,254\n";
+
+        testContext.assertQueryReturns(mdx, desiredResult );
+    }
+
+    public void testWithoutRollupType() {
+        String mdx = ""
+                + "select\n"
+                + "[Measures].[Unit Sales] on columns,\n"
+                + "Descendants([Time].[1997], [Time].[Quarter]) on rows\n"
+                + "from [Sales]";
+
+        String schema = ""
+                + "<?xml version=\"1.0\"?>\n"
+                + "<Schema name=\"FoodMart 2399 Rollup Type\">\n"
+                + "<Cube name=\"Sales\" defaultMeasure=\"Unit Sales\">\n"
+                + "  <Table name=\"sales_fact_1997\">\n"
+                + "<AggExclude name=\"agg_c_14_sales_fact_1997\" />\n"
+                + "<AggExclude name=\"agg_g_ms_pcat_sales_fact_1997\" />\n"
+                + "    <AggExclude name=\"agg_l_03_sales_fact_1997\" />\n"
+                + "<AggExclude name=\"agg_l_04_sales_fact_1997\" />\n"
+                + "<AggExclude name=\"agg_l_05_sales_fact_1997\" />\n"
+                + "<AggExclude name=\"agg_lc_06_sales_fact_1997\" />\n"
+                + "<AggExclude name=\"agg_lc_100_sales_fact_1997\" />\n"
+                + "    <AggExclude name=\"agg_ll_01_sales_fact_1997\" />\n"
+                + "    <AggExclude name=\"agg_pl_01_sales_fact_1997\" />\n"
+                + "<AggExclude name=\"agg_c_special_sales_fact_1997\" />\n"
+                + "    <AggName name=\"agg_c_10_sales_fact_1997\">\n"
+                + "        <AggFactCount column=\"FACT_COUNT\"/>\n"
+                + "        <AggMeasure name=\"[Measures].[Unit Sales]\" column=\"UNIT_SALES\" />\n"
+                + "        <AggLevel name=\"[Time].[Year]\" column=\"THE_YEAR\" />\n"
+                + "        <AggLevel name=\"[Time].[Quarter]\" column=\"QUARTER\" />\n"
+                + "    </AggName>\n"
+                + "  </Table>\n"
+                + "  <Dimension name=\"Time\" type=\"TimeDimension\" foreignKey=\"time_id\">\n"
+                + "    <Hierarchy hasAll=\"false\" primaryKey=\"time_id\">\n"
+                + "      <Table name=\"time_by_day\"/>\n"
+                + "      <Level name=\"Year\" column=\"the_year\" type=\"Numeric\" uniqueMembers=\"true\"\n"
+                + "          levelType=\"TimeYears\"/>\n"
+                + "      <Level name=\"Quarter\" column=\"quarter\" uniqueMembers=\"false\"\n"
+                + "          levelType=\"TimeQuarters\"/>\n"
+                + "    </Hierarchy>\n"
+                + "  </Dimension>\n"
+                + "  <Measure name=\"Unit Sales\" column=\"unit_sales\" aggregator=\"avg\" />\n"
+                + "</Cube>\n"
+                + "</Schema>";
+
+        TestContext testContext = TestContext
+                .instance()
+                .withFreshConnection()
+                .withSchema(schema);
+        propSaver.set(props.UseAggregates, true);
+        propSaver.set(props.ReadAggregates, true);
+
+        String desiredResult = ""
+                + "Axis #0:\n"
+                + "{}\n"
+                + "Axis #1:\n"
+                + "{[Measures].[Unit Sales]}\n"
+                + "Axis #2:\n"
+                + "{[Time].[1997].[Q1]}\n"
+                + "{[Time].[1997].[Q2]}\n"
+                + "{[Time].[1997].[Q3]}\n"
+                + "{[Time].[1997].[Q4]}\n"
+                + "Row #0: 22,157.417\n"
+                + "Row #1: 20,880.448\n"
+                + "Row #2: 22,036.988\n"
+                + "Row #3: 24,368.758\n";
+
+        testContext.assertQueryReturns(mdx, desiredResult );
+    }
+
     /**
      *
      * There are cross database order issues in this test.


### PR DESCRIPTION
[SP-3344] Backport of MONDRIAN-2399 - No way to use an AvgFromSum calculation with explicitly defined aggregate tables (6.1 Suite)