### PR TITLE
[ANALYZER-3488]: Unable to do case insensitive search with multi-byte…

### DIFF
--- a/mondrian/src/it/java/mondrian/spi/DialectUtilTest.java
+++ b/mondrian/src/it/java/mondrian/spi/DialectUtilTest.java
@@ -1,0 +1,37 @@
+/*
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (c) 2015-2017 Pentaho Corporation.
+// All rights reserved.
+ */
+package mondrian.spi;
+
+import junit.framework.TestCase;
+
+public class DialectUtilTest extends TestCase {
+
+  public void testCleanUnicodeAwareCaseFlag_InputNull() {
+    String inputExpression = null;
+    String cleaned = DialectUtil.cleanUnicodeAwareCaseFlag( inputExpression );
+    assertNull( cleaned );
+  }
+
+  public void testCleanUnicodeAwareCaseFlag_InputContainsFlag() {
+    String inputExpression = "(?i)|(?u).*ａ.*";
+    String expectedExpression = "(?i).*ａ.*";
+    String cleaned = DialectUtil.cleanUnicodeAwareCaseFlag( inputExpression );
+    assertEquals( expectedExpression, cleaned );
+  }
+
+  public void testCleanUnicodeAwareCaseFlag_InputNotContainsFlag() {
+    String inputExpression = "(?i).*ａ.*";
+    String expectedExpression = "(?i).*ａ.*";
+    String cleaned = DialectUtil.cleanUnicodeAwareCaseFlag( inputExpression );
+    assertEquals( expectedExpression, cleaned );
+  }
+
+}
+//End DialectUtilTest.java

--- a/mondrian/src/it/java/mondrian/spi/impl/JdbcDialectImplTest.java
+++ b/mondrian/src/it/java/mondrian/spi/impl/JdbcDialectImplTest.java
@@ -1,0 +1,26 @@
+/*
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (c) 2015-2017 Pentaho Corporation.
+// All rights reserved.
+ */
+package mondrian.spi.impl;
+
+import junit.framework.TestCase;
+
+public class JdbcDialectImplTest extends TestCase {
+  private JdbcDialectImpl jdbcDialect = new JdbcDialectImpl();
+
+  public void testAllowsRegularExpressionInWhereClause() {
+    assertFalse( jdbcDialect.allowsRegularExpressionInWhereClause() );
+  }
+
+  public void testGenerateRegularExpression() {
+    assertNull( jdbcDialect.generateRegularExpression( null, null ) );
+  }
+
+}
+//End JdbcDialectImplTest.java

--- a/mondrian/src/it/java/mondrian/spi/impl/MySqlDialectTest.java
+++ b/mondrian/src/it/java/mondrian/spi/impl/MySqlDialectTest.java
@@ -1,0 +1,58 @@
+/*
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (c) 2015-2017 Pentaho Corporation.
+// All rights reserved.
+ */
+package mondrian.spi.impl;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+
+import com.mysql.jdbc.Statement;
+
+import junit.framework.TestCase;
+import mondrian.spi.Dialect;
+
+public class MySqlDialectTest extends TestCase {
+  private Connection connection = mock( Connection.class );
+  private DatabaseMetaData metaData = mock( DatabaseMetaData.class );
+  Statement statmentMock = mock( Statement.class );
+  private MySqlDialect dialect;
+
+  @Override
+  protected void setUp() throws Exception {
+    when( metaData.getDatabaseProductName() ).thenReturn( Dialect.DatabaseProduct.MYSQL.name() );
+    when( metaData.getDatabaseProductVersion() ).thenReturn( "5.0" );
+    when( statmentMock.execute( any() ) ).thenReturn( false );
+    when( connection.getMetaData() ).thenReturn( metaData );
+    when( connection.createStatement() ).thenReturn( statmentMock );
+    dialect = new MySqlDialect( connection );
+  }
+
+  public void testAllowsRegularExpressionInWhereClause() {
+    assertTrue( dialect.allowsRegularExpressionInWhereClause() );
+  }
+
+  public void testGenerateRegularExpression_InvalidRegex() throws Exception {
+    assertNull( "Invalid regex should be ignored", dialect.generateRegularExpression( "table.column", "(a" ) );
+  }
+
+  public void testGenerateRegularExpression_CaseInsensitive() throws Exception {
+    String sql = dialect.generateRegularExpression( "table.column", "(?i)|(?u).*a.*" );
+    assertEquals( "table.column IS NOT NULL AND UPPER(table.column) REGEXP '.*A.*'", sql );
+  }
+
+  public void testGenerateRegularExpression_CaseSensitive() throws Exception {
+    String sql = dialect.generateRegularExpression( "table.column", ".*a.*" );
+    assertEquals( "table.column IS NOT NULL AND table.column REGEXP '.*a.*'", sql );
+  }
+}
+//End MySqlDialectTest.java

