### PR TITLE
[SP-3615] - Backport of MONDRIAN-2150 - Log Full of "CrossJoinFunDef.…

### DIFF
--- a/src/main/mondrian/olap/fun/CrossJoinFunDef.java
+++ b/src/main/mondrian/olap/fun/CrossJoinFunDef.java
@@ -907,8 +907,7 @@ public class CrossJoinFunDef extends FunDefBase {
                             }
                         }
                         if (!found) {
-                            System.out.println(
-                                "CrossJoinFunDef.nonEmptyListNEW: ERROR");
+                            LOGGER.warn( "CrossJoinFunDef.nonEmptyListNEW: ERROR" );
                         }
                     } else {
                         // The Hierarchy does NOT have an All member


### PR DESCRIPTION
[SP-3615] - Backport of MONDRIAN-2150 - Log Full of "CrossJoinFunDefnonEmptyListNEW: ERROR" (6.1 Suite)