### PR TITLE
Introduce Locus.isEmpty to prevent exceptions

### DIFF
--- a/mondrian/src/main/java/mondrian/server/Execution.java
+++ b/mondrian/src/main/java/mondrian/server/Execution.java
@@ -96,7 +96,11 @@ public class Execution {
     {
         Execution parentExec;
         try {
-            parentExec = Locus.peek().execution;
+            if (Locus.isEmpty()) {
+                parentExec = null;
+            } else {
+                parentExec = Locus.peek().execution;
+            }
         } catch (EmptyStackException e) {
             parentExec = null;
         }

--- a/mondrian/src/main/java/mondrian/server/Locus.java
+++ b/mondrian/src/main/java/mondrian/server/Locus.java
@@ -60,6 +60,10 @@ public class Locus {
     public static Locus peek() {
         return THREAD_LOCAL.get().peek();
     }
+    
+    public static boolean isEmpty() {
+        return THREAD_LOCAL.get().isEmpty();
+    }
 
     public static <T> T execute(
         RolapConnection connection,


### PR DESCRIPTION
Hello. We observe queries execution time from 10sec to 2 seconds by not trying to peek from Lokus when it is empty