--- a/mondrian/src/it/java/mondrian/spi/impl/OracleDialectTest.java
+++ b/mondrian/src/it/java/mondrian/spi/impl/OracleDialectTest.java
@@ -1,0 +1,54 @@
+/*
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (c) 2015-2017 Pentaho Corporation.
+// All rights reserved.
+ */
+package mondrian.spi.impl;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+
+import com.mysql.jdbc.Statement;
+
+import junit.framework.TestCase;
+import mondrian.spi.Dialect;
+
+public class OracleDialectTest extends TestCase {
+  private Connection connection = mock( Connection.class );
+  private DatabaseMetaData metaData = mock( DatabaseMetaData.class );
+  Statement statmentMock = mock( Statement.class );
+  private OracleDialect dialect;
+
+  @Override
+  protected void setUp() throws Exception {
+    when( metaData.getDatabaseProductName() ).thenReturn( Dialect.DatabaseProduct.ORACLE.name() );
+    when( connection.getMetaData() ).thenReturn( metaData );
+    dialect = new OracleDialect( connection );
+  }
+
+  public void testAllowsRegularExpressionInWhereClause() {
+    assertTrue( dialect.allowsRegularExpressionInWhereClause() );
+  }
+
+  public void testGenerateRegularExpression_InvalidRegex() throws Exception {
+    assertNull( "Invalid regex should be ignored", dialect.generateRegularExpression( "table.column", "(a" ) );
+  }
+
+  public void testGenerateRegularExpression_CaseInsensitive() throws Exception {
+    String sql = dialect.generateRegularExpression( "table.column", "(?i)|(?u).*a.*" );
+    assertEquals( "table.column IS NOT NULL AND REGEXP_LIKE(table.column, '.*a.*', 'i')", sql );
+  }
+
+  public void testGenerateRegularExpression_CaseSensitive() throws Exception {
+    String sql = dialect.generateRegularExpression( "table.column", ".*a.*" );
+    assertEquals( "table.column IS NOT NULL AND REGEXP_LIKE(table.column, '.*a.*', '')", sql );
+  }
+}
+//End OracleDialectTest.java

--- a/mondrian/src/it/java/mondrian/spi/impl/PostgreSqlDialectTest.java
+++ b/mondrian/src/it/java/mondrian/spi/impl/PostgreSqlDialectTest.java
@@ -1,0 +1,55 @@
+/*
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (c) 2015-2017 Pentaho Corporation.
+// All rights reserved.
+ */
+package mondrian.spi.impl;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+
+import com.mysql.jdbc.Statement;
+
+import junit.framework.TestCase;
+import mondrian.spi.Dialect;
+
+public class PostgreSqlDialectTest extends TestCase {
+  private Connection connection = mock( Connection.class );
+  private DatabaseMetaData metaData = mock( DatabaseMetaData.class );
+  Statement statmentMock = mock( Statement.class );
+  private PostgreSqlDialect dialect;
+
+  @Override
+  protected void setUp() throws Exception {
+    when( metaData.getDatabaseProductName() ).thenReturn( Dialect.DatabaseProduct.POSTGRESQL.name() );
+    when( connection.getMetaData() ).thenReturn( metaData );
+    dialect = new PostgreSqlDialect( connection );
+  }
+
+  public void testAllowsRegularExpressionInWhereClause() {
+    assertTrue( dialect.allowsRegularExpressionInWhereClause() );
+  }
+
+  public void testGenerateRegularExpression_InvalidRegex() throws Exception {
+    assertNull( "Invalid regex should be ignored", dialect.generateRegularExpression( "table.column", "(a" ) );
+  }
+
+  public void testGenerateRegularExpression_CaseInsensitive() throws Exception {
+    String sql = dialect.generateRegularExpression( "table.column", "(?i)|(?u).*a.*" );
+    assertEquals( "cast(table.column as text) is not null and cast(table.column as text) ~ '(?i).*a.*'", sql );
+  }
+
+  public void testGenerateRegularExpression_CaseSensitive() throws Exception {
+    String sql = dialect.generateRegularExpression( "table.column", ".*a.*" );
+    assertEquals( "cast(table.column as text) is not null and cast(table.column as text) ~ '.*a.*'", sql );
+  }
+
+}
+//End PostgreSqlDialectTest.java

