### PR TITLE
[SP-3537] Backport of MONDRIAN-2428 - Using inconsistent names in a s…

### DIFF
--- a/src/main/mondrian/rolap/DelegatingRolapMember.java
+++ b/src/main/mondrian/rolap/DelegatingRolapMember.java
@@ -5,7 +5,7 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2001-2005 Julian Hyde
-// Copyright (C) 2005-2015 Pentaho and others
+// Copyright (C) 2005-2017 Pentaho and others
 // All Rights Reserved.
 */
 package mondrian.rolap;
@@ -80,7 +80,12 @@ public class DelegatingRolapMember extends RolapMemberBase {
     }
 
     public boolean isChildOrEqualTo(Member member2) {
-        return member.isChildOrEqualTo(member2);
+        if (member2 instanceof DelegatingRolapMember) {
+            return member
+                    .isChildOrEqualTo(((DelegatingRolapMember) member2).member);
+        } else {
+            return member.isChildOrEqualTo(member2);
+        }
     }
 
     public boolean isCalculated() {

--- a/testsrc/main/mondrian/rolap/BatchTestCase.java
+++ b/testsrc/main/mondrian/rolap/BatchTestCase.java
@@ -5,7 +5,7 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2004-2005 Julian Hyde
-// Copyright (C) 2005-2015 Pentaho and others
+// Copyright (C) 2005-2017 Pentaho and others
 // All Rights Reserved.
 */
 package mondrian.rolap;
@@ -992,6 +992,19 @@ public class BatchTestCase extends FoodMartTestCase {
             TestContext.toString(expectedResult));
     }
 
+    public static void checkNotNative(String mdx, Result expectedResult, final TestContext context) {
+        BatchTestCase test = new BatchTestCase() {
+            @Override
+            public TestContext getTestContext() {
+                return context;
+            }
+        };
+        test.checkNotNative(
+                getRowCount(expectedResult),
+                mdx,
+                TestContext.toString(expectedResult));
+    }
+
     public static void checkNative(String mdx, Result expectedResult) {
         BatchTestCase test = new BatchTestCase();
         test.checkNative(
@@ -1000,6 +1013,21 @@ public class BatchTestCase extends FoodMartTestCase {
             mdx,
             TestContext.toString(expectedResult),
             true);
+    }
+
+    public static void checkNative(String mdx, Result expectedResult, final TestContext context) {
+        BatchTestCase test = new BatchTestCase() {
+            @Override
+            public TestContext getTestContext() {
+                return context;
+            }
+        };
+        test.checkNative(
+                0,
+                getRowCount(expectedResult),
+                mdx,
+                TestContext.toString(expectedResult),
+                true);
     }
 
     private static int getRowCount(Result result) {

--- a/testsrc/main/mondrian/test/NativeSetEvaluationTest.java
+++ b/testsrc/main/mondrian/test/NativeSetEvaluationTest.java
@@ -12,6 +12,7 @@ package mondrian.test;
 import mondrian.olap.CacheControl;
 import mondrian.olap.MondrianProperties;
 import mondrian.olap.NativeEvaluationUnsupportedException;
+import mondrian.olap.Result;
 import mondrian.rolap.*;
 import mondrian.spi.Dialect;
 import mondrian.spi.Dialect.DatabaseProduct;
@@ -1764,6 +1765,33 @@ public class NativeSetEvaluationTest extends BatchTestCase {
                 "The results of native and non-native evaluations should be equal";
         verifySameNativeAndNot(query, message, getTestContext());
     }
+
+    public void testDimensionUsageWithDifferentNameExecutedNatively() {
+      TestContext testContext = getTestContext()
+              .createSubstitutingCube(
+                  "Sales",
+                  "<DimensionUsage name=\"PurchaseDate\" source=\"Time\" foreignKey=\"time_id\"/>");
+      String mdx = ""
+              + "with member Measures.q1Sales as '([PurchaseDate].[1997].[Q1], Measures.[Unit Sales])'\n"
+              + "select NonEmptyCrossjoin([PurchaseDate].[1997].[Q1], Gender.Gender.members) on 0 \n"
+              + "from Sales where Measures.q1Sales";
+      Result result = testContext.executeQuery(mdx);
+
+      checkNative(mdx, result, testContext);
+    }
+
+    public void testDimensionUsageExecutedNatively() {
+      TestContext testContext = getTestContext();
+      String mdx = ""
+              + "with member Measures.q1Sales as '([Time].[1997].[Q1], Measures.[Unit Sales])'\n"
+              + "select NonEmptyCrossjoin( [Time].[1997].[Q1], Gender.Gender.members) on 0 \n"
+              + "from Sales where Measures.q1Sales";
+      Result result = testContext.executeQuery(mdx);
+
+      checkNative(mdx, result);
+    }
+
+
 }
 
 // End NativeSetEvaluationTest.java


### PR DESCRIPTION
[SP-3537] Backport of MONDRIAN-2428 - Using inconsistent names in a shared dimension vs. a dimension usage can result in mishandling of member names (6.1 Suite)