### PR TITLE
[BACKLOG-18450] remove or fix version specific integration tests in Mondrian

### DIFF
--- a/mondrian/build.xml
+++ b/mondrian/build.xml
@@ -156,6 +156,7 @@ class MondrianServerVersion {
     static final String VERSION = "${project.version}";
     static final int MAJOR_VERSION = ${project.version.major};
     static final int MINOR_VERSION = ${project.version.minor};
+    static final int SCHEMA_VERSION = ${schema.version};
     static final String COPYRIGHT_YEAR = "${copyright.year}";
 }
 // End MondrianServerVersion.java</echo>

--- a/mondrian/pom.xml
+++ b/mondrian/pom.xml
@@ -13,11 +13,12 @@
   <description>Mondrian OLAP Engine</description>
   <url>http://mondrian.pentaho.com</url>
   <properties>
-    <project.version.minor>150</project.version.minor>
+    <project.version.minor>000</project.version.minor>
     <copyright.year>2017</copyright.year>
     <xml-apis.version>2.0.2</xml-apis.version>
     <driver.version>${project.version}</driver.version>
-    <project.version.major>3</project.version.major>
+    <project.version.major>8</project.version.major>
+    <schema.version>3</schema.version>
     <driver.name>Mondrian olap4j driver</driver.name>
     <driver.version.minor>${project.version.minor}</driver.version.minor>
     <vendor>Pentaho</vendor>

--- a/mondrian/src/it/resources/mondrian/test/loader/SteelWheels.mysql.sql
+++ b/mondrian/src/it/resources/mondrian/test/loader/SteelWheels.mysql.sql
@@ -3492,7 +3492,7 @@ CREATE TABLE `orderfact` (
   `REQUIREDDATE` timestamp NOT NULL default '0000-00-00 00:00:00',
   `SHIPPEDDATE` timestamp NOT NULL default '0000-00-00 00:00:00',
   `STATUS` varchar(15) collate latin1_general_cs default NULL,
-  `COMMENTS` mediumtext collate latin1_general_cs,
+  `COMMENTS` varchar(1024) collate latin1_general_cs,
   `CUSTOMERNUMBER` int(11) default NULL,
   `TIME_ID` varchar(10) collate latin1_general_cs default NULL,
   `QTR_ID` bigint(20) default NULL,
@@ -6526,7 +6526,7 @@ CREATE TABLE `orders` (
   `REQUIREDDATE` timestamp NOT NULL default '0000-00-00 00:00:00',
   `SHIPPEDDATE` timestamp NOT NULL default '0000-00-00 00:00:00',
   `STATUS` varchar(15) collate latin1_general_cs NOT NULL default '',
-  `COMMENTS` mediumtext collate latin1_general_cs,
+  `COMMENTS` varchar(1024) collate latin1_general_cs,
   `CUSTOMERNUMBER` int(11) NOT NULL default '0',
   PRIMARY KEY  (`ORDERNUMBER`)
 ) ENGINE=MEMORY DEFAULT CHARSET=latin1 COLLATE=latin1_general_cs;
@@ -7175,7 +7175,7 @@ CREATE TABLE `products` (
   `PRODUCTLINE` varchar(50) collate latin1_general_cs NOT NULL default '',
   `PRODUCTSCALE` varchar(10) collate latin1_general_cs NOT NULL default '',
   `PRODUCTVENDOR` varchar(50) collate latin1_general_cs NOT NULL default '',
-  `PRODUCTDESCRIPTION` mediumtext collate latin1_general_cs NOT NULL,
+  `PRODUCTDESCRIPTION` varchar(1024) collate latin1_general_cs NOT NULL,
   `QUANTITYINSTOCK` smallint(6) NOT NULL default '0',
   `BUYPRICE` decimal(17,0) NOT NULL default '0',
   `MSRP` decimal(17,0) NOT NULL default '0',

--- a/mondrian/src/main/java/mondrian/olap/MondrianServer.java
+++ b/mondrian/src/main/java/mondrian/olap/MondrianServer.java
@@ -99,6 +99,15 @@ public abstract class MondrianServer {
     public abstract int getId();
 
     /**
+     * Returns the schema version of this MondrianServer.
+     *
+     * @return Server's schema version
+     */
+    public int getSchemaVersion() {
+        return MondrianServerRegistry.INSTANCE.getSchemaVersion();
+    }
+
+    /**
      * Returns the version of this MondrianServer.
      *
      * @return Server's version

--- a/mondrian/src/main/java/mondrian/rolap/RolapSchema.java
+++ b/mondrian/src/main/java/mondrian/rolap/RolapSchema.java
@@ -388,12 +388,10 @@ public class RolapSchema implements Schema {
         final String schemaMajor =
             versionParts.length > 0 ? versionParts[0] : "";
 
-        MondrianServer.MondrianVersion mondrianVersion =
-            MondrianServer.forId(null).getVersion();
-        final String serverMajor =
-            mondrianVersion.getMajorVersion() + ""; // "3"
+        String serverSchemaVersion =
+            Integer.toString(MondrianServer.forId(null).getSchemaVersion());
 
-        if (serverMajor.compareTo(schemaMajor) < 0) {
+        if (serverSchemaVersion.compareTo(schemaMajor) < 0) {
             String errorMsg =
                 "Schema version '" + schemaVersion
                 + "' is later than schema version "

--- a/mondrian/src/main/java/mondrian/server/MondrianServerRegistry.java
+++ b/mondrian/src/main/java/mondrian/server/MondrianServerRegistry.java
@@ -76,6 +76,8 @@ public class MondrianServerRegistry {
         return MondrianServerVersion.VERSION;
     }
 
+    public int getSchemaVersion() { return MondrianServerVersion.SCHEMA_VERSION; }
+
     public MondrianServer.MondrianVersion getVersion() {
         if (logger.isDebugEnabled()){
             logger.debug(" Vendor: " + MondrianServerVersion.VENDOR);
@@ -118,6 +120,9 @@ public class MondrianServerRegistry {
             }
             public int getMajorVersion() {
                 return MondrianServerVersion.MAJOR_VERSION;
+            }
+            public int getSchemaVersion() {
+                return MondrianServerVersion.SCHEMA_VERSION;
             }
         };
     }


### PR DESCRIPTION
@pentaho/2-1b please review. I could not duplicate the original issue but found some broken CREATE statements and fixed them while investigating. mediumtext column types are not available when the ENGINE type is MEMORY in MySQL.