### PR TITLE
[SP-3883]: Backport of MONDRIAN-2534 - Mondrian CancellationChecker.checkCancelOrTimeout does not terminate thread (7.1 Suite)

### DIFF
--- a/mondrian/src/it/java/mondrian/test/Main.java
+++ b/mondrian/src/it/java/mondrian/test/Main.java
@@ -196,6 +196,7 @@ public class Main extends TestSuite {
             addTest(suite, HierarchyBugTest.class);
             addTest(suite, ScheduleTest.class);
             addTest(suite, UtilTestCase.class);
+            addTest(suite, CancellationCheckerTest.class);
             addTest(suite, PartiallyOrderedSetTest.class);
             addTest(suite, ConcatenableListTest.class);
             addTest(suite, ExpiringReferenceTest.class);

--- a/mondrian/src/it/java/mondrian/test/TupleListTest.java
+++ b/mondrian/src/it/java/mondrian/test/TupleListTest.java
@@ -245,7 +245,7 @@ public class TupleListTest extends FoodMartTestCase {
         final boolean fail = true;
         Cube salesCube = schema.lookupCube("Sales", fail);
         final SchemaReader schemaReader =
-            salesCube.getSchemaReader(null); // unrestricted
+            salesCube.getSchemaReader(null).withLocus(); // unrestricted
         return schemaReader.getMemberByUniqueName(
             Util.parseIdentifier(memberName), true);
     }

--- a/mondrian/src/it/java/mondrian/util/CancellationCheckerTest.java
+++ b/mondrian/src/it/java/mondrian/util/CancellationCheckerTest.java
@@ -1,0 +1,66 @@
+  /*
+  // This software is subject to the terms of the Eclipse Public License v1.0
+  // Agreement, available at the following URL:
+  // http://www.eclipse.org/legal/epl-v10.html.
+  // You must accept the terms of that agreement to use this software.
+  //
+  // Copyright (c) 2002-2017 Hitachi Vantara..  All rights reserved.
+  */
+  package mondrian.util;
+
+  import static org.mockito.Mockito.mock;
+  import static org.mockito.Mockito.never;
+  import static org.mockito.Mockito.verify;
+
+  import junit.framework.TestCase;
+  import mondrian.olap.MondrianProperties;
+  import mondrian.server.Execution;
+
+  public class CancellationCheckerTest extends TestCase {
+    private Execution excMock = mock(Execution.class);
+
+    public void testCheckCancelOrTimeoutWithIntExecution() {
+      int currentIteration = 10;
+      MondrianProperties.instance().CheckCancelOrTimeoutInterval.set(1);
+      CancellationChecker.checkCancelOrTimeout(currentIteration, excMock);
+      verify(excMock).checkCancelOrTimeout();
+    }
+
+    public void testCheckCancelOrTimeoutWithLongExecution() {
+      long currentIteration = 10L;
+      MondrianProperties.instance().CheckCancelOrTimeoutInterval.set(1);
+      CancellationChecker.checkCancelOrTimeout(currentIteration, excMock);
+      verify(excMock).checkCancelOrTimeout();
+    }
+
+    public void testCheckCancelOrTimeoutLongMoreThanIntExecution() {
+      long currentIteration = 2147483648L;
+      MondrianProperties.instance().CheckCancelOrTimeoutInterval.set(1);
+      CancellationChecker.checkCancelOrTimeout(currentIteration, excMock);
+      verify(excMock).checkCancelOrTimeout();
+    }
+
+    public void testCheckCancelOrTimeoutMaxLongExecution() {
+      long currentIteration = 9223372036854775807L;
+      MondrianProperties.instance().CheckCancelOrTimeoutInterval.set(1);
+      CancellationChecker.checkCancelOrTimeout(currentIteration, excMock);
+      verify(excMock).checkCancelOrTimeout();
+    }
+
+    public void testCheckCancelOrTimeoutNoExecution_IntervalZero() {
+      int currentIteration = 10;
+      MondrianProperties.instance().CheckCancelOrTimeoutInterval.set(0);
+      CancellationChecker.checkCancelOrTimeout(currentIteration, excMock);
+      verify(excMock, never()).checkCancelOrTimeout();
+    }
+
+    public void testCheckCancelOrTimeoutNoExecutionEvenIntervalOddIteration() {
+      int currentIteration = 3;
+      MondrianProperties.instance().CheckCancelOrTimeoutInterval.set(10);
+      CancellationChecker.checkCancelOrTimeout(currentIteration, excMock);
+      verify(excMock, never()).checkCancelOrTimeout();
+    }
+
+  }
+
+// End CancellationCheckerTest.java

--- a/mondrian/src/main/java/mondrian/olap/fun/CrossJoinFunDef.java
+++ b/mondrian/src/main/java/mondrian/olap/fun/CrossJoinFunDef.java
@@ -233,11 +233,15 @@ public class CrossJoinFunDef extends FunDefBase {
                             TupleCollections.emptyList(1).tupleCursor();
                         final Member[] members = new Member[arity];
 
+                        long currentIteration = 0;
+                        Execution execution = Locus.peek().execution;
                         public boolean forward() {
                             if (i2.forward()) {
                                 return true;
                             }
                             while (i1.forward()) {
+                                CancellationChecker.checkCancelOrTimeout(
+                                    currentIteration++, execution);
                                 i2 = it2.tupleCursor();
                                 if (i2.forward()) {
                                     return true;

--- a/mondrian/src/main/java/mondrian/olap4j/MondrianOlap4jCellSetAxis.java
+++ b/mondrian/src/main/java/mondrian/olap4j/MondrianOlap4jCellSetAxis.java
@@ -12,6 +12,7 @@ package mondrian.olap4j;
 import mondrian.calc.TupleList;
 import mondrian.olap.AxisOrdinal;
 import mondrian.rolap.RolapAxis;
+import mondrian.server.Locus;
 
 import org.olap4j.*;
 import org.olap4j.metadata.Member;
@@ -76,7 +77,14 @@ class MondrianOlap4jCellSetAxis implements CellSetAxis {
             }
 
             public int size() {
-                return axis.getTupleList().size();
+              return Locus.execute(
+                  olap4jCellSet.olap4jStatement.olap4jConnection
+                  .getMondrianConnection2(),
+                  "Getting List<Position>.size", new Locus.Action<Integer>() {
+                public Integer execute() {
+                  return axis.getTupleList().size();
+                }
+              });
             }
         };
     }

--- a/mondrian/src/main/java/mondrian/util/CancellationChecker.java
+++ b/mondrian/src/main/java/mondrian/util/CancellationChecker.java
@@ -23,8 +23,14 @@ public class CancellationChecker {
   public static void checkCancelOrTimeout(
       int currentIteration, Execution execution)
   {
-    int checkCancelOrTimeoutInterval =
-        MondrianProperties.instance().CheckCancelOrTimeoutInterval.get();
+    checkCancelOrTimeout((long) currentIteration, execution);
+  }
+
+  public static void checkCancelOrTimeout(
+      long currentIteration, Execution execution)
+  {
+    int checkCancelOrTimeoutInterval = MondrianProperties.instance()
+        .CheckCancelOrTimeoutInterval.get();
     if (execution != null) {
       synchronized (execution) {
         if (checkCancelOrTimeoutInterval > 0
@@ -32,7 +38,7 @@ public class CancellationChecker {
         {
           execution.checkCancelOrTimeout();
         }
-    }
+      }
     }
   }
 }


### PR DESCRIPTION
This is the cherry-pick of the fix for [MONDRIAN-2534]: Mondrian CancellationChecker.checkCancelOrTimeout does not terminate thread

Fixed according to the comment in the jira, added unit tests.
Placed a Locus in the execution context for MondrianOlap4jCellSetAxis on getting axis positions size.
Fixed checksyle issues.