### PR TITLE
[SP-4038]: Backport of MONDRIAN-2608 - Error with cached data when ordinalColumn is defined and parameter mondrian.native.ExpandNonNative is set to true (7.1 Suite)

### DIFF
--- a/mondrian/src/main/java/mondrian/rolap/RolapCubeHierarchy.java
+++ b/mondrian/src/main/java/mondrian/rolap/RolapCubeHierarchy.java
@@ -5,7 +5,7 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2001-2005 Julian Hyde
-// Copyright (C) 2005-2017 Pentaho and others
+// Copyright (C) 2005-2018 Pentaho and others
 // All Rights Reserved.
 */
 package mondrian.rolap;
@@ -772,9 +772,9 @@ public class RolapCubeHierarchy extends RolapHierarchy {
                         newlist.add(getAllMember());
                     } else {
                         RolapCubeMember cubeMember =
-                            lookupCubeMemberWithParent(
-                                member,
-                                cubeLevel);
+                                lookupCubeMemberWithParent(
+                                        member,
+                                        cubeLevel);
                         newlist.add(cubeMember);
                     }
                 }
@@ -839,14 +839,29 @@ public class RolapCubeHierarchy extends RolapHierarchy {
                     cubeMember = (RolapCubeMember)
                         rolapCubeCacheHelper.getMember(key, false);
                     if (cubeMember == null) {
-                        cubeMember = new RolapCubeMember(parent, member, level);
+                        cubeMember =
+                            new RolapCubeMember(parent, member, level);
                         rolapCubeCacheHelper.putMember(key, cubeMember);
+                    } else {
+                      if (level.hasOrdinalExp()) {
+                        fixOrdinal(cubeMember, member.getOrdinal());
+                      }
                     }
                 } else {
                     cubeMember = new RolapCubeMember(parent, member, level);
                 }
                 return cubeMember;
             }
+        }
+
+        private void fixOrdinal(
+            RolapCubeMember rlCubeMemberToFix,
+            int ordinalToSet)
+        {
+          RolapMember rolapMember = rlCubeMemberToFix.getRolapMember();
+          if (rolapMember instanceof RolapMemberBase) {
+            ((RolapMemberBase) rolapMember).setOrdinal(ordinalToSet, true);
+          }
         }
 
         public int getMemberCount() {

--- a/mondrian/src/main/java/mondrian/rolap/RolapLevel.java
+++ b/mondrian/src/main/java/mondrian/rolap/RolapLevel.java
@@ -5,7 +5,7 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2001-2005 Julian Hyde
-// Copyright (C) 2005-2016 Pentaho and others
+// Copyright (C) 2005-2018 Pentaho and others
 // All Rights Reserved.
 */
 package mondrian.rolap;
@@ -268,6 +268,10 @@ public class RolapLevel extends LevelBase {
 
     public boolean hasCaptionColumn() {
         return captionExp != null;
+    }
+
+    public boolean hasOrdinalExp() {
+      return !getOrdinalExp().equals(getKeyExp());
     }
 
     final int getFlags() {
@@ -654,5 +658,6 @@ public class RolapLevel extends LevelBase {
         }
         return null;
     }
+
 }
 // End RolapLevel.java

--- a/mondrian/src/main/java/mondrian/rolap/RolapMemberBase.java
+++ b/mondrian/src/main/java/mondrian/rolap/RolapMemberBase.java
@@ -5,7 +5,7 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2001-2005 Julian Hyde
-// Copyright (C) 2005-2017 Pentaho and others
+// Copyright (C) 2005-2018 Pentaho and others
 // All Rights Reserved.
 */
 package mondrian.rolap;
@@ -513,9 +513,17 @@ public class RolapMemberBase
 
     void setOrdinal(int ordinal) {
         if (this.ordinal == -1) {
-            this.ordinal = ordinal;
+          this.ordinal = ordinal;
         }
     }
+
+    protected void setOrdinal(int ordinal, boolean forced) {
+      if (forced) {
+          this.ordinal = ordinal;
+      } else {
+        setOrdinal(ordinal);
+      }
+  }
 
     void setOrderKey(Comparable orderKey) {
         this.orderKey = orderKey;


### PR DESCRIPTION
This is the cherry-pick of the fix for [MONDRIAN-2608]: Error with cached data when ordinalColumn is defined and parameter mondrian.native.ExpandNonNative is set to true (#1001)
There are fix, IT test and check-style fixes.