### PR TITLE
Count distinct Bug in SQLMemberSource

### DIFF
--- a/mondrian/src/main/java/mondrian/rolap/SqlMemberSource.java
+++ b/mondrian/src/main/java/mondrian/rolap/SqlMemberSource.java
@@ -270,6 +270,7 @@ class SqlMemberSource
                     if (i > 0) {
                         sb.append(", ");
                     }
+                    i++;
                     sb.append(
                         sqlQuery.getDialect()
                             .generateCountExpression(colDef));


### PR DESCRIPTION
The separator "," was never added because the counter "i" was never incremented