### PR TITLE
[SP-3751] - Backport of MONDRIAN-2253 - Pentaho analyzer is throwing …

### DIFF
--- a/mondrian/src/it/java/mondrian/test/DialectTest.java
+++ b/mondrian/src/it/java/mondrian/test/DialectTest.java
@@ -4,12 +4,13 @@
 // http://www.eclipse.org/legal/epl-v10.html.
 // You must accept the terms of that agreement to use this software.
 //
-// Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
+// Copyright (c) 2002-2017 Pentaho Corporation..  All rights reserved.
 */
 package mondrian.test;
 
 import mondrian.olap.*;
 import mondrian.rolap.*;
+import mondrian.rolap.sql.SqlQuery;
 import mondrian.spi.Dialect;
 import mondrian.spi.DialectManager;
 import mondrian.spi.impl.*;
@@ -24,6 +25,9 @@ import java.sql.Connection;
 import java.util.*;
 
 import javax.sql.DataSource;
+
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 /**
  * Unit test which checks that {@link mondrian.spi.Dialect}
@@ -1654,6 +1658,20 @@ public class DialectTest extends TestCase {
         public int getScale(int column) throws SQLException {
             return scale;
         }
+    }
+
+    public void testMondrian2253() throws SQLException {
+        String expected = "    1 ASC";
+        // "1" is supposed to be a column number
+        String expr = "1";
+        JdbcDialectImpl dialect = new VectorwiseDialect(getConnection());
+
+        SqlQuery query = new SqlQuery(dialect, true);
+        query.addOrderBy(
+            expr, null, true, false,
+            dialect.requiresUnionOrderByOrdinal(), true);
+
+        assertTrue(query.toString().contains(expected));
     }
 }
 

--- a/mondrian/src/main/java/mondrian/spi/impl/VectorwiseDialect.java
+++ b/mondrian/src/main/java/mondrian/spi/impl/VectorwiseDialect.java
@@ -1,12 +1,11 @@
 /*
-* This software is subject to the terms of the Eclipse Public License v1.0
-* Agreement, available at the following URL:
-* http://www.eclipse.org/legal/epl-v10.html.
-* You must accept the terms of that agreement to use this software.
-*
-* Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (c) 2002-2017 Pentaho Corporation..  All rights reserved.
 */
-
 package mondrian.spi.impl;
 
 import java.sql.Connection;
@@ -52,6 +51,11 @@ public class VectorwiseDialect extends IngresDialect {
     @Override
     public boolean requiresAliasForFromQuery() {
         return true;
+    }
+
+    @Override
+    public boolean requiresUnionOrderByOrdinal() {
+        return false;
     }
 }
 


### PR DESCRIPTION
…error when multiple shared dimensions are used in a virtual cube - Vectorwise DB (7.1 Suite)

@mchen-len-son, could you please take a look? 