### PR TITLE
[MONDRIAN-2402]: Mondrian incorrectly resolves <String> Generate(<Set>, <String>, <String>) to <Set> Generate(<Set>, <Set>, <Symbol>)

### DIFF
--- a/mondrian/src/it/java/mondrian/olap/fun/FunctionTest.java
+++ b/mondrian/src/it/java/mondrian/olap/fun/FunctionTest.java
@@ -6970,6 +6970,28 @@ public class FunctionTest extends FoodMartTestCase {
         fail("should have timed out");
     }
 
+    //The test case for the issue: MONDRIAN-2402
+    public void testGenerateForStringMemberProperty() {
+      assertQueryReturns(
+          "WITH MEMBER [Store].[Lineage of Time] AS\n"
+          + " Generate(Ascendants([Time].CurrentMember), [Time].CurrentMember.Properties(\"MEMBER_CAPTION\"), \",\")\n"
+          + " SELECT\n"
+          + "  {[Time].[1997]} ON Axis(0),\n"
+          + "  Union(\n"
+          + "   {([Store].[Lineage of Time])},\n"
+          + "   {[Store].[All Stores]}) ON Axis(1)\n"
+          + " FROM [Sales]\n",
+          "Axis #0:\n"
+          + "{}\n"
+          + "Axis #1:\n"
+          + "{[Time].[1997]}\n"
+          + "Axis #2:\n"
+          + "{[Store].[Lineage of Time]}\n"
+          + "{[Store].[All Stores]}\n"
+          + "Row #0: 1997\n"
+          + "Row #1: 266,773\n");
+    }
+
     public void testFilterWillTimeout() {
         propSaver.set(propSaver.properties.QueryTimeout, 3);
         propSaver.set(propSaver.properties.EnableNativeNonEmpty, false);

--- a/mondrian/src/it/java/mondrian/olap/fun/PropertiesFunctionTest.java
+++ b/mondrian/src/it/java/mondrian/olap/fun/PropertiesFunctionTest.java
@@ -1,0 +1,146 @@
+/*
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (c) 2015-2017 Pentaho Corporation.
+// All rights reserved.
+ */
+package mondrian.olap.fun;
+
+import mondrian.olap.Category;
+import mondrian.olap.Connection;
+import mondrian.olap.Exp;
+import mondrian.olap.MondrianException;
+import mondrian.olap.Query;
+import mondrian.olap.Result;
+import mondrian.olap.type.StringType;
+import mondrian.olap.type.Type;
+import mondrian.test.FoodMartTestCase;
+
+public class PropertiesFunctionTest extends FoodMartTestCase {
+
+  private static final String TIME_MEMBER_CAPTION = "1997";
+  private static final String TIME_WEEKLY_MEMBER_CAPTION = "All Time.Weeklys";
+  private static final String STORE_MEMBER_CAPTION = "All Stores";
+  private static final int[] ZERO_POS = new int[] { 0 };
+  private Query query;
+  private Result result;
+  private Connection connection;
+  private Exp resolvedFun;
+  private static final StringType STRING_TYPE = new StringType();
+
+  @Override
+  protected void setUp() throws Exception {
+    connection = getConnection();
+    query = null;
+    result = null;
+    resolvedFun = null;
+  }
+
+  // The "Time" dimention in foodmart schema contains two hierarchies.
+  // The first hierarchy doesn't have a name. By default, a hierarchy has the same name as its dimension, so the first
+  // hierarchy is called "Time".
+  // Below the tests for the "Time" hierarchy and dimention.
+  public void testMemberCaptionPropertyOnTimeDimension() {
+    verifyMemberCaptionPropertyFunction( "[Time].Properties('MEMBER_CAPTION')", Category.String, STRING_TYPE, TIME_MEMBER_CAPTION );
+  }
+
+  public void testCurrentMemberCaptionPropertyOnTimeDimension() {
+    verifyMemberCaptionPropertyFunction( "[Time].CurrentMember.Properties('MEMBER_CAPTION')", Category.String, STRING_TYPE, TIME_MEMBER_CAPTION );
+  }
+
+  public void testMemberCaptionPropertyOnTimeHierarchy() {
+    verifyMemberCaptionPropertyFunction( "[Time].[Time].Properties('MEMBER_CAPTION')", Category.String, STRING_TYPE, TIME_MEMBER_CAPTION );
+  }
+
+  public void testCurrentMemberCaptionPropertyOnTimeHierarchy() {
+    verifyMemberCaptionPropertyFunction( "[Time].[Time].CurrentMember.Properties('MEMBER_CAPTION')", Category.String, STRING_TYPE, TIME_MEMBER_CAPTION );
+  }
+
+  public void testGenerateWithMemberCaptionPropertyOnTimeDimension() {
+    verifyGenerateWithMemberCaptionPropertyFunction( "Generate([Time].CurrentMember, [Time].CurrentMember.Properties('MEMBER_CAPTION'))", Category.String, STRING_TYPE, TIME_MEMBER_CAPTION );
+  }
+
+  public void testGenerateWithMemberCaptionPropertyOnTimeHierarchy() {
+    verifyGenerateWithMemberCaptionPropertyFunction( "Generate([Time].CurrentMember, [Time].[Time].CurrentMember.Properties('MEMBER_CAPTION'))", Category.String, STRING_TYPE, TIME_MEMBER_CAPTION );
+  }
+
+  // Below the tests for the "Time.Weekly" hierarchy.
+  public void testMemberCaptionPropertyOnWeeklyHierarchy() {
+    verifyMemberCaptionPropertyFunction( "[Time.Weekly].Properties('MEMBER_CAPTION')", Category.String, STRING_TYPE, TIME_WEEKLY_MEMBER_CAPTION );
+  }
+
+  public void testCurrentMemberCaptionPropertyOnWeeklyHierarchy() {
+    verifyMemberCaptionPropertyFunction( "[Time.Weekly].CurrentMember.Properties('MEMBER_CAPTION')", Category.String, STRING_TYPE, TIME_WEEKLY_MEMBER_CAPTION );
+  }
+
+  public void testGenerateWithMemberCaptionPropertyOnWeeklyHierarchy() {
+    verifyGenerateWithMemberCaptionPropertyFunction( "Generate([Time.Weekly].CurrentMember, [Time.Weekly].CurrentMember.Properties('MEMBER_CAPTION'))", Category.String, STRING_TYPE, TIME_WEEKLY_MEMBER_CAPTION );
+  }
+
+  // The "Store" dimention in foodmart schema contains only one hierarchy that has no name. So its name is "Store".
+  // Below the tests for the "Store" hierarchy and dimention.
+  public void testMemberCaptionPropertyOnStoreDimension() {
+    verifyMemberCaptionPropertyFunction( "[Store].Properties('MEMBER_CAPTION')", Category.String, STRING_TYPE, STORE_MEMBER_CAPTION );
+  }
+
+  public void testCurrentMemberCaptionPropertyOnStoreDimension() {
+    verifyMemberCaptionPropertyFunction( "[Store].CurrentMember.Properties('MEMBER_CAPTION')", Category.String, STRING_TYPE, STORE_MEMBER_CAPTION );
+  }
+
+  public void testMemberCaptionPropertyOnStoreHierarchy() {
+    verifyMemberCaptionPropertyFunction( "[Store].[Store].Properties('MEMBER_CAPTION')", Category.String, STRING_TYPE, STORE_MEMBER_CAPTION );
+  }
+
+  public void testCurrentMemberCaptionPropertyOnStoreHierarchy() {
+    verifyMemberCaptionPropertyFunction( "[Store].[Store].CurrentMember.Properties('MEMBER_CAPTION')", Category.String, STRING_TYPE, STORE_MEMBER_CAPTION );
+  }
+
+  public void testGenerateWithMemberCaptionPropertyOnStoreDimension() {
+    verifyGenerateWithMemberCaptionPropertyFunction( "Generate([Store].CurrentMember, [Store].CurrentMember.Properties('MEMBER_CAPTION'))", Category.String, STRING_TYPE, STORE_MEMBER_CAPTION );
+  }
+
+  public void testGenerateWithMemberCaptionPropertyOnStoreHierarchy() {
+    verifyGenerateWithMemberCaptionPropertyFunction( "Generate([Store].CurrentMember, [Store].[Store].CurrentMember.Properties('MEMBER_CAPTION'))", Category.String, STRING_TYPE, STORE_MEMBER_CAPTION );
+  }
+
+  private void verifyMemberCaptionPropertyFunction( String propertyQuery, int expectedCategory, Type expectedReturnType, String expectedResult ) {
+    query = connection.parseQuery( generateQueryString( propertyQuery ) );
+    assertNotNull( query );
+    resolvedFun = query.getFormulas()[0].getExpression();
+
+    assertNotNull( resolvedFun );
+    assertEquals( expectedCategory, resolvedFun.getCategory() );
+    assertEquals( expectedReturnType, resolvedFun.getType() );
+
+    result = getConnection().execute( query );
+    assertNotNull( result );
+    assertEquals( expectedResult, result.getCell( ZERO_POS ).getFormattedValue() );
+  }
+
+  private void verifyGenerateWithMemberCaptionPropertyFunction( String functionQuery, int expectedCategory, Type expectedReturnType, String expectedResult ) {
+    try {
+      query = connection.parseQuery( generateQueryString( functionQuery ) );
+    } catch ( MondrianException e ) {
+      e.printStackTrace();
+      fail( "No exception should be thrown but we have: " + e.getCause().getLocalizedMessage() );
+    }
+    assertNotNull( query );
+    resolvedFun = query.getFormulas()[0].getExpression();
+
+    assertNotNull( resolvedFun );
+    assertEquals( expectedCategory, resolvedFun.getCategory() );
+    assertEquals( expectedReturnType, resolvedFun.getType() );
+
+    result = getConnection().execute( query );
+    assertNotNull( result );
+    assertEquals( expectedResult, result.getCell( ZERO_POS ).getFormattedValue() );
+  }
+
+  private static String generateQueryString( String exp ) {
+    return "WITH MEMBER [Measures].[Foo] as " + exp + "SELECT {[Measures].[Foo]} ON COLUMNS from [Sales]";
+  }
+
+}

--- a/mondrian/src/it/java/mondrian/test/Main.java
+++ b/mondrian/src/it/java/mondrian/test/Main.java
@@ -155,6 +155,7 @@ public class Main extends TestSuite {
             }
             addTest(suite, SqlConstraintUtilsTest.class);
             addTest(suite, IifFunDefTest.class);
+            addTest(suite, PropertiesFunctionTest.class);
             addTest(suite, SegmentBuilderTest.class);
             addTest(suite, DenseDoubleSegmentBodyTest.class);
             addTest(suite, DenseIntSegmentBodyTest.class);

--- a/mondrian/src/it/java/mondrian/test/ParameterTest.java
+++ b/mondrian/src/it/java/mondrian/test/ParameterTest.java
@@ -5,7 +5,7 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2003-2005 Julian Hyde
-// Copyright (C) 2005-2014 Pentaho
+// Copyright (C) 2005-2017 Pentaho
 // All Rights Reserved.
 */
 package mondrian.test;
@@ -330,7 +330,7 @@ public class ParameterTest extends FoodMartTestCase {
             "java.lang.NumberFormatException: For input string: \"xy\"");
     }
 
