### PR TITLE
[MONDRIAN-2575] Sql WHERE clause is missing predicates when aggregated calculated member crossjoined w/ SetToStr() and Filter()

### DIFF
--- a/mondrian/src/it/java/mondrian/test/NativeSetEvaluationTest.java
+++ b/mondrian/src/it/java/mondrian/test/NativeSetEvaluationTest.java
@@ -1791,7 +1791,26 @@ public class NativeSetEvaluationTest extends BatchTestCase {
       checkNative(mdx, result);
     }
 
-
+    public void testMondrian2575() {
+        assertQueriesReturnSimilarResults(
+                "WITH member [Customers].[AggregatePageMembers] AS \n" +
+                        "'Aggregate({[Customers].[USA].[CA].[Altadena].[Amy Petranoff], [Customers].[USA].[CA].[Altadena].[Arvid Duran]})'\n" +
+                        "member [Measures].[test set] AS \n" +
+                        "'SetToStr(Filter([Product].[Product Name].Members,[Measures].[Store Sales] > 0))'\n" +
+                        "SELECT {[Measures].[test set]} ON COLUMNS,\n" +
+                        "{[Product].[All Products], [Product].[All Products].Children} ON ROWS\n" +
+                        "FROM [Sales]\n" +
+                        "WHERE [Customers].[AggregatePageMembers]",
+                "WITH member [Customers].[AggregatePageMembers] AS \n" +
+                        "'Aggregate({[Customers].[USA].[CA].[Altadena].[Arvid Duran], [Customers].[USA].[CA].[Altadena].[Amy Petranoff]})'\n" +
+                        "member [Measures].[test set] AS \n" +
+                        "'SetToStr(Filter([Product].[Product Name].Members,[Measures].[Store Sales] > 0))'\n" +
+                        "SELECT {[Measures].[test set]} ON COLUMNS,\n" +
+                        "{[Product].[All Products], [Product].[All Products].Children} ON ROWS\n" +
+                        "FROM [Sales]\n" +
+                        "WHERE [Customers].[AggregatePageMembers]",
+                getTestContext().withFreshConnection());
+    }
 }
 
 // End NativeSetEvaluationTest.java

--- a/mondrian/src/main/java/mondrian/rolap/RolapResult.java
+++ b/mondrian/src/main/java/mondrian/rolap/RolapResult.java
@@ -5,7 +5,7 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2001-2005 Julian Hyde
-// Copyright (C) 2005-2016 Pentaho and others
+// Copyright (C) 2005-2017 Pentaho and others
 // All Rights Reserved.
 */
 package mondrian.rolap;
@@ -1298,6 +1298,7 @@ public class RolapResult extends ResultBase {
                     point.setAxis(axisOrdinal, tupleIndex);
                     final int savepoint = revaluator.savepoint();
                     try {
+                        revaluator.setEvalAxes( true );
                         revaluator.setContext(tuple);
                         execution.checkCancelOrTimeout();
                         executeStripe(axisOrdinal - 1, revaluator, pos);


### PR DESCRIPTION
- missed axes evaluation was set