### PR TITLE
[SP-3345] Backport of MONDRIAN-2399 - No way to use an AvgFromSum cal…

### DIFF
--- a/src/main/mondrian/gui/SchemaExplorer.java
+++ b/src/main/mondrian/gui/SchemaExplorer.java
@@ -5,10 +5,11 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2002-2005 Julian Hyde
-// Copyright (C) 2005-2015 Pentaho and others
+// Copyright (C) 2005-2017 Pentaho and others
 // Copyright (C) 2006-2007 CINCOM SYSTEMS, INC.
 // All Rights Reserved.
 */
+
 package mondrian.gui;
 
 import org.apache.log4j.Logger;
@@ -5095,7 +5096,7 @@ public class SchemaExplorer
     static final String[] DEF_AGG_EXCLUDE = {"pattern", "name", "ignorecase"};
     static final String[] DEF_AGG_IGNORE_COLUMN = {"column"};
     static final String[] DEF_AGG_FOREIGN_KEY = {"factColumn", "aggColumn"};
-    static final String[] DEF_AGG_MEASURE = {"column", "name"};
+    static final String[] DEF_AGG_MEASURE = {"column", "name", "rollupType"};
     static final String[] DEF_AGG_LEVEL = {
         "column",
         "name",

--- a/src/main/mondrian/olap/Mondrian.xml
+++ b/src/main/mondrian/olap/Mondrian.xml
@@ -1935,12 +1935,21 @@ Revision is $Id$
                 The name of the Cube measure.
             </Doc>
         </Attribute>
+        <Attribute name="rollupType" required="false">
+            <Doc>
+                Explicitly define rollup type. Available types: AvgFromSum, AvgFromAvg, SumFromAvg.
+                Will be ignored if wrong type is chosen.
+            </Doc>
+        </Attribute>
         <Code>
             public String getNameAttribute() {
                 return name;
             }
             public String getColumn() {
                 return column;
+            }
+            public String getRollupType() {
+                return rollupType;
             }
         </Code>
     </Element>

--- a/src/main/mondrian/olap/Mondrian_SW.xml
+++ b/src/main/mondrian/olap/Mondrian_SW.xml
@@ -1979,12 +1979,21 @@
                 The name of the Cube measure.
             </Doc>
         </Attribute>
+        <Attribute name="rollupType" required="false">
+            <Doc>
+                Explicitly define rollup type. Available types: AvgFromSum, AvgFromAvg, SumFromAvg.
+                Will be ignored if wrong type is chosen.
+            </Doc>
+        </Attribute>
         <Code>
             public String getNameAttribute() {
                 return name;
             }
             public String getColumn() {
                 return column;
+            }
+            public String getRollupType() {
+                return rollupType;
             }
         </Code>
     </Element>

--- a/src/main/mondrian/rolap/aggmatcher/ExplicitRecognizer.java
+++ b/src/main/mondrian/rolap/aggmatcher/ExplicitRecognizer.java
@@ -5,7 +5,7 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2005-2005 Julian Hyde
-// Copyright (C) 2005-2015 Pentaho and others
+// Copyright (C) 2005-2017 Pentaho and others
 // All Rights Reserved.
 */
 package mondrian.rolap.aggmatcher;
@@ -177,11 +177,22 @@ class ExplicitRecognizer extends Recognizer {
             aggColumn.newUsage(JdbcSchema.UsageType.MEASURE);
 
         aggUsage.setSymbolicName(measure.getSymbolicName());
-        RolapAggregator ra = (factAgg == null)
+
+        ExplicitRules.TableDef.RollupType explicitRollupType = measure
+                .getExplicitRollupType();
+        RolapAggregator ra = null;
+
+        // precedence to the explicitly defined rollup type
+        if (explicitRollupType != null) {
+            String factCountExpr = getFactCountExpr(aggUsage);
+            ra = explicitRollupType.getAggregator(factCountExpr);
+        } else {
+            ra = (factAgg == null)
                     ? convertAggregator(aggUsage, rm.getAggregator())
                     : convertAggregator(aggUsage, factAgg, rm.getAggregator());
-        aggUsage.setAggregator(ra);
+        }
 
+        aggUsage.setAggregator(ra);
         aggUsage.rMeasure = rm;
     }
 

--- a/src/main/mondrian/rolap/aggmatcher/Recognizer.java
+++ b/src/main/mondrian/rolap/aggmatcher/Recognizer.java
@@ -5,9 +5,10 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2005-2005 Julian Hyde
-// Copyright (C) 2005-2015 Pentaho and others
+// Copyright (C) 2005-2017 Pentaho and others
 // All Rights Reserved.
 */
+
 package mondrian.rolap.aggmatcher;
 
 import mondrian.olap.*;
@@ -16,6 +17,7 @@ import mondrian.resource.MondrianResource;
 import mondrian.rolap.*;
 import mondrian.rolap.sql.SqlQuery;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 
 import java.util.*;
@@ -888,7 +890,7 @@ abstract class Recognizer {
      * @param aggUsage Aggregate table column usage
      * @return The name of the column which holds the fact count.
      */
-    private String getFactCountExpr(
+    protected String getFactCountExpr(
         final JdbcSchema.Table.Column.Usage aggUsage)
     {
         // get the fact count column name.


### PR DESCRIPTION
[SP-3345] Backport of MONDRIAN-2399 - No way to use an AvgFromSum calculation with explicitly defined aggregate tables (7.0 Suite)