### PR TITLE
[SP-3664]: Backport of ANALYZER-3433 - Drill through does not recognize level's nameColumn attribute (7.1 Suite)

### DIFF
--- a/mondrian/src/main/java/mondrian/rolap/RolapAggregationManager.java
+++ b/mondrian/src/main/java/mondrian/rolap/RolapAggregationManager.java
@@ -5,7 +5,7 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2001-2005 Julian Hyde
-// Copyright (C) 2005-2016 Pentaho and others
+// Copyright (C) 2005-2017 Pentaho and others
 // All Rights Reserved.
 //
 // jhyde, 30 August, 2001
@@ -466,6 +466,7 @@ public abstract class RolapAggregationManager {
                 final RolapStar.Column nameColumn = column.getNameColumn();
                 Util.assertTrue(nameColumn != null);
                 request.addConstrainedColumn(nameColumn, null);
+                ((DrillThroughCellRequest)request).addDrillThroughColumn(nameColumn);
             }
         }
     }


### PR DESCRIPTION
cherry-pick of the fix for [ANALYZER-3433]: Drill through does not recognize level's nameColumn attribute