### PR TITLE
[SP-3736]: Backport of MONDRIAN-2379 - Axes with empty sets cause NPE in XmlaHandler. (7.1 Suite)

### DIFF
--- a/mondrian/src/it/java/mondrian/xmla/XmlaBasicTest.java
+++ b/mondrian/src/it/java/mondrian/xmla/XmlaBasicTest.java
@@ -5,7 +5,7 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2002-2005 Julian Hyde
-// Copyright (C) 2005-2016 Pentaho and others
+// Copyright (C) 2005-2017 Pentaho and others
 // All Rights Reserved.
 */
 package mondrian.xmla;
@@ -997,6 +997,17 @@ public class XmlaBasicTest extends XmlaBaseTestCase {
         props.setProperty(DATA_SOURCE_INFO_PROP, DATA_SOURCE_INFO);
 
         doTest(requestType, props, testContext);
+    }
+
+    /**
+     * MONDRIAN-2379: "Axes with empty sets cause NPE in XmlaHandler"</a>.
+     * @throws Exception
+     */
+    public void testEmptySet() throws Exception {
+      TestContext context = getTestContext().withCube("Sales");
+      String requestType = "EXECUTE";
+      Properties props = getDefaultRequestProperties(requestType);
+      doTest(requestType, props, context);
     }
 
     private void doTestExecuteContent(

--- a/mondrian/src/it/java/mondrian/xmla/XmlaBasicTest.ref.xml
+++ b/mondrian/src/it/java/mondrian/xmla/XmlaBasicTest.ref.xml
@@ -24604,4 +24604,244 @@ select [Measures].[Unit Sales] on columns from [Sales]
 ]]>
         </Resource>
     </TestCase>
