### PR TITLE
[SP-3803] Backport of MONDRIAN-2572 - Exclude filter fails on levels added from dimensions that are not part of the aggregate table definition (6.1 Suite)

### DIFF
--- a/src/main/mondrian/rolap/RolapNativeFilter.java
+++ b/src/main/mondrian/rolap/RolapNativeFilter.java
@@ -6,7 +6,7 @@
 //
 // Copyright (C) 2004-2005 TONBELLER AG
 // Copyright (C) 2005-2005 Julian Hyde
-// Copyright (C) 2005-2016 Pentaho
+// Copyright (C) 2005-2017 Pentaho
 // All Rights Reserved.
 */
 package mondrian.rolap;
@@ -14,6 +14,7 @@ package mondrian.rolap;
 import mondrian.mdx.MdxVisitorImpl;
 import mondrian.mdx.MemberExpr;
 import mondrian.olap.*;
+import mondrian.rolap.TupleReader.MemberBuilder;
 import mondrian.rolap.aggmatcher.AggStar;
 import mondrian.rolap.sql.*;
 
@@ -103,11 +104,40 @@ public class RolapNativeFilter extends RolapNativeSet {
             Evaluator evaluator = this.getEvaluator();
             SqlQuery testQuery = SqlQuery.newQuery(ds, "testQuery");
             SqlTupleReader sqlTupleReader = new SqlTupleReader(this);
+            
+            Role role = evaluator.getSchemaReader().getRole();
+            RolapSchemaReader reader = new RolapSchemaReader(role, evaluator.getSchemaReader().getSchema());
+            
+            for (CrossJoinArg arg : args) {
+                addLevel(sqlTupleReader, reader, arg);
+            }
+            
             RolapCube cube = (RolapCube) evaluator.getCube();
             this.addConstraint
                     (testQuery, cube, sqlTupleReader.chooseAggStar
                             (this, evaluator, cube));
             return testQuery.isSupported();
+        }
+        
+
+        private void addLevel(TupleReader tr, RolapSchemaReader schemaReader, CrossJoinArg arg) {
+            RolapLevel level = arg.getLevel();
+            if (level == null) {
+                // Level can be null if the CrossJoinArg represent
+                // an empty set.
+                // This is used to push down the "1 = 0" predicate
+                // into the emerging CJ so that the entire CJ can
+                // be natively evaluated.
+                tr.incrementEmptySets();
+                return;
+            }
+
+            RolapHierarchy hierarchy = level.getHierarchy();
+            MemberReader mr = schemaReader.getMemberReader(hierarchy);
+            MemberBuilder mb = mr.getMemberBuilder();
+            Util.assertTrue(mb != null, "MemberBuilder not found");
+
+            tr.addLevelMembers(level, mb, null);
         }
 
         public Object getCacheKey() {


### PR DESCRIPTION
- backport of #891