### PR TITLE
[PPP-3566] Use of vulnerable component xerces:xercesImpl:2.9.1and 2.1…

### DIFF
--- a/assemblies/psw-ce/pom.xml
+++ b/assemblies/psw-ce/pom.xml
@@ -226,12 +226,6 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
-      <groupId>xerces</groupId>
-      <artifactId>xercesImpl</artifactId>
-      <version>${xercesImpl.version}</version>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
       <groupId>pentaho</groupId>
       <artifactId>oss-licenses</artifactId>
       <version>${dependency.oss-licenses.revision}</version>

--- a/mondrian/pom.xml
+++ b/mondrian/pom.xml
@@ -28,12 +28,8 @@
     <vendor>Pentaho</vendor>
     <driver.version.major>${project.version.major}</driver.version.major>
   </properties>
+
   <dependencies>
-    <dependency>
-      <groupId>xml-apis</groupId>
-      <artifactId>xml-apis</artifactId>
-      <version>${xml-apis.version}</version>
-    </dependency>
     <dependency>
       <groupId>commons-collections</groupId>
       <artifactId>commons-collections</artifactId>
@@ -42,7 +38,6 @@
     <dependency>
       <groupId>commons-dbcp</groupId>
       <artifactId>commons-dbcp</artifactId>
-      <version>${commons-dbcp.version}</version>
     </dependency>
     <dependency>
       <groupId>commons-lang</groupId>
@@ -73,17 +68,11 @@
     <dependency>
       <groupId>commons-pool</groupId>
       <artifactId>commons-pool</artifactId>
