### PR TITLE
[CLEANUP] Update application launcher version property

### DIFF
--- a/assemblies/psw-ce/pom.xml
+++ b/assemblies/psw-ce/pom.xml
@@ -20,7 +20,7 @@
   </scm>
   <properties>
     <jlfgr.version>1.0</jlfgr.version>
-    <dependency.pentaho-application-launcher.revision>7.1-SNAPSHOT</dependency.pentaho-application-launcher.revision>
+    <pentaho-launcher.version>8.0-SNAPSHOT</pentaho-launcher.version>
     <guava.version>17.0</guava.version>
     <dependency.groovy-all.revision>2.4.7</dependency.groovy-all.revision>
     <dependency.pdi-dataservice-client-plugin.revision>8.0-SNAPSHOT</dependency.pdi-dataservice-client-plugin.revision>
@@ -180,7 +180,7 @@
     <dependency>
       <groupId>pentaho</groupId>
       <artifactId>pentaho-application-launcher</artifactId>
-      <version>${dependency.pentaho-application-launcher.revision}</version>
+      <version>${pentaho-launcher.version}</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>

--- a/workbench/pom.xml
+++ b/workbench/pom.xml
@@ -19,7 +19,7 @@
   </scm>
   <properties>
     <jlfgr.version>1.0</jlfgr.version>
-    <dependency.pentaho-application-launcher.revision>7.1-SNAPSHOT</dependency.pentaho-application-launcher.revision>
+    <pentaho-launcher.version>8.0-SNAPSHOT</pentaho-launcher.version>
     <dependency.groovy-all.revision>2.4.7</dependency.groovy-all.revision>
     <dependency.pdi-dataservice-client-plugin.revision>8.0-SNAPSHOT</dependency.pdi-dataservice-client-plugin.revision>
     <dependency.oss-licenses.revision>8.0-SNAPSHOT</dependency.oss-licenses.revision>


### PR DESCRIPTION
@lgrill-pentaho Please review. Tested change with the following jobs:

http://cerberusdmz.pentaho.com/job/8.0/job/mondrian-jar/52/consoleFull
http://cerberusdmz.pentaho.com/job/8.0/job/mondrian-workbench/49/consoleFull
http://cerberusdmz.pentaho.com/job/8.0/job/psw-assembly/50/consoleFull

You now see this in the log:

>14:19:20 14:19:20.723 [main] INFO  com.pentaho.VersionMerger - Updating 'pentaho-launcher.version' old value='8.0-SNAPSHOT' new value='8.0-QAT-81'