### PR TITLE
[SP-3616] Backport of MONDRIAN-2150 - Log Full of "CrossJoinFunDef.no…

### DIFF
--- a/mondrian/src/main/java/mondrian/olap/fun/CrossJoinFunDef.java
+++ b/mondrian/src/main/java/mondrian/olap/fun/CrossJoinFunDef.java
@@ -914,8 +914,7 @@ public class CrossJoinFunDef extends FunDefBase {
                             }
                         }
                         if (!found) {
-                            System.out.println(
-                                "CrossJoinFunDef.nonEmptyListNEW: ERROR");
+                            LOGGER.warn( "CrossJoinFunDef.nonEmptyListNEW: ERROR" );
                         }
                     } else {
                         // The Hierarchy does NOT have an All member


### PR DESCRIPTION
[SP-3616] Backport of MONDRIAN-2150 - Log Full of "CrossJoinFunDef.nonEmptyListNEW: ERROR" (7.1 Suite)