-      <version>${commons-pool.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-vfs2</artifactId>
       <version>${commons-vfs2.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>dom4j</groupId>
-      <artifactId>dom4j</artifactId>
-      <version>${dom4j.version}</version>
     </dependency>
     <dependency>
       <groupId>javax.validation</groupId>
@@ -93,17 +82,14 @@
     <dependency>
       <groupId>eigenbase</groupId>
       <artifactId>eigenbase-xom</artifactId>
-      <version>${eigenbase-xom.version}</version>
     </dependency>
     <dependency>
       <groupId>eigenbase</groupId>
       <artifactId>eigenbase-properties</artifactId>
-      <version>${eigenbase-properties.version}</version>
     </dependency>
     <dependency>
       <groupId>eigenbase</groupId>
       <artifactId>eigenbase-resgen</artifactId>
-      <version>${eigenbase-resgen.version}</version>
     </dependency>
     <dependency>
       <groupId>org.olap4j</groupId>
@@ -120,11 +106,6 @@
       <artifactId>olap4j-tck</artifactId>
       <version>${olap4j-tck.version}</version>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>xerces</groupId>
-      <artifactId>xercesImpl</artifactId>
-      <version>${xercesImpl.version}</version>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>

--- a/mondrian/src/it/java/mondrian/xmla/XmlaBaseTestCase.java
+++ b/mondrian/src/it/java/mondrian/xmla/XmlaBaseTestCase.java
@@ -4,7 +4,7 @@
 // http://www.eclipse.org/legal/epl-v10.html.
 // You must accept the terms of that agreement to use this software.
 //
-// Copyright (C) 2002-2014 Pentaho and others
+// Copyright (C) 2002-2017 Pentaho and others
 // All Rights Reserved.
 */
 package mondrian.xmla;
@@ -142,7 +142,7 @@ System.out.println("requestText=" + requestText);
         boolean validate)
         throws Exception
     {
-        if (validate && XmlUtil.supportsValidation()) {
+        if (validate) {
             if (XmlaSupport.validateSoapXmlaUsingXpath(bytes)) {
                 if (DEBUG) {
                     System.out.println("XML Data is Valid");
@@ -280,7 +280,7 @@ System.out.println("Got CONTINUE");
 
     protected void addDatasourceInfoResponseKey(Properties props) {
         XmlaTestContext s = new XmlaTestContext();
-        String con = s.getConnectString().replaceAll("&amp;","&");
+        String con = s.getConnectString().replaceAll("&amp;", "&");
         PropertyList pl = Util.parseConnectString(con);
         pl.remove(RolapConnectionProperties.Jdbc.name());
         pl.remove(RolapConnectionProperties.JdbcUser.name());
@@ -617,11 +617,9 @@ System.out.println("Got CONTINUE");
             XmlaSupport.processXmla(
                 xmlaReqDoc, filterConnectString(connectString),
                 catalogNameUrls, role, SERVER_CACHE);
-        if (XmlUtil.supportsValidation()
-            // We can't validate against the schema when the content type
-            // is Data because it doesn't respect the XDS.
-            && !content.equals(XmlaConstants.Content.Data))
-        {
+        // We can't validate against the schema when the content type
+        // is Data because it doesn't respect the XDS.
+        if (content != XmlaConstants.Content.Data) {
             // Validating requires a <?xml header.
             String response = new String(bytes);
             if (!response.startsWith("<?xml version=\"1.0\"?>")) {
@@ -656,7 +654,7 @@ System.out.println("Got CONTINUE");
 
         validate(
             bytes, expectedDoc, testContext, replace,
-            content.equals(XmlaConstants.Content.Data) ? false : true);
+                content != XmlaConstants.Content.Data);
         Util.discard(entry);
     }
 

--- a/mondrian/src/main/java/mondrian/tui/XmlaSupport.java
+++ b/mondrian/src/main/java/mondrian/tui/XmlaSupport.java
@@ -4,7 +4,7 @@
 // http://www.eclipse.org/legal/epl-v10.html.
 // You must accept the terms of that agreement to use this software.
 //
-// Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
+// Copyright (c) 2002-2017 Pentaho Corporation..  All rights reserved.
 */
 package mondrian.tui;
 
@@ -1014,10 +1014,6 @@ public class XmlaSupport {
     public static boolean validateSoapXmlaUsingXpath(byte[] bytes)
             throws SAXException, IOException, XPathException
     {
-        if (! XmlUtil.supportsValidation()) {
-            return false;
-        }
-
         // Remove the UTF BOM for proper validation.
         bytes = removeUtfBom(bytes);
 
@@ -1071,10 +1067,6 @@ public class XmlaSupport {
     public static boolean validateXmlaUsingXpath(byte[] bytes)
             throws SAXException, IOException, XPathException
     {
-        if (! XmlUtil.supportsValidation()) {
-            return false;
-        }
-
         // Remove the UTF BOM for proper validation.
         bytes = removeUtfBom(bytes);
 
@@ -1092,9 +1084,6 @@ public class XmlaSupport {
     public static boolean validateNodes(Node[] nodes)
         throws SAXException, IOException
     {
-        if (! XmlUtil.supportsValidation()) {
-            return false;
-        }
         if (nodes.length == 0) {
             // no nodes
             return false;
@@ -1140,10 +1129,6 @@ public class XmlaSupport {
                ParserConfigurationException,
                TransformerException
     {
-        if (! XmlUtil.supportsValidation()) {
-            return false;
-        }
-
         Document doc = XmlUtil.parse(bytes);
         return validateEmbeddedSchema(doc, schemaTransform, dataTransform);
     }
@@ -1172,10 +1157,6 @@ public class XmlaSupport {
                ParserConfigurationException,
                TransformerException
     {
-        if (! XmlUtil.supportsValidation()) {
-            return false;
-        }
-
         Node dataDoc = XmlUtil.transform(
             doc,
             new BufferedReader(new StringReader(dataTransform)));

--- a/mondrian/src/main/java/mondrian/util/XmlParserFactoryProducer.java
+++ b/mondrian/src/main/java/mondrian/util/XmlParserFactoryProducer.java
@@ -5,7 +5,7 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2003-2005 Julian Hyde
-// Copyright (C) 2005-2016 Pentaho
+// Copyright (C) 2005-2017 Pentaho
 // All Rights Reserved.
 */
 package mondrian.util;
@@ -13,9 +13,6 @@ package mondrian.util;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
-import org.dom4j.io.SAXReader;
-import org.xml.sax.EntityResolver;
-import org.xml.sax.SAXException;
 import org.xml.sax.SAXNotRecognizedException;
 import org.xml.sax.SAXNotSupportedException;
 
@@ -78,24 +75,6 @@ public class XmlParserFactoryProducer {
         factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
         factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
         return factory;
-    }
-
-    public static SAXReader getSAXReader(final EntityResolver resolver) {
-        SAXReader reader = new SAXReader();
-        if (resolver != null) {
-            reader.setEntityResolver(resolver);
-        }
-        try {
-            reader.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-            reader.setFeature("http://xml.org/sax/features/external-general-entities", false);
-            reader.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-            reader.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
-        } catch (SAXException e) {
-            logger.error("Some parser properties are not supported.");
-        }
-        reader.setIncludeExternalDTDDeclarations(false);
-        reader.setIncludeInternalDTDDeclarations(false);
-        return reader;
     }
 }
 

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,63 @@
     <commons-lang.version>2.4</commons-lang.version>
     <xmlunit.version>1.1</xmlunit.version>
   </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>commons-dbcp</groupId>
+        <artifactId>commons-dbcp</artifactId>
+        <version>${commons-dbcp.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>xerces</groupId>
+            <artifactId>xercesImpl</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>xml-apis</groupId>
+            <artifactId>xml-apis</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>commons-pool</groupId>
+        <artifactId>commons-pool</artifactId>
+        <version>${commons-pool.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>xerces</groupId>
+            <artifactId>xercesImpl</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>xml-apis</groupId>
+            <artifactId>xml-apis</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>eigenbase</groupId>
+        <artifactId>eigenbase-xom</artifactId>
+        <version>${eigenbase-xom.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>xerces</groupId>
+            <artifactId>xercesImpl</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>eigenbase</groupId>
+        <artifactId>eigenbase-properties</artifactId>
+        <version>${eigenbase-properties.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>eigenbase</groupId>
+        <artifactId>eigenbase-resgen</artifactId>
+        <version>${eigenbase-resgen.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <profiles>
     <profile>
       <id>mondrian</id>


### PR DESCRIPTION
…1.0 -

CVE-2009-2625 and CVE-2013-4002
- removed xerces jars in order to switch to JRE bundled implementation
- replaced all explicit xerces calls with JAXP and DOM LS Specification use.
- checked source code of commons-dbcp and commons-pool of specified versions for explicit xerces usage - didn't find any - thus, excluded xerces for that dependencies.
- also excluded xerces for eigenbase-xom, since it is not "effectively" used there. XercesDOMParser is not used at code-generation, it is only used in tests.