### PR TITLE
[MONDRIAN-2207] The segment cache index registry must use SchemaKey instead of only the checksum

### DIFF
--- a/mondrian/src/main/java/mondrian/rolap/RolapSchema.java
+++ b/mondrian/src/main/java/mondrian/rolap/RolapSchema.java
@@ -5,7 +5,7 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2001-2005 Julian Hyde
-// Copyright (C) 2005-2016 Pentaho and others
+// Copyright (C) 2005-2017 Pentaho and others
 // All Rights Reserved.
 */
 package mondrian.rolap;
@@ -453,6 +453,14 @@ public class RolapSchema implements Schema {
      */
     public String getId() {
         return this.id;
+    }
+
+    /**
+     * Returns this schema instance unique key.
+     * @return a {@link SchemaKey}.
+     */
+    public SchemaKey getKey() {
+        return key;
     }
 
     public Map<String, Annotation> getAnnotationMap() {

--- a/mondrian/src/main/java/mondrian/rolap/SchemaKey.java
+++ b/mondrian/src/main/java/mondrian/rolap/SchemaKey.java
@@ -4,7 +4,7 @@
 * http://www.eclipse.org/legal/epl-v10.html.
 * You must accept the terms of that agreement to use this software.
 *
-* Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+* Copyright (c) 2002-2017 Pentaho Corporation..  All rights reserved.
 */
 
 package mondrian.rolap;
@@ -17,7 +17,7 @@ import mondrian.util.Pair;
  * Equivalent schemas can share the same cache, including a distributed
  * cache.
  */
-class SchemaKey
+public class SchemaKey
     extends Pair<SchemaContentKey, ConnectionKey>
 {
     /** Creates a schema key. */

--- a/mondrian/src/main/java/mondrian/rolap/agg/SegmentCacheManager.java
+++ b/mondrian/src/main/java/mondrian/rolap/agg/SegmentCacheManager.java
@@ -4,7 +4,7 @@
 // http://www.eclipse.org/legal/epl-v10.html.
 // You must accept the terms of that agreement to use this software.
 //
-// Copyright (c) 2002-2016 Pentaho Corporation.
+// Copyright (c) 2002-2017 Pentaho Corporation.
 // All Rights Reserved.
 */
 package mondrian.rolap.agg;
@@ -1568,9 +1568,9 @@ public class SegmentCacheManager {
      * The index is based off the checksum of the schema.
      */
     public class SegmentCacheIndexRegistry {
-        private final Map<ByteString, SegmentCacheIndex> indexes =
+        private final Map<SchemaKey, SegmentCacheIndex> indexes =
             Collections.synchronizedMap(
-                new HashMap<ByteString, SegmentCacheIndex>());
+                new HashMap<SchemaKey, SegmentCacheIndex>());
 
         /**
          * Returns the {@link SegmentCacheIndex} for a given
@@ -1581,17 +1581,17 @@ public class SegmentCacheManager {
                 "SegmentCacheManager.SegmentCacheIndexRegistry.getIndex:"
                 + System.identityHashCode(star));
 
-            if (!indexes.containsKey(star.getSchema().getChecksum())) {
+            if (!indexes.containsKey(star.getSchema().getKey())) {
                 final SegmentCacheIndexImpl index =
                     new SegmentCacheIndexImpl(thread);
                 LOGGER.trace(
                     "SegmentCacheManager.SegmentCacheIndexRegistry.getIndex:"
                     + "Creating New Index "
                     + System.identityHashCode(index));
-                indexes.put(star.getSchema().getChecksum(), index);
+                indexes.put(star.getSchema().getKey(), index);
             }
             final SegmentCacheIndex index =
-                indexes.get(star.getSchema().getChecksum());
+                indexes.get(star.getSchema().getKey());
             LOGGER.trace(
                 "SegmentCacheManager.SegmentCacheIndexRegistry.getIndex:"
                 + "Returning Index "
@@ -1606,13 +1606,6 @@ public class SegmentCacheManager {
         private SegmentCacheIndex getIndex(
             SegmentHeader header)
         {
-            // First we check the indexes that already exist.
-            // This is fast.
-            if (indexes.containsKey(header.schemaChecksum)) {
-                return indexes.get(header.schemaChecksum);
-            }
-
-            // The index doesn't exist. Let's create it.
             final RolapStar star = getStar(header);
             if (star == null) {
                 // TODO FIXME this happens when a cache event comes


### PR DESCRIPTION
- SchemaKey became public
- key getter was added into RolapSchema
- SegmentCacheIndexRegistry now use SchemaKey