### PR TITLE
[MONDRIAN-2622] - Does Not Contain Filter from Analyzer (NOT MATCHES)…

### DIFF
--- a/mondrian/src/main/java/mondrian/rolap/sql/MemberListCrossJoinArg.java
+++ b/mondrian/src/main/java/mondrian/rolap/sql/MemberListCrossJoinArg.java
@@ -5,13 +5,12 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2004-2005 TONBELLER AG
-// Copyright (C) 2006-2017 Hitachi Vantara and others
+// Copyright (C) 2006-2018 Hitachi Vantara and others
 // All Rights Reserved.
 */
 
 package mondrian.rolap.sql;
 
-import mondrian.olap.MondrianProperties;
 import mondrian.rolap.*;
 import mondrian.rolap.aggmatcher.AggStar;
 
@@ -62,7 +61,7 @@ public class MemberListCrossJoinArg implements CrossJoinArg {
 
         // First check that the member list will not result in a predicate
         // longer than the underlying DB could support.
-        if (argSize > MondrianProperties.instance().MaxConstraints.get()) {
+        if (argSize > evaluator.getDialect().getMaxConstraints()) {
             argSizeNotSupported = true;
         }
 

--- a/mondrian/src/main/java/mondrian/spi/Dialect.java
+++ b/mondrian/src/main/java/mondrian/spi/Dialect.java
@@ -806,6 +806,14 @@ public interface Dialect {
         throws SQLException;
 
     /**
+     * Retrieves the maximum number of constraints in a single 'IN' SQL clause based on dialect information
+     * This value might depend on database products or on their runtime settings.
+     *
+     * @return The maximum number of constraints in a single 'IN' SQL clause
+     */
+    int getMaxConstraints();
+
+    /**
      * Enumeration of common database types.
      *
      * <p>Branching on this enumeration allows you to write code which behaves

--- a/mondrian/src/main/java/mondrian/spi/impl/Db2Dialect.java
+++ b/mondrian/src/main/java/mondrian/spi/impl/Db2Dialect.java
@@ -4,7 +4,7 @@
 // http://www.eclipse.org/legal/epl-v10.html.
 // You must accept the terms of that agreement to use this software.
 //
-// Copyright (c) 2002-2017 Hitachi Vantara..  All rights reserved.
+// Copyright (c) 2002-2018 Hitachi Vantara..  All rights reserved.
 */
 package mondrian.spi.impl;
 
@@ -20,6 +20,8 @@ import java.sql.SQLException;
  * @since Nov 23, 2008
  */
 public class Db2Dialect extends JdbcDialectImpl {
+
+    private final int MAX_CONSTRAINTS = 2500;
 
     public static final JdbcDialectFactory FACTORY =
         new JdbcDialectFactory(
@@ -41,6 +43,11 @@ public class Db2Dialect extends JdbcDialectImpl {
 
     public boolean supportsGroupingSets() {
         return true;
+    }
+
+    @Override
+    public int getMaxConstraints() {
+        return MAX_CONSTRAINTS;
     }
 }
 

--- a/mondrian/src/main/java/mondrian/spi/impl/JdbcDialectImpl.java
+++ b/mondrian/src/main/java/mondrian/spi/impl/JdbcDialectImpl.java
@@ -939,6 +939,11 @@ public class JdbcDialectImpl implements Dialect {
         return internalType;
     }
 
+    @Override
+    public int getMaxConstraints() {
+        return MondrianProperties.instance().MaxConstraints.get();
+    }
+
 
     void logTypeInfo(
         ResultSetMetaData metaData, int columnIndex,

--- a/mondrian/src/main/java/mondrian/spi/impl/MySqlDialect.java
+++ b/mondrian/src/main/java/mondrian/spi/impl/MySqlDialect.java
@@ -4,7 +4,7 @@
 // http://www.eclipse.org/legal/epl-v10.html.
 // You must accept the terms of that agreement to use this software.
 //
-// Copyright (C) 2002-2017 Hitachi Vantara and others
+// Copyright (C) 2002-2018 Hitachi Vantara and others
 // All Rights Reserved.
 */
 package mondrian.spi.impl;
@@ -29,6 +29,7 @@ public class MySqlDialect extends JdbcDialectImpl {
     private final Pattern flagsPattern = Pattern.compile(flagsRegexp);
     private final String escapeRegexp = "(\\\\Q([^\\\\Q]+)\\\\E)";
     private final Pattern escapePattern = Pattern.compile(escapeRegexp);
+    private final int MAX_CONSTRAINTS = 10000;
 
     public static final JdbcDialectFactory FACTORY =
         new JdbcDialectFactory(
@@ -365,6 +366,11 @@ public class MySqlDialect extends JdbcDialectImpl {
     @Override
     public boolean requiresOrderByAlias() {
         return productVersion.compareTo("5.7") >= 0;
+    }
+
+    @Override
+    public int getMaxConstraints() {
+        return MAX_CONSTRAINTS;
     }
 }
 


### PR DESCRIPTION
… is not natively evaluated resulting in CrossJoin result exceeded limit

* Changed the calculation of maximum number of constraints in a single 'IN' SQL clause and it's now based on dialect information