### PR TITLE
[SP-4150]: Backport of MONDRIAN-2613 - ArrayIndexOutOfBoundsException…

### DIFF
--- a/mondrian/src/it/java/mondrian/util/FormatTest.java
+++ b/mondrian/src/it/java/mondrian/util/FormatTest.java
@@ -890,6 +890,29 @@ public class FormatTest extends TestCase {
         // It should run without losing precision
         Assert.assertEquals("123 456 789 123 456 789 123 456 789", result.toString());
     }
+
+    /**
+     * Test case for bug <a href="http://jira.pentaho.com/browse/MONDRIAN-2613">
+     * MONDRIAN-2613</a>,
+     * "ArrayIndexOutOfBoundsException in mondrian.util.Format.formatFd2
+     * formatting a BigDecimal".
+     */
+    public void testBigDecimalWithSpecificCustomFormat() {
+      //the format string used in the jira case
+      final String format = "0000000000000";
+      //test data from the jira case
+      checkFormat(null, new BigDecimal("109146240.292"), format, "0000109146240");
+      checkFormat(null, new BigDecimal("0.123"), format, "0000000000000");
+      //additional data
+      checkFormat(null, new BigDecimal("1.1"), format, "0000000000001");
+      checkFormat(null, new BigDecimal("-1.1"), format, "-0000000000001");
+      checkFormat(null, new BigDecimal("0.1"), format, "0000000000000");
+      checkFormat(null, new BigDecimal("-0.1"), format, "0000000000000");
+      checkFormat(null, new BigDecimal("100000000.1"), format, "0000100000000");
+      checkFormat(null, new BigDecimal("-100000000.1"), format, "-0000100000000");
+      checkFormat(null, new BigDecimal("100000001.1"), format, "0000100000001");
+      checkFormat(null, new BigDecimal("100000000.5"), format, "0000100000001");
+      }
 }
 
 // End FormatTest.java

--- a/mondrian/src/main/java/mondrian/util/Format.java
+++ b/mondrian/src/main/java/mondrian/util/Format.java
@@ -2936,8 +2936,13 @@ public class Format {
         //         +maxDigitsRightOfDecimal
         //          + 10  (for decimal point and sign or -Infinity)
         //         +decExponent/3 (for the thousand separators)
+        // crashes e.g. for 1.1 and format '0000000000000'
         int resultLen =
-            10 + Math.abs(fd.decExponent) * 4 / 3 + maxDigitsRightOfDecimal;
+            10
+            + Math.max(
+                Math.abs(fd.decExponent),
+                minDigitsLeftOfDecimal) * 4 / 3
+            + maxDigitsRightOfDecimal;
         char result[] = new char[resultLen];
         int i = formatFd1(
             fd,


### PR DESCRIPTION
… in mondrian.util.Format.formatFd2 formatting a BigDecimal (8.0 Suite)

This is the cherry-pick of the fix for [MONDRIAN-2613]: ArrayIndexOutOfBoundsException in mondrian.util.Format.formatFd2 formatting a BigDecimal

There are fix and unit tests.