### PR TITLE
[MONDRIAN-2408]: <Set> IIf(<Logical Expression>, <Set>, <Set>) confus…

### DIFF
--- a/mondrian/src/it/java/mondrian/olap/fun/FunctionTest.java
+++ b/mondrian/src/it/java/mondrian/olap/fun/FunctionTest.java
@@ -5,7 +5,7 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2003-2005 Julian Hyde
-// Copyright (C) 2005-2016 Pentaho and others
+// Copyright (C) 2005-2017 Pentaho and others
 // All Rights Reserved.
 */
 package mondrian.olap.fun;
@@ -5235,6 +5235,21 @@ public class FunctionTest extends FoodMartTestCase {
             "IIf(1 > 2, {[Store].[USA], [Store].[USA].[CA]}, {[Store].[Mexico], [Store].[USA].[OR]})",
             "[Store].[Mexico]\n"
             + "[Store].[USA].[OR]");
+    }
+
+    // MONDRIAN-2408 - Consumer wants ITERABLE or ANY in CrossJoinFunDef.compileCall(ResolvedFunCall, ExpCompiler)
+    public void testIIfSetType_InCrossJoin() {
+      assertAxisReturns(
+          "CROSSJOIN([Store Type].[Deluxe Supermarket],IIf(1 = 1, {[Store].[USA], [Store].[USA].[CA]}, {[Store].[Mexico], [Store].[USA].[OR]}))",
+          "{[Store Type].[Deluxe Supermarket], [Store].[USA]}\n"
+          + "{[Store Type].[Deluxe Supermarket], [Store].[USA].[CA]}");
+    }
+
+    //MONDRIAN-2408 - Consumer wants (immutable) LIST in CrossJoinFunDef.compileCall(ResolvedFunCall, ExpCompiler)
+    public void testIIfSetType_InCrossJoinAndAvg() {
+      assertExprReturns(
+          "Avg(CROSSJOIN([Store Type].[Deluxe Supermarket],IIf(1 = 1, {[Store].[USA].[OR], [Store].[USA].[WA]}, {[Store].[Mexico], [Store].[USA].[CA]})), [Measures].[Store Sales])",
+          "81,031.12");
     }
 
     public void testDimensionCaption() {

--- a/mondrian/src/it/java/mondrian/olap/fun/IifFunDefTest.java
+++ b/mondrian/src/it/java/mondrian/olap/fun/IifFunDefTest.java
@@ -1,0 +1,60 @@
+/*
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (c) 2002-2017 Pentaho Corporation..  All rights reserved.
+*/
+package mondrian.olap.fun;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import junit.framework.TestCase;
+import mondrian.calc.Calc;
+import mondrian.calc.ExpCompiler;
+import mondrian.calc.ResultStyle;
+import mondrian.mdx.ResolvedFunCall;
+import mondrian.olap.Exp;
+import mondrian.olap.FunDef;
+import mondrian.olap.fun.SetFunDef.SetListCalc;
+import mondrian.olap.type.SetType;
+
+public class IifFunDefTest extends TestCase {
+
+  private Exp logicalParamMock = mock( Exp.class );
+  private Exp trueCaseParamMock = mock( Exp.class );
+  private Exp falseCaseParamMock = mock( Exp.class );
+  private FunDef funDefMock = mock( FunDef.class );
+  private ExpCompiler compilerMock = mock( ExpCompiler.class );
+  private Exp[] args = new Exp[] { logicalParamMock, trueCaseParamMock, falseCaseParamMock };
+  private SetType setTypeMock = mock( SetType.class );
+  private SetListCalc setListCalc;
+  ResolvedFunCall call;
+
+  @Override
+  protected void setUp() throws Exception {
+    when( trueCaseParamMock.getType() ).thenReturn( setTypeMock );
+    setListCalc = new SetListCalc( trueCaseParamMock, new Exp[] { args[1] }, compilerMock, ResultStyle.LIST_MUTABLELIST );
+    call = new ResolvedFunCall( funDefMock, args, setTypeMock );
+    when( compilerMock.compileAs( any(), any(), any() ) ).thenReturn( setListCalc );
+  }
+
+  public void testGetResultType() {
+    ResultStyle actualResStyle = null;
+    ResultStyle expectedResStyle = setListCalc.getResultStyle();
+    // Compile calculation for IIf function for (<Logical Expression>, <SetType>, <SetType>) params
+    Calc calc = IifFunDef.SET_INSTANCE.compileCall( call, compilerMock );
+    try {
+      actualResStyle = calc.getResultStyle();
+    } catch ( Exception e ) {
+      fail( "Should not have thrown any exception." );
+    }
+    assertNotNull( actualResStyle );
+    assertEquals( expectedResStyle, actualResStyle );
+
+  }
+
+}

--- a/mondrian/src/it/java/mondrian/test/Main.java
+++ b/mondrian/src/it/java/mondrian/test/Main.java
@@ -149,6 +149,7 @@ public class Main extends TestSuite {
                 return suite;
             }
             addTest(suite, SqlConstraintUtilsTest.class);
+            addTest(suite, IifFunDefTest.class);
             addTest(suite, SegmentBuilderTest.class);
             addTest(suite, DenseDoubleSegmentBodyTest.class);
             addTest(suite, DenseIntSegmentBodyTest.class);

--- a/mondrian/src/main/java/mondrian/olap/fun/IifFunDef.java
+++ b/mondrian/src/main/java/mondrian/olap/fun/IifFunDef.java
@@ -4,7 +4,7 @@
 * http://www.eclipse.org/legal/epl-v10.html.
 * You must accept the terms of that agreement to use this software.
 *
-* Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+* Copyright (c) 2002-2017 Pentaho Corporation..  All rights reserved.
 */
 
 package mondrian.olap.fun;
@@ -84,6 +84,10 @@ public class IifFunDef extends FunDefBase {
                 public Calc[] getCalcs() {
                     return new Calc[] {booleanCalc, calc1, calc2};
                 }
+
+                public ResultStyle getResultStyle() {
+                    return calc1.getResultStyle();
+              }
             };
         } else {
             return new GenericCalc(call) {


### PR DESCRIPTION
…es mondrian into throwing ResultStyleException "Wanted ResultStyles: {LIST,MUTABLE_LIST} but got: VALUE"

GenericIterCalc that is used in Iif function for return type=SetType always returns ResultStyle.VALUE.

The fix is to get the correct ResultStyle for the function using the calculation of value parameters.
As Iif function takes the same types for second and third parameters (please see Iif function signature in http://mondrian.pentaho.com/documentation/mdx.php),
so we can use the any of them.