### PR TITLE
[PPP-3692] - Use of vulnerable component commons-beanutils: 1.8.0 - C…

### DIFF
--- a/assemblies/psw-ce/pom.xml
+++ b/assemblies/psw-ce/pom.xml
@@ -119,10 +119,6 @@
           <artifactId>bsh-core</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>commons-beanutils</groupId>
-          <artifactId>commons-beanutils-core</artifactId>
-        </exclusion>
-        <exclusion>
           <groupId>commons-digester</groupId>
           <artifactId>commons-digester</artifactId>
         </exclusion>


### PR DESCRIPTION
…VE-2014-0114

- remove redundant dependency commons-collections-core

@pamval, @mbatchelor, @graimundo could you please take a look?

no need exclusion more since there is no jar in kettle-core 