### PR TITLE
[SP-3957]: Backport of MONDRIAN-2603 - Measures completely disappear from a second cube defined in the same schema when measures are constrained using Mondrian role (8.0 Suite)

### DIFF
--- a/mondrian/src/main/java/mondrian/rolap/RolapCube.java
+++ b/mondrian/src/main/java/mondrian/rolap/RolapCube.java
@@ -498,12 +498,14 @@ public class RolapCube extends CubeBase {
             }
             List<Member> cubeMeasures = cube.getMeasures();
             boolean found = false;
+            boolean isDefaultMeasureFound = false;
             for (Member cubeMeasure : cubeMeasures) {
                 if (cubeMeasure.getUniqueName().equals(xmlMeasure.name)) {
                     if (cubeMeasure.getName().equalsIgnoreCase(
                             xmlVirtualCube.defaultMeasure))
                     {
-                        defaultMeasure = cubeMeasure;
+                      defaultMeasure = cubeMeasure;
+                      isDefaultMeasureFound = true;
                     }
                     found = true;
                     if (cubeMeasure instanceof RolapCalculatedMember) {
@@ -556,6 +558,11 @@ public class RolapCube extends CubeBase {
                             Property.CAPTION.name,
                             cubeMeasure.getCaption());
                         origMeasureList.add(virtualCubeMeasure);
+                        //Set the actual virtual cube measure
+                        //to the default measure
+                        if (isDefaultMeasureFound) {
+                          defaultMeasure = virtualCubeMeasure;
+                        }
                     }
                     break;
                 }

--- a/mondrian/src/main/java/mondrian/rolap/RolapDimension.java
+++ b/mondrian/src/main/java/mondrian/rolap/RolapDimension.java
@@ -218,6 +218,34 @@ class RolapDimension extends DimensionBase {
     public Map<String, Annotation> getAnnotationMap() {
         return annotationMap;
     }
+
+    @Override
+    protected int computeHashCode() {
+      if (isMeasuresDimension()) {
+        return System.identityHashCode(this);
+      }
+      return super.computeHashCode();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+    if (!(o instanceof RolapDimension)) {
+        return false;
+    }
+      if (isMeasuresDimension()) {
+        RolapDimension that = (RolapDimension) o;
+        return this == that;
+      }
+      return super.equals(o);
+    }
+
+    private boolean isMeasuresDimension() {
+      return this.getDimensionType() == DimensionType.MeasuresDimension;
+    }
+
 }
 
 // End RolapDimension.java


### PR DESCRIPTION
This is the cherry-pick of the fix for [MONDRIAN-2603]: Measures completely disappear from a second cube defined in the same schema when measures are constrained using Mondrian role (#994)