--- a/mondrian/src/main/java/mondrian/spi/DialectUtil.java
+++ b/mondrian/src/main/java/mondrian/spi/DialectUtil.java
@@ -1,0 +1,40 @@
+/*
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (c) 2015-2017 Pentaho Corporation.
+// All rights reserved.
+ */
+package mondrian.spi;
+
+import java.util.regex.Pattern;
+
+public class DialectUtil {
+
+  private static final Pattern UNICODE_CASE_FLAG_IN_JAVA_REG_EXP_PATTERN = Pattern.compile( "\\|\\(\\?u\\)" );
+  private static final String EMPTY = "";
+
+  /**
+   * Cleans up the reqular expression from the unicode-aware case folding embedded flag expression (?u)
+   *
+   * @param javaRegExp
+   *          the regular expression to clean up
+   * @return the cleaned regular expression
+   */
+  public static String cleanUnicodeAwareCaseFlag( String javaRegExp ) {
+    String cleaned = javaRegExp;
+    if ( cleaned != null && isUnicodeCaseFlagInRegExp( cleaned ) ) {
+      cleaned = UNICODE_CASE_FLAG_IN_JAVA_REG_EXP_PATTERN.matcher( cleaned ).replaceAll( EMPTY );
+    }
+    return cleaned;
+  }
+
+  private static boolean isUnicodeCaseFlagInRegExp( String javaRegExp ) {
+    return UNICODE_CASE_FLAG_IN_JAVA_REG_EXP_PATTERN.matcher( javaRegExp ).find();
+  }
+
+}
+
+//End DialectUtil.java

