### PR TITLE
[SP-4149]: Backport of MONDRIAN-2613 - ArrayIndexOutOfBoundsException…

### DIFF
--- a/mondrian/src/it/java/mondrian/util/FormatTest.java
+++ b/mondrian/src/it/java/mondrian/util/FormatTest.java
@@ -4,7 +4,7 @@
 * http://www.eclipse.org/legal/epl-v10.html.
 * You must accept the terms of that agreement to use this software.
 *
-* Copyright (c) 2002-2017 Pentaho Corporation..  All rights reserved.
+* Copyright (c) 2002-2018 Hitachi Vantara..  All rights reserved.
 */
 
 package mondrian.util;
@@ -890,6 +890,29 @@ public class FormatTest extends TestCase {
         // It should run without losing precision
         Assert.assertEquals("123 456 789 123 456 789 123 456 789", result.toString());
     }
+
+    /**
+     * Test case for bug <a href="http://jira.pentaho.com/browse/MONDRIAN-2613">
+     * MONDRIAN-2613</a>,
+     * "ArrayIndexOutOfBoundsException in mondrian.util.Format.formatFd2
+     * formatting a BigDecimal".
+     */
+    public void testBigDecimalWithSpecificCustomFormat() {
+      //the format string used in the jira case
+      final String format = "0000000000000";
+      //test data from the jira case
+      checkFormat(null, new BigDecimal("109146240.292"), format, "0000109146240");
+      checkFormat(null, new BigDecimal("0.123"), format, "0000000000000");
+      //additional data
+      checkFormat(null, new BigDecimal("1.1"), format, "0000000000001");
+      checkFormat(null, new BigDecimal("-1.1"), format, "-0000000000001");
+      checkFormat(null, new BigDecimal("0.1"), format, "0000000000000");
+      checkFormat(null, new BigDecimal("-0.1"), format, "0000000000000");
+      checkFormat(null, new BigDecimal("100000000.1"), format, "0000100000000");
+      checkFormat(null, new BigDecimal("-100000000.1"), format, "-0000100000000");
+      checkFormat(null, new BigDecimal("100000001.1"), format, "0000100000001");
+      checkFormat(null, new BigDecimal("100000000.5"), format, "0000100000001");
+      }
 }
 
 // End FormatTest.java

--- a/mondrian/src/main/java/mondrian/util/Format.java
+++ b/mondrian/src/main/java/mondrian/util/Format.java
@@ -5,7 +5,7 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2000-2005 Julian Hyde
-// Copyright (C) 2005-2018 Pentaho and others
+// Copyright (C) 2005-2018 Hitachi Vantara..
 // All Rights Reserved.
 //
 // jhyde, 2 November, 2000
@@ -2936,8 +2936,13 @@ public class Format {
         //         +maxDigitsRightOfDecimal
         //          + 10  (for decimal point and sign or -Infinity)
         //         +decExponent/3 (for the thousand separators)
+        // crashes e.g. for 1.1 and format '0000000000000'
         int resultLen =
-            10 + Math.abs(fd.decExponent) * 4 / 3 + maxDigitsRightOfDecimal;
+            10
+            + Math.max(
+                Math.abs(fd.decExponent),
+                minDigitsLeftOfDecimal) * 4 / 3
+            + maxDigitsRightOfDecimal;
         char result[] = new char[resultLen];
         int i = formatFd1(
             fd,


### PR DESCRIPTION
… in mondrian.util.Format.formatFd2 formatting a BigDecimal (7.1 Suite)

This is the cherry-pick of the fix for [MONDRIAN-2613]: ArrayIndexOutOfBoundsException in mondrian.util.Format.formatFd2 formatting a BigDecimal
There are fix and unit tests.