### PR TITLE
[SP-3741]: Backport of MONDRIAN-2408 - <Set> IIf(<Logical Expression>…

### DIFF
--- a/src/main/mondrian/olap/fun/IifFunDef.java
+++ b/src/main/mondrian/olap/fun/IifFunDef.java
@@ -4,7 +4,7 @@
 * http://www.eclipse.org/legal/epl-v10.html.
 * You must accept the terms of that agreement to use this software.
 *
-* Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+* Copyright (c) 2002-2017 Pentaho Corporation..  All rights reserved.
 */
 
 package mondrian.olap.fun;
@@ -84,6 +84,10 @@ public class IifFunDef extends FunDefBase {
                 public Calc[] getCalcs() {
                     return new Calc[] {booleanCalc, calc1, calc2};
                 }
+
+                public ResultStyle getResultStyle() {
+                    return calc1.getResultStyle();
+              }
             };
         } else {
             return new GenericCalc(call) {

--- a/testsrc/main/mondrian/olap/fun/FunctionTest.java
+++ b/testsrc/main/mondrian/olap/fun/FunctionTest.java
@@ -5,7 +5,7 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2003-2005 Julian Hyde
-// Copyright (C) 2005-2016 Pentaho and others
+// Copyright (C) 2005-2017 Pentaho and others
 // All Rights Reserved.
 */
 package mondrian.olap.fun;
@@ -5235,6 +5235,21 @@ public class FunctionTest extends FoodMartTestCase {
             "IIf(1 > 2, {[Store].[USA], [Store].[USA].[CA]}, {[Store].[Mexico], [Store].[USA].[OR]})",
             "[Store].[Mexico]\n"
             + "[Store].[USA].[OR]");
+    }
+
+    // MONDRIAN-2408 - Consumer wants ITERABLE or ANY in CrossJoinFunDef.compileCall(ResolvedFunCall, ExpCompiler)
+    public void testIIfSetType_InCrossJoin() {
+      assertAxisReturns(
+          "CROSSJOIN([Store Type].[Deluxe Supermarket],IIf(1 = 1, {[Store].[USA], [Store].[USA].[CA]}, {[Store].[Mexico], [Store].[USA].[OR]}))",
+          "{[Store Type].[Deluxe Supermarket], [Store].[USA]}\n"
+          + "{[Store Type].[Deluxe Supermarket], [Store].[USA].[CA]}");
+    }
+
+    //MONDRIAN-2408 - Consumer wants (immutable) LIST in CrossJoinFunDef.compileCall(ResolvedFunCall, ExpCompiler)
+    public void testIIfSetType_InCrossJoinAndAvg() {
+      assertExprReturns(
+          "Avg(CROSSJOIN([Store Type].[Deluxe Supermarket],IIf(1 = 1, {[Store].[USA].[OR], [Store].[USA].[WA]}, {[Store].[Mexico], [Store].[USA].[CA]})), [Measures].[Store Sales])",
+          "81,031.12");
     }
 
     public void testDimensionCaption() {


### PR DESCRIPTION
…, <Set>, <Set>) confuses mondrian into throwing ResultStyleException "Wanted ResultStyles: {LIST,MUTABLE_LIST} but got: VALUE" (6.1 Suite)

This is the cherry-pick of the fix for [MONDRIAN-2408]: <Set> IIf(<Logical Expression>, <Set>, <Set>) confuses mondrian into throwing ResultStyleException "Wanted ResultStyles: {LIST,MUTABLE_LIST} but got: VALUE"

GenericIterCalc that is used in Iif function for return type=SetType always returns ResultStyle.VALUE.

The fix is to get the correct ResultStyle for the function using the calculation of value parameters.
As Iif function takes the same types for second and third parameters (please see Iif function signature in http://mondrian.pentaho.com/documentation/mdx.php),
so we can use the any of them.

Added unit tests to cover cases like in the issue.