### PR TITLE
Enable caching member properties even if data-cache is disabled

### DIFF
--- a/mondrian/src/main/java/mondrian/olap/MondrianProperties.xml
+++ b/mondrian/src/main/java/mondrian/olap/MondrianProperties.xml
@@ -613,6 +613,19 @@ query to the next (the cache is cleared after each query).
         <Default>false</Default>
     </PropertyDefinition>
     <PropertyDefinition>
+        <Name>ForceMemberCaching</Name>
+        <Path>mondrian.rolap.star.forceMemberCaching</Path>
+        <Category>Caching</Category>
+        <Description>
+Boolean property that controls whether Axis Members
+properties (especially member children) should be cached.
+If true, member children will be cached even if 
+DisableCaching is true (which is useful not to cache data).
+        </Description>
+        <Type>boolean</Type>
+        <Default>false</Default>
+    </PropertyDefinition>
+    <PropertyDefinition>
         <Name>DisableLocalSegmentCache</Name>
         <Path>mondrian.rolap.star.disableLocalSegmentCache</Path>
         <Category>Caching</Category>

--- a/mondrian/src/main/java/mondrian/rolap/RolapSchema.java
+++ b/mondrian/src/main/java/mondrian/rolap/RolapSchema.java
@@ -1251,7 +1251,7 @@ System.out.println("RolapSchema.createMemberReader: CONTAINS NAME");
             } else {
                 LOGGER.debug(
                     "Normal cardinality for " + hierarchy.getDimension());
-                if (MondrianProperties.instance().DisableCaching.get()) {
+                if (MondrianProperties.instance().DisableCaching.get() && !MondrianProperties.instance().ForceMemberCaching.get()) {
                     // If the cell cache is disabled, we can't cache
                     // the members or else we get undefined results,
                     // depending on the functions used and all.


### PR DESCRIPTION
We observed MDX execution timings dropping from 60s to 10s by caching member details, even if data-caching is enabled.