### PR TITLE
[SP-4024]: Backport of MONDRIAN-1233 - MySQL/MS SQL Dialect needs to override Dialect.quoteBooleanLiteral (8.0 Suite)

### DIFF
--- a/mondrian/src/it/java/mondrian/spi/impl/JdbcDialectImplTest.java
+++ b/mondrian/src/it/java/mondrian/spi/impl/JdbcDialectImplTest.java
@@ -4,7 +4,7 @@
 // http://www.eclipse.org/legal/epl-v10.html.
 // You must accept the terms of that agreement to use this software.
 //
-// Copyright (c) 2015-2017 Hitachi Vantara.
+// Copyright (c) 2015-2018 Hitachi Vantara.
 // All rights reserved.
  */
 package mondrian.spi.impl;
@@ -12,15 +12,85 @@ package mondrian.spi.impl;
 import junit.framework.TestCase;
 
 public class JdbcDialectImplTest extends TestCase {
+  private static final String ILLEGAL_BOOLEAN_LITERAL =
+      "illegal for base dialect implemetation boolean literal";
+  private static final String ILLEGAL_BOOLEAN_LITERAL_MESSAGE =
+      "Illegal BOOLEAN literal:  ";
+  private static final String BOOLEAN_LITERAL_TRUE = "True";
+  private static final String BOOLEAN_LITERAL_FALSE = "False";
+  private static final String BOOLEAN_LITERAL_ONE = "1";
+  private static final String BOOLEAN_LITERAL_ZERO = "0";
+
   private JdbcDialectImpl jdbcDialect = new JdbcDialectImpl();
+  private StringBuilder buf;
+
+  @Override
+  protected void setUp() throws Exception {
+    buf = new StringBuilder();
+  }
 
   public void testAllowsRegularExpressionInWhereClause() {
-    assertFalse( jdbcDialect.allowsRegularExpressionInWhereClause() );
+    assertFalse(jdbcDialect.allowsRegularExpressionInWhereClause());
   }
 
   public void testGenerateRegularExpression() {
-    assertNull( jdbcDialect.generateRegularExpression( null, null ) );
+    assertNull(jdbcDialect.generateRegularExpression(null, null));
+  }
+
+  public void testQuoteBooleanLiteral_True() throws Exception {
+    assertEquals(0, buf.length());
+    jdbcDialect.quoteBooleanLiteral(buf, BOOLEAN_LITERAL_TRUE);
+    assertEquals(BOOLEAN_LITERAL_TRUE, buf.toString());
+  }
+
+  public void testQuoteBooleanLiteral_False() throws Exception {
+    assertEquals(0, buf.length());
+    jdbcDialect.quoteBooleanLiteral(buf, BOOLEAN_LITERAL_FALSE);
+    assertEquals(BOOLEAN_LITERAL_FALSE, buf.toString());
+  }
+
+  public void testQuoteBooleanLiteral_OneIllegaLiteral() throws Exception {
+    assertEquals(0, buf.length());
+    try {
+      jdbcDialect.quoteBooleanLiteral(buf, BOOLEAN_LITERAL_ONE);
+    fail(
+        "The illegal boolean literal exception should appear BUT it was not.");
+    } catch (NumberFormatException e) {
+      assertEquals(
+          ILLEGAL_BOOLEAN_LITERAL_MESSAGE
+          + BOOLEAN_LITERAL_ONE,
+          e.getMessage());
+    }
+  }
+
+  public void testQuoteBooleanLiteral_ZeroIllegaLiteral() throws Exception {
+    assertEquals(0, buf.length());
+    try {
+      jdbcDialect.quoteBooleanLiteral(buf, BOOLEAN_LITERAL_ZERO);
+    fail(
+        "The illegal boolean literal exception should appear BUT it was not.");
+    } catch (NumberFormatException e) {
+      assertEquals(
+          ILLEGAL_BOOLEAN_LITERAL_MESSAGE
+          + BOOLEAN_LITERAL_ZERO,
+          e.getMessage());
+    }
+  }
+
+  public void testQuoteBooleanLiteral_TrowsExceptionOnIllegaLiteral()
+      throws Exception {
+    assertEquals(0, buf.length());
+    try {
+      jdbcDialect.quoteBooleanLiteral(buf, ILLEGAL_BOOLEAN_LITERAL);
+    fail(
+        "The illegal boolean literal exception should appear BUT it was not.");
+    } catch (NumberFormatException e) {
+      assertEquals(
+          ILLEGAL_BOOLEAN_LITERAL_MESSAGE
+          + ILLEGAL_BOOLEAN_LITERAL,
+          e.getMessage());
+    }
   }
 
 }