+    <TestCase name="testEmptySet">
+        <Resource name="response">
+            <![CDATA[<?xml version="1.0"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" >
+	<SOAP-ENV:Header>
+	</SOAP-ENV:Header>
+	<SOAP-ENV:Body>
+		<cxmla:ExecuteResponse xmlns:cxmla="urn:schemas-microsoft-com:xml-analysis">
+			<cxmla:return>
+				<root xmlns="urn:schemas-microsoft-com:xml-analysis:mddataset" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:EX="urn:schemas-microsoft-com:xml-analysis:exception">
+					<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:schemas-microsoft-com:xml-analysis:mddataset" xmlns="urn:schemas-microsoft-com:xml-analysis:mddataset" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:sql="urn:schemas-microsoft-com:xml-sql" elementFormDefault="qualified">
+						<xsd:complexType name="MemberType">
+							<xsd:sequence>
+								<xsd:element name="UName" type="xsd:string"/>
+								<xsd:element name="Caption" type="xsd:string"/>
+								<xsd:element name="LName" type="xsd:string"/>
+								<xsd:element name="LNum" type="xsd:unsignedInt"/>
+								<xsd:element name="DisplayInfo" type="xsd:unsignedInt"/>
+								<xsd:sequence maxOccurs="unbounded" minOccurs="0">
+									<xsd:any processContents="lax" maxOccurs="unbounded"/>
+								</xsd:sequence>
+							</xsd:sequence>
+							<xsd:attribute name="Hierarchy" type="xsd:string"/>
+						</xsd:complexType>
+						<xsd:complexType name="PropType">
+							<xsd:attribute name="name" type="xsd:string"/>
+						</xsd:complexType>
+						<xsd:complexType name="TupleType">
+							<xsd:sequence maxOccurs="unbounded">
+								<xsd:element name="Member" type="MemberType"/>
+							</xsd:sequence>
+						</xsd:complexType>
+						<xsd:complexType name="MembersType">
+							<xsd:sequence maxOccurs="unbounded">
+								<xsd:element name="Member" type="MemberType"/>
+							</xsd:sequence>
+							<xsd:attribute name="Hierarchy" type="xsd:string"/>
+						</xsd:complexType>
+						<xsd:complexType name="TuplesType">
+							<xsd:sequence maxOccurs="unbounded">
+								<xsd:element name="Tuple" type="TupleType"/>
+							</xsd:sequence>
+						</xsd:complexType>
+						<xsd:complexType name="CrossProductType">
+							<xsd:sequence>
+								<xsd:choice minOccurs="0" maxOccurs="unbounded">
+									<xsd:element name="Members" type="MembersType"/>
+									<xsd:element name="Tuples" type="TuplesType"/>
+								</xsd:choice>
+							</xsd:sequence>
+							<xsd:attribute name="Size" type="xsd:unsignedInt"/>
+						</xsd:complexType>
+						<xsd:complexType name="OlapInfo">
+							<xsd:sequence>
+								<xsd:element name="CubeInfo">
+									<xsd:complexType>
+										<xsd:sequence>
+											<xsd:element name="Cube" maxOccurs="unbounded">
+												<xsd:complexType>
+													<xsd:sequence>
+														<xsd:element name="CubeName" type="xsd:string"/>
+													</xsd:sequence>
+												</xsd:complexType>
+											</xsd:element>
+										</xsd:sequence>
+									</xsd:complexType>
+								</xsd:element>
+								<xsd:element name="AxesInfo">
+									<xsd:complexType>
+										<xsd:sequence>
+											<xsd:element name="AxisInfo" maxOccurs="unbounded">
+												<xsd:complexType>
+													<xsd:sequence>
+														<xsd:element name="HierarchyInfo" minOccurs="0" maxOccurs="unbounded">
+															<xsd:complexType>
+																<xsd:sequence>
+																	<xsd:sequence maxOccurs="unbounded">
+																		<xsd:element name="UName" type="PropType"/>
+																		<xsd:element name="Caption" type="PropType"/>
+																		<xsd:element name="LName" type="PropType"/>
+																		<xsd:element name="LNum" type="PropType"/>
+																		<xsd:element name="DisplayInfo" type="PropType" minOccurs="0" maxOccurs="unbounded"/>
+																	</xsd:sequence>
+																	<xsd:sequence>
+																		<xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+																	</xsd:sequence>
+																</xsd:sequence>
+																<xsd:attribute name="name" type="xsd:string" use="required"/>
+															</xsd:complexType>
+														</xsd:element>
+													</xsd:sequence>
+													<xsd:attribute name="name" type="xsd:string"/>
+												</xsd:complexType>
+											</xsd:element>
+										</xsd:sequence>
+									</xsd:complexType>
+								</xsd:element>
+								<xsd:element name="CellInfo">
+									<xsd:complexType>
+										<xsd:sequence>
+											<xsd:sequence minOccurs="0" maxOccurs="unbounded">
+												<xsd:choice>
+													<xsd:element name="Value" type="PropType"/>
+													<xsd:element name="FmtValue" type="PropType"/>
+													<xsd:element name="BackColor" type="PropType"/>
+													<xsd:element name="ForeColor" type="PropType"/>
+													<xsd:element name="FontName" type="PropType"/>
+													<xsd:element name="FontSize" type="PropType"/>
+													<xsd:element name="FontFlags" type="PropType"/>
+													<xsd:element name="FormatString" type="PropType"/>
+													<xsd:element name="NonEmptyBehavior" type="PropType"/>
+													<xsd:element name="SolveOrder" type="PropType"/>
+													<xsd:element name="Updateable" type="PropType"/>
+													<xsd:element name="Visible" type="PropType"/>
+													<xsd:element name="Expression" type="PropType"/>
+												</xsd:choice>
+											</xsd:sequence>
+											<xsd:sequence maxOccurs="unbounded" minOccurs="0">
+												<xsd:any processContents="lax" maxOccurs="unbounded"/>
+											</xsd:sequence>
+										</xsd:sequence>
+									</xsd:complexType>
+								</xsd:element>
+							</xsd:sequence>
+						</xsd:complexType>
+						<xsd:complexType name="Axes">
+							<xsd:sequence maxOccurs="unbounded">
+								<xsd:element name="Axis">
+									<xsd:complexType>
+										<xsd:choice minOccurs="0" maxOccurs="unbounded">
+											<xsd:element name="CrossProduct" type="CrossProductType"/>
+											<xsd:element name="Tuples" type="TuplesType"/>
+											<xsd:element name="Members" type="MembersType"/>
+										</xsd:choice>
+										<xsd:attribute name="name" type="xsd:string"/>
+									</xsd:complexType>
+								</xsd:element>
+							</xsd:sequence>
+						</xsd:complexType>
+						<xsd:complexType name="CellData">
+							<xsd:sequence>
+								<xsd:element name="Cell" minOccurs="0" maxOccurs="unbounded">
+									<xsd:complexType>
+										<xsd:sequence maxOccurs="unbounded">
+											<xsd:choice>
+												<xsd:element name="Value"/>
+												<xsd:element name="FmtValue" type="xsd:string"/>
+												<xsd:element name="BackColor" type="xsd:unsignedInt"/>
+												<xsd:element name="ForeColor" type="xsd:unsignedInt"/>
+												<xsd:element name="FontName" type="xsd:string"/>
+												<xsd:element name="FontSize" type="xsd:unsignedShort"/>
+												<xsd:element name="FontFlags" type="xsd:unsignedInt"/>
+												<xsd:element name="FormatString" type="xsd:string"/>
+												<xsd:element name="NonEmptyBehavior" type="xsd:unsignedShort"/>
+												<xsd:element name="SolveOrder" type="xsd:unsignedInt"/>
+												<xsd:element name="Updateable" type="xsd:unsignedInt"/>
+												<xsd:element name="Visible" type="xsd:unsignedInt"/>
+												<xsd:element name="Expression" type="xsd:string"/>
+											</xsd:choice>
+										</xsd:sequence>
+										<xsd:attribute name="CellOrdinal" type="xsd:unsignedInt" use="required"/>
+									</xsd:complexType>
+								</xsd:element>
+							</xsd:sequence>
+						</xsd:complexType>
+						<xsd:element name="root">
+							<xsd:complexType>
+								<xsd:sequence maxOccurs="unbounded">
+									<xsd:element name="OlapInfo" type="OlapInfo"/>
+									<xsd:element name="Axes" type="Axes"/>
+									<xsd:element name="CellData" type="CellData"/>
+								</xsd:sequence>
+							</xsd:complexType>
+						</xsd:element>
+					</xsd:schema>
+					<OlapInfo>
+						<CubeInfo>
+							<Cube>
+								<CubeName>Sales</CubeName>
+							</Cube>
+						</CubeInfo>
+						<AxesInfo>
+							<AxisInfo name="Axis0"/>
+							<AxisInfo name="SlicerAxis"/>
+						</AxesInfo>
+						<CellInfo>
+							<Value name="VALUE"/>
+							<FmtValue name="FORMATTED_VALUE"/>
+							<FormatString name="FORMAT_STRING"/>
+						</CellInfo>
+					</OlapInfo>
+					<Axes>
+						<Axis name="Axis0">
+							<Tuples/>
+						</Axis>
+						<Axis name="SlicerAxis">
+							<Tuples>
+								<Tuple/>
+							</Tuples>
+						</Axis>
+					</Axes>
+					<CellData/>
+				</root>
+			</cxmla:return>
+		</cxmla:ExecuteResponse>
+	</SOAP-ENV:Body>
+</SOAP-ENV:Envelope>
+]]>
+        </Resource>
+        <Resource name="request">
+            <![CDATA[
+<soapenv:Envelope
+    xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <soapenv:Body>
+        <Execute xmlns="urn:schemas-microsoft-com:xml-analysis">
+        <Command>
+        <Statement>
+           SELECT {} ON COLUMNS FROM Sales
+         </Statement>
+        </Command>
+        <Restrictions>
+          <RestrictionList>
+            <CATALOG_NAME>${catalog}</CATALOG_NAME>
+          </RestrictionList>
+        </Restrictions>
+        <Properties>
+          <PropertyList>
+            <DataSourceInfo>${data.source.info}</DataSourceInfo>
+            <Format>${format}</Format>
+            <AxisFormat>TupleFormat</AxisFormat>
+          </PropertyList>
+        </Properties>
+</Execute>
+</soapenv:Body>
+</soapenv:Envelope>
+]]>
+        </Resource>
+    </TestCase>
 </Root>

--- a/mondrian/src/main/java/mondrian/olap/type/TypeUtil.java
+++ b/mondrian/src/main/java/mondrian/olap/type/TypeUtil.java
@@ -5,10 +5,9 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2005-2005 Julian Hyde
-// Copyright (C) 2005-2013 Pentaho
+// Copyright (C) 2005-2017 Pentaho
 // All Rights Reserved.
 */
-
 package mondrian.olap.type;
 
 import mondrian.mdx.UnresolvedFunCall;
@@ -513,7 +512,10 @@ public class TypeUtil {
             }
             return hierarchyList;
         } else {
-            return Collections.singletonList(type.getHierarchy());
+            Hierarchy hierarchy = type.getHierarchy();
+            return hierarchy == null
+                ? Collections.<Hierarchy>emptyList()
+                : Collections.singletonList(hierarchy);
         }
     }
 


### PR DESCRIPTION
This is the cherry-pick of the fix for [MONDRIAN-2379]: Axes with empty sets cause NPE in XmlaHandler.

Used the origin commit: https://github.com/pentaho/mondrian/pull/256/commits/10f4a562985cdc467e14c24a6199c30194baeb47
Changed the unit test to get exactly described in the issue NPE.