--- a/src/main/mondrian/spi/impl/ImpalaDialect.java
+++ b/src/main/mondrian/spi/impl/ImpalaDialect.java
@@ -15,6 +15,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
+import mondrian.spi.DialectUtil;
+
 /**
  * Dialect for Cloudera's Impala DB.
  *
@@ -176,7 +178,7 @@ public class ImpalaDialect extends HiveDialect {
             // Not a valid Java regex. Too risky to continue.
             return null;
         }
-
+        javaRegex = DialectUtil.cleanUnicodeAwareCaseFlag(javaRegex);
         // We might have to use case-insensitive matching
         final Matcher flagsMatcher = flagsPattern.matcher(javaRegex);
         boolean caseSensitive = true;

--- a/src/main/mondrian/spi/impl/MySqlDialect.java
+++ b/src/main/mondrian/spi/impl/MySqlDialect.java
@@ -10,6 +10,7 @@
 package mondrian.spi.impl;
 
 import mondrian.olap.Util;
+import mondrian.spi.DialectUtil;
 
 import java.sql.*;
 import java.util.List;
@@ -288,6 +289,7 @@ public class MySqlDialect extends JdbcDialectImpl {
         }
 
         // We might have to use case-insensitive matching
+        javaRegex = DialectUtil.cleanUnicodeAwareCaseFlag(javaRegex);
         final Matcher flagsMatcher = flagsPattern.matcher(javaRegex);
         boolean caseSensitive = true;
         if (flagsMatcher.matches()) {

--- a/src/main/mondrian/spi/impl/OracleDialect.java
+++ b/src/main/mondrian/spi/impl/OracleDialect.java
@@ -9,6 +9,7 @@
 package mondrian.spi.impl;
 
 import mondrian.rolap.SqlStatement;
+import mondrian.spi.DialectUtil;
 
 import java.sql.*;
 import java.util.List;
@@ -92,6 +93,7 @@ public class OracleDialect extends JdbcDialectImpl {
             // Not a valid Java regex. Too risky to continue.
             return null;
         }
+        javaRegex = DialectUtil.cleanUnicodeAwareCaseFlag(javaRegex);
         final Matcher flagsMatcher = flagsPattern.matcher(javaRegex);
         final String suffix;
         if (flagsMatcher.matches()) {

--- a/src/main/mondrian/spi/impl/PostgreSqlDialect.java
+++ b/src/main/mondrian/spi/impl/PostgreSqlDialect.java
@@ -10,6 +10,7 @@
 package mondrian.spi.impl;
 
 import mondrian.rolap.SqlStatement;
+import mondrian.spi.DialectUtil;
 
 import java.sql.*;
 import java.util.regex.Pattern;
@@ -88,6 +89,7 @@ public class PostgreSqlDialect extends JdbcDialectImpl {
             // Not a valid Java regex. Too risky to continue.
             return null;
         }
+        javaRegex = DialectUtil.cleanUnicodeAwareCaseFlag(javaRegex);
         javaRegex = javaRegex.replace("\\Q", "");
         javaRegex = javaRegex.replace("\\E", "");
         final StringBuilder sb = new StringBuilder();

--- a/testsrc/main/mondrian/test/Main.java
+++ b/testsrc/main/mondrian/test/Main.java
@@ -24,7 +24,12 @@ import mondrian.rolap.agg.*;
 import mondrian.rolap.aggmatcher.*;
 import mondrian.rolap.sql.*;
 import mondrian.server.FileRepositoryTest;
+import mondrian.spi.DialectUtilTest;
 import mondrian.spi.impl.ImpalaDialectTest;
+import mondrian.spi.impl.JdbcDialectImplTest;
+import mondrian.spi.impl.MySqlDialectTest;
+import mondrian.spi.impl.OracleDialectTest;
+import mondrian.spi.impl.PostgreSqlDialectTest;
 import mondrian.spi.impl.SybaseDialectTest;
 import mondrian.test.build.CodeComplianceTest;
 import mondrian.test.clearview.*;
@@ -43,7 +48,6 @@ import junit.framework.*;
 
 import org.apache.log4j.Logger;
 
-import java.io.PrintWriter;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Enumeration;
@@ -358,8 +362,13 @@ public class Main extends TestSuite {
             addTest(suite, XmlaExtraTest.class);
             addTest(suite, CrossJoinArgFactoryTest.class);
             addTest(suite, UnionFunDefTest.class);
+            addTest(suite, JdbcDialectImplTest.class);
             addTest(suite, ImpalaDialectTest.class);
             addTest(suite, SybaseDialectTest.class);
+            addTest(suite, PostgreSqlDialectTest.class);
+            addTest(suite, OracleDialectTest.class);
+            addTest(suite, MySqlDialectTest.class);
+            addTest(suite, DialectUtilTest.class);
             addTest(suite, IdBatchResolverTest.class);
             addTest(suite, MemberCacheHelperTest.class);
             addTest(suite, EffectiveMemberCacheTest.class);


### PR DESCRIPTION
… characters in filter dialog and using the Matches operator

The problem:
The fix: https://github.com/pentaho/pentaho-analyzer/commit/021a081d26fc51e13753ae5210073f38d5519b2d was not completed in full.
It covers the DBs that are not supported native evalution of the Matches MDX function.
In this case mondrian uses Java regex engine to evaluate matching.
By default, case-insensitive matching assumes that only characters in the US-ASCII charset are being matched (Please see https://docs.oracle.com/javase/7/docs/api/java/util/regex/Pattern.html#UNICODE_CASE).
So it was added (?u) flag to allow unicode-aware case folding for Java regex engine. Please see details in https://github.com/pentaho/pentaho-analyzer/commit/021a081d26fc51e13753ae5210073f38d5519b2d.

But we have also BDs with implemented support of native evalution of the Matches MDX function (was introduced in MONDRIAN-944).
None of them does not support (?u) flag. And moreove this flag doesn't need for them.
So the fix is just to clean up the expression from this (?u) flag.
Also added unit tests for all DB dialects with native support of regular expression.