### PR TITLE
Fix crash in mondrian.rolap.cache.SegmentCacheIndexImpl.findRollupCandidatesAmong

### DIFF
--- a/mondrian/src/main/java/mondrian/util/PartiallyOrderedSet.java
+++ b/mondrian/src/main/java/mondrian/util/PartiallyOrderedSet.java
@@ -652,12 +652,12 @@ public class PartiallyOrderedSet<E> extends AbstractSet<E>
         final List<E> list = new ArrayList<E>();
         while (!deque.isEmpty()) {
             Node<E> node1 = deque.pop();
+            if(node1.e == null) {
+                // Node is top or bottom.
+                continue;
+            }
             list.add(node1.e);
             for (Node<E> child : up ? node1.childList : node1.parentList) {
-                if (child.e == null) {
-                    // Node is top or bottom.
-                    break;
-                }
                 if (seen.add(child)) {
                     deque.add(child);
                 }


### PR DESCRIPTION
PartiallyOrderedSet.getAncestors() would sometimes return a list containing null item, causing an exception:
java.lang.NullPointerException
        at mondrian.rolap.cache.SegmentCacheIndexImpl.findRollupCandidatesAmong(SegmentCacheIndexImpl.java:814)

Problem pops up randomly when stress testing mondrian with multiple parallel requests.

Problem is also reported by another person here:
https://forums.pentaho.com/archive/index.php/t-208717.html

This patch solved the problem for me.