### PR TITLE
[MONDRIAN-2603]: Measures completely disappear from a second cube defined in the same schema when measures are constrained using Mondrian role

### DIFF
--- a/mondrian/src/main/java/mondrian/rolap/RolapCube.java
+++ b/mondrian/src/main/java/mondrian/rolap/RolapCube.java
@@ -498,12 +498,14 @@ public class RolapCube extends CubeBase {
             }
             List<Member> cubeMeasures = cube.getMeasures();
             boolean found = false;
+            boolean isDefaultMeasureFound = false;
             for (Member cubeMeasure : cubeMeasures) {
                 if (cubeMeasure.getUniqueName().equals(xmlMeasure.name)) {
                     if (cubeMeasure.getName().equalsIgnoreCase(
                             xmlVirtualCube.defaultMeasure))
                     {
-                        defaultMeasure = cubeMeasure;
+                      defaultMeasure = cubeMeasure;
+                      isDefaultMeasureFound = true;
                     }
                     found = true;
                     if (cubeMeasure instanceof RolapCalculatedMember) {
@@ -556,6 +558,11 @@ public class RolapCube extends CubeBase {
                             Property.CAPTION.name,
                             cubeMeasure.getCaption());
                         origMeasureList.add(virtualCubeMeasure);
+                        //Set the actual virtual cube measure
+                        //to the default measure
+                        if (isDefaultMeasureFound) {
+                          defaultMeasure = virtualCubeMeasure;
+                        }
                     }
                     break;
                 }

--- a/mondrian/src/main/java/mondrian/rolap/RolapDimension.java
+++ b/mondrian/src/main/java/mondrian/rolap/RolapDimension.java
@@ -218,6 +218,34 @@ class RolapDimension extends DimensionBase {
     public Map<String, Annotation> getAnnotationMap() {
         return annotationMap;
     }
+
+    @Override
+    protected int computeHashCode() {
+      if (isMeasuresDimension()) {
+        return System.identityHashCode(this);
+      }
+      return super.computeHashCode();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+    if (!(o instanceof RolapDimension)) {
+        return false;
+    }
+      if (isMeasuresDimension()) {
+        RolapDimension that = (RolapDimension) o;
+        return this == that;
+      }
+      return super.equals(o);
+    }
+
+    private boolean isMeasuresDimension() {
+      return this.getDimensionType() == DimensionType.MeasuresDimension;
+    }
+
 }
 
 // End RolapDimension.java


### PR DESCRIPTION
**Cause of the problem:**
**[Measures]** dimension access for Role should be placed in `dimensionGrants` map, if **[Measures]** hierarchy has access modifier in Role.
**[Measures]** dimension acts as a key of `dimensionGrants` map.
Since **[Measures]** dimension is represented by `RolapDimention` and this one has no overridden `equals` method but only base in `OlapElementBase`, we can put only one **[Measures]** dimension object into `dimensionGrants`.
So e.g. for two cubes with restrictions on **[Measures]** dimensions we will have only one item in `dimensionGrants`.
But when we get access to **[Measures]** dimension to decide to display measures or not, **[Measures]** dimension objects are compared by object identity (please see https://github.com/pentaho/mondrian/blob/master/mondrian/src/main/java/mondrian/olap/RoleImpl.java#L331-LL336).  This was added as a fix for MONDRIAN-1434. 
That is why **[Measures]** for the second cube are not allowed.
**The fix:**
We need to distinguish between **[Measures]** dimensions that are in different cubes.
Since **[Measures]** dimension is represented by `RolapDimention`, we have no possibility to use cube, because `RolapDimention` stores no information about cube.
But we can override `equals` method for only measure dimension to compare them by object identity.
In this case `dimensionGrants` map will contain unique **[Measures]** dimensions per cube, if it needs in the Role.
Added test