### PR TITLE
[BACKLOG-13813] - Downstream updates

### DIFF
--- a/assemblies/psw-ce/pom.xml
+++ b/assemblies/psw-ce/pom.xml
@@ -23,6 +23,7 @@
     <dependency.jersey.revision>1.19.1</dependency.jersey.revision>
     <pdi.version>8.1.0.0-SNAPSHOT</pdi.version>
     <commons-xul.version>8.1.0.0-SNAPSHOT</commons-xul.version>
+    <mondrian-schemaworkbench-plugins.version>${project.version}</mondrian-schemaworkbench-plugins.version>
   </properties>
   <dependencies>
     <dependency>
@@ -186,9 +187,9 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>pentaho</groupId>
-      <artifactId>pentaho-mondrianschemaworkbench-plugins</artifactId>
-      <version>${project.version}</version>
+      <groupId>org.pentaho</groupId>
+      <artifactId>mondrian-schemaworkbench-plugins</artifactId>
+      <version>${mondrian-schemaworkbench-plugins.version}</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.groovy</groupId>


### PR DESCRIPTION
@pentaho/2-1b depoends on https://github.com/pentaho/pentaho-mondrianschemaworkbench-plugins/pull/23