-//End JdbcDialectImplTest.java
+// End JdbcDialectImplTest.java

--- a/mondrian/src/it/java/mondrian/spi/impl/MicrosoftSqlServerDialectTest.java
+++ b/mondrian/src/it/java/mondrian/spi/impl/MicrosoftSqlServerDialectTest.java
@@ -19,9 +19,11 @@ import java.sql.DatabaseMetaData;
 import com.mysql.jdbc.Statement;
 
 import junit.framework.TestCase;
+import mondrian.olap.Util;
 import mondrian.spi.Dialect;
 
-public class MySqlDialectTest extends TestCase {
+public class MicrosoftSqlServerDialectTest extends TestCase {
+
   private static final String ILLEGAL_BOOLEAN_LITERAL =
       "illegal for this dialect boolean literal";
   private static final String ILLEGAL_BOOLEAN_LITERAL_MESSAGE =
@@ -33,70 +35,43 @@ public class MySqlDialectTest extends TestCase {
   private Connection connection = mock(Connection.class);
   private DatabaseMetaData metaData = mock(DatabaseMetaData.class);
   Statement statmentMock = mock(Statement.class);
-  private MySqlDialect dialect;
+  private MicrosoftSqlServerDialect dialect;
   private StringBuilder buf;
 
   @Override
   protected void setUp() throws Exception {
     when(metaData.getDatabaseProductName()).thenReturn(
-        Dialect.DatabaseProduct.MYSQL.name());
-    when(metaData.getDatabaseProductVersion()).thenReturn("5.0");
+        Dialect.DatabaseProduct.MSSQL.name());
     when(statmentMock.execute(any())).thenReturn(false);
     when(connection.getMetaData()).thenReturn(metaData);
     when(connection.createStatement()).thenReturn(statmentMock);
-    dialect = new MySqlDialect(connection);
+    dialect = new MicrosoftSqlServerDialect(connection);
     buf = new StringBuilder();
-  }
-
-  public void testAllowsRegularExpressionInWhereClause() {
-    assertTrue(dialect.allowsRegularExpressionInWhereClause());
-  }
-
-  public void testGenerateRegularExpression_InvalidRegex() throws Exception {
-    assertNull(
-        "Invalid regex should be ignored",
-        dialect.generateRegularExpression("table.column", "(a"));
-  }
-
-  public void testGenerateRegularExpression_CaseInsensitive()
-      throws Exception {
-    String sql =
-        dialect.generateRegularExpression("table.column", "(?i)|(?u).*a.*");
-    assertEquals(
-        "table.column IS NOT NULL AND UPPER(table.column) REGEXP '.*A.*'",
-        sql);
-  }
-
-  public void testGenerateRegularExpression_CaseSensitive()
-      throws Exception {
-    String sql =
-        dialect.generateRegularExpression("table.column", ".*a.*");
-    assertEquals(
-        "table.column IS NOT NULL AND table.column REGEXP '.*a.*'", sql);
   }
 
   public void testQuoteBooleanLiteral_True() throws Exception {
     assertEquals(0, buf.length());
     dialect.quoteBooleanLiteral(buf, BOOLEAN_LITERAL_TRUE);
-    assertEquals(BOOLEAN_LITERAL_TRUE, buf.toString());
+    assertEquals(Util.singleQuoteString(BOOLEAN_LITERAL_TRUE), buf.toString());
   }
 
   public void testQuoteBooleanLiteral_False() throws Exception {
     assertEquals(0, buf.length());
     dialect.quoteBooleanLiteral(buf, BOOLEAN_LITERAL_FALSE);
-    assertEquals(BOOLEAN_LITERAL_FALSE, buf.toString());
+    assertEquals(Util.singleQuoteString(
+        BOOLEAN_LITERAL_FALSE), buf.toString());
   }
 
   public void testQuoteBooleanLiteral_One() throws Exception {
     assertEquals(0, buf.length());
     dialect.quoteBooleanLiteral(buf, BOOLEAN_LITERAL_ONE);
-    assertEquals(BOOLEAN_LITERAL_ONE, buf.toString());
+    assertEquals(Util.singleQuoteString(BOOLEAN_LITERAL_ONE), buf.toString());
   }
 
   public void testQuoteBooleanLiteral_Zero() throws Exception {
     assertEquals(0, buf.length());
     dialect.quoteBooleanLiteral(buf, BOOLEAN_LITERAL_ZERO);
-    assertEquals(BOOLEAN_LITERAL_ZERO, buf.toString());
+    assertEquals(Util.singleQuoteString(BOOLEAN_LITERAL_ZERO), buf.toString());
   }
 
   public void testQuoteBooleanLiteral_TrowsException() throws Exception {
@@ -114,4 +89,4 @@ public class MySqlDialectTest extends TestCase {
   }
 
 }
-// End MySqlDialectTest.java
+// End MicrosoftSqlServerDialectTest.java

--- a/mondrian/src/main/java/mondrian/spi/impl/MicrosoftSqlServerDialect.java
+++ b/mondrian/src/main/java/mondrian/spi/impl/MicrosoftSqlServerDialect.java
@@ -4,7 +4,7 @@
 * http://www.eclipse.org/legal/epl-v10.html.
 * You must accept the terms of that agreement to use this software.
 *
-* Copyright (c) 2002-2017 Hitachi Vantara..  All rights reserved.
+* Copyright (c) 2002-2018 Hitachi Vantara..  All rights reserved.
 */
 
 package mondrian.spi.impl;
@@ -16,6 +16,8 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.List;
+
+import mondrian.olap.Util;
 
 /**
  * Implementation of {@link mondrian.spi.Dialect} for the Microsoft SQL Server
@@ -59,6 +61,22 @@ public class MicrosoftSqlServerDialect extends JdbcDialectImpl {
 
     public boolean requiresUnionOrderByOrdinal() {
         return false;
+    }
+
+    @Override
+    public void quoteBooleanLiteral(StringBuilder buf, String value) {
+      //avoid padding origin values with blanks to n for char(n),
+      //when ANSI_PADDING=ON
+      String boolLiteral = value.trim();
+      if (!boolLiteral.equalsIgnoreCase("TRUE")
+          && !(boolLiteral.equalsIgnoreCase("FALSE"))
+          && !(boolLiteral.equalsIgnoreCase("1"))
+          && !(boolLiteral.equalsIgnoreCase("0")))
+      {
+        throw new NumberFormatException(
+            "Illegal BOOLEAN literal:  " + value);
+      }
+      buf.append(Util.singleQuoteString(value));
     }
 
     protected void quoteDateLiteral(StringBuilder buf, String value, Date date)

--- a/mondrian/src/main/java/mondrian/spi/impl/MySqlDialect.java
+++ b/mondrian/src/main/java/mondrian/spi/impl/MySqlDialect.java
@@ -4,7 +4,7 @@
 // http://www.eclipse.org/legal/epl-v10.html.
 // You must accept the terms of that agreement to use this software.
 //
-// Copyright (C) 2002-2017 Hitachi Vantara and others
+// Copyright (C) 2002-2018 Hitachi Vantara and others
 // All Rights Reserved.
 */
 package mondrian.spi.impl;
@@ -222,6 +222,19 @@ public class MySqlDialect extends JdbcDialectImpl {
         String s1 = Util.replace(s0, "\\", "\\\\");
         buf.append(s1);
         buf.append('\'');
+    }
+
+
+
+    @Override
+    public void quoteBooleanLiteral(StringBuilder buf, String value) {
+      if (!value.equalsIgnoreCase("1")
+          && !(value.equalsIgnoreCase("0")))
+      {
+        super.quoteBooleanLiteral(buf, value);
+      } else {
+        buf.append(value);
+      }
     }
 
     @Override


### PR DESCRIPTION
This is the cherry-pick of the fix for [MONDRIAN-1233]: MySQL/MS SQL Dialect needs to override Dialect.quoteBooleanLiteral (#999)
Fixed, added unit tsts.