### PR TITLE
[PSW-229] Script files don't have an header with Copyright data

### DIFF
--- a/assemblies/psw-ce/src/main/resources/workbench.command
+++ b/assemblies/psw-ce/src/main/resources/workbench.command
@@ -1,3 +1,12 @@
+# ***************************************************************************
+# This software is subject to the terms of the Eclipse Public License v1.0
+# Agreement, available at the following URL:
+# http://www.eclipse.org/legal/epl-v10.html.
+# You must accept the terms of that agreement to use this software.
+#
+# Copyright (c) 2007-2017 Hitachi Vantara..  All rights reserved.
+# ***************************************************************************
+
 cd `dirname $0`
 
 # if a BASE_DIR argument has been passed to this .command, use it


### PR DESCRIPTION
- added license to the command file