-    public void testParameterDimension() {
+    public void testParameterDimensionWithTwoHierarchies() {
         assertExprReturns(
             "Parameter(\"Foo\",[Time],[Time].[1997],\"Foo\").Name", "1997");
         assertExprReturns(
@@ -339,12 +339,28 @@ public class ParameterTest extends FoodMartTestCase {
         // wrong dimension
         assertExprThrows(
             "Parameter(\"Foo\",[Time],[Product].[All Products],\"Foo\").Name",
-            "Default value of parameter 'Foo' is not consistent with the parameter type 'MemberType<dimension=[Time]>");
+            "Default value of parameter 'Foo' is not consistent with the parameter type 'MemberType<hierarchy=[Time]>");
         // non-existent member
         assertExprThrows(
             "Parameter(\"Foo\",[Time],[Time].[1997].[Q5],\"Foo\").Name",
             "MDX object '[Time].[1997].[Q5]' not found in cube 'Sales'");
     }
+
+    public void testParameterDimensionWithOneHierarchy() {
+      assertExprReturns(
+          "Parameter(\"Foo\",[Store],[Store].[USA],\"Foo\").Name", "USA");
+      assertExprReturns(
+          "Parameter(\"Foo\",[Store],[Store].[USA].[OR].[Portland],\"Foo\").Name",
+          "Portland");
+      // wrong dimension
+      assertExprThrows(
+          "Parameter(\"Foo\",[Store],[Product].[All Products],\"Foo\").Name",
+          "Default value of parameter 'Foo' is not consistent with the parameter type 'MemberType<hierarchy=[Store]>");
+      // non-existent member
+      assertExprThrows(
+          "Parameter(\"Foo\",[Store],[Store].[USA].[NY],\"Foo\").Name",
+          "MDX object '[Store].[USA].[NY]' not found in cube 'Sales'");
+  }
 
     public void testParameterHierarchy() {
         assertExprReturns(

--- a/mondrian/src/main/java/mondrian/olap/type/DimensionType.java
+++ b/mondrian/src/main/java/mondrian/olap/type/DimensionType.java
@@ -5,7 +5,7 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2005-2005 Julian Hyde
-// Copyright (C) 2005-2011 Pentaho
+// Copyright (C) 2005-2017 Pentaho
 // All Rights Reserved.
 */
 
@@ -65,8 +65,17 @@ public class DimensionType implements Type {
         return dimension == null
             ? null
             : dimension.getHierarchies().length > 1
-            ? null
+            ? getHierarchyWithDefaultName()
             : dimension.getHierarchies()[0];
+    }
+
+    private Hierarchy getHierarchyWithDefaultName() {
+      for ( Hierarchy hierarchy : dimension.getHierarchies() ) {
+        if ( Util.equalName( hierarchy.getName(), dimension.getName() ) ) {
+          return hierarchy;
+        }
+      }
+      return null;
     }
 
     public Level getLevel() {


### PR DESCRIPTION
The cause of the bug:
In mondrian schema a dimention can contain many hierarchies.
In mondrian schema it's allowed hierarchies without name attribute. In this case the hierarchy has the same name as its dimension.
When expression with a dimention is been parsing and resolving and it needs to get the hierarchy of this dimention, then it's returned null for the case when the dimention contains two hierarchy.
This is incorrect because we ignore the hierarchies with the same name as dimention name.
An this is the cause of the issue because the return type for the member Property function is taken exactly from this member resolved hierarchy levels.
Please see:
https://github.com/pentaho/mondrian/blob/master/mondrian/src/main/java/mondrian/olap/fun/PropertiesFunDef.java#L113
https://github.com/pentaho/mondrian/blob/master/mondrian/src/main/java/mondrian/olap/fun/PropertiesFunDef.java#L137-L159

The fix is to return the hierarchy of the dimention with the same name as dimention name, when the dimention contains more then one hierarchy.
Added unit tests.