### PR TITLE
[MONDRIAN-2633] - Regression: Aggregate Tables not hit when Using a D…

### DIFF
--- a/mondrian/src/it/java/mondrian/rolap/SqlConstraintUtilsTest.java
+++ b/mondrian/src/it/java/mondrian/rolap/SqlConstraintUtilsTest.java
@@ -5,7 +5,7 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2003-2005 Julian Hyde
-// Copyright (C) 2005-2017 Hitachi Vantara and others
+// Copyright (C) 2005-2018 Hitachi Vantara and others
 // All Rights Reserved.
 */
 package mondrian.rolap;
@@ -35,7 +35,11 @@ import mondrian.olap.type.DecimalType;
 import mondrian.olap.type.NullType;
 import mondrian.olap.type.TupleType;
 import mondrian.olap.type.Type;
+import mondrian.rolap.aggmatcher.AggStar;
+import mondrian.rolap.sql.SqlQuery;
 import mondrian.server.Execution;
+import mondrian.spi.Dialect;
+import mondrian.spi.DialectManager;
 import mondrian.test.FoodMartTestCase;
 import mondrian.test.TestContext;
 
@@ -815,6 +819,30 @@ public class SqlConstraintUtilsTest extends FoodMartTestCase {
         when(mock.isParentChildLeaf()).thenReturn(isParentChildLeaf);
         when(mock.getHierarchy()).thenReturn(hierarchy);
         return mock;
+    }
+
+    public void testConstrainLevel(){
+
+        final RolapCubeLevel level = mock( RolapCubeLevel.class);
+        final RolapCube baseCube = mock(RolapCube.class);
+        final RolapStar.Column column = mock(RolapStar.Column.class);
+
+        final TestContext testContext = TestContext.instance();
+        final Connection connection = testContext.getConnection();
+
+        final AggStar aggStar = null;
+        final Dialect dialect =  DialectManager.createDialect(connection.getDataSource(), null);
+        final SqlQuery query = new SqlQuery(dialect);
+
+        when(level.getBaseStarKeyColumn(baseCube)).thenReturn(column);
+        when(column.getNameColumn()).thenReturn(column);
+        when(column.generateExprString(query)).thenReturn("dummyName");
+
+        String[] columnValue = new String[1];
+        columnValue[0] = "dummyValue";
+
+        String levelStr = SqlConstraintUtils.constrainLevel(level, query, baseCube, aggStar, columnValue, false);
+        assertEquals("dummyName = 'dummyValue'",  levelStr);
     }
 }
 

--- a/mondrian/src/main/java/mondrian/resource/MondrianResource.xml
+++ b/mondrian/src/main/java/mondrian/resource/MondrianResource.xml
@@ -790,6 +790,12 @@
         Zero size Aggregate table ''{0}'' for Fact Table ''{1}''.
     </text>
 </message>
+
+<message id="7000421" name="AggTableNoConstraintGenerated">
+    <text>
+        Aggregate star fact table ''{0}'':  A constraint will not be generated because name column is not the same as key column.
+    </text>
+</message>
 <!-- Aggregate tables: end -->
 
 <exception id="7000500" name="CacheFlushRegionMustContainMembers">

--- a/mondrian/src/main/java/mondrian/rolap/SqlConstraintUtils.java
+++ b/mondrian/src/main/java/mondrian/rolap/SqlConstraintUtils.java
@@ -6,7 +6,7 @@
 //
 // Copyright (C) 2004-2005 TONBELLER AG
 // Copyright (C) 2005-2005 Julian Hyde
-// Copyright (C) 2005-2017 Hitachi Vantara and others
+// Copyright (C) 2005-2018 Hitachi Vantara and others
 // All Rights Reserved.
 */
 package mondrian.rolap;
@@ -75,6 +75,7 @@ public class SqlConstraintUtils {
 
     private static final Logger LOG =
         Logger.getLogger(SqlConstraintUtils.class);
+    private static final MondrianResource mres = MondrianResource.instance();
 
     /** Utility class */
     private SqlConstraintUtils() {
@@ -1674,6 +1675,12 @@ public class SqlConstraintUtils {
                 // as the key column
                 int bitPos = column.getBitPosition();
                 AggStar.Table.Column aggColumn = aggStar.lookupColumn(bitPos);
+
+                if(aggColumn == null){
+                    LOG.warn(mres.AggTableNoConstraintGenerated.str(aggStar.getFactTable().getName()));
+                    return "";
+                }
+
                 columnString = aggColumn.generateExprString(query);
             } else {
                 columnString = column.generateExprString(query);

--- a/mondrian/src/main/java/mondrian/rolap/SqlTupleReader.java
+++ b/mondrian/src/main/java/mondrian/rolap/SqlTupleReader.java
@@ -1797,20 +1797,6 @@ public class SqlTupleReader implements TupleReader {
                             // target group.
                             continue;
                         }
-                        // member constraint
-                        // with name columns in agg table is not supported
-                        if (arg instanceof MemberListCrossJoinArg) {
-                            if (level.getNameExp() != null
-                                    && !Util.equals(
-                                        level.getNameExp(), level.getKeyExp()))
-                            {
-                                LOGGER.warn(
-                                    ""
-                                    + "Member constraint"
-                                    + " is not supported with name column in agg table");
-                                return null;
-                            }
-                        }
                         levelBitKey.set(column.getBitPosition());
                     }
                 }


### PR DESCRIPTION
…imension Filter

* Fixed a side effect introduced in MONDRIAN-2285.
* Improved mechanism in aggregate table: a constraint will not be generated because name column is not the same as key column.