### PR TITLE
[MONDRIAN-2640] - SqlMemberSource.getMemberChildren queries fired dow…

### DIFF
--- a/mondrian/src/it/java/mondrian/rolap/RestrictedMemberReaderTest.java
+++ b/mondrian/src/it/java/mondrian/rolap/RestrictedMemberReaderTest.java
@@ -4,7 +4,7 @@
 // http://www.eclipse.org/legal/epl-v10.html.
 // You must accept the terms of that agreement to use this software.
 //
-// Copyright (c) 2002-2017 Hitachi Vantara..  All rights reserved.
+// Copyright (c) 2002-2018 Hitachi Vantara..  All rights reserved.
 */
 package mondrian.rolap;
 
@@ -17,15 +17,17 @@ import mondrian.olap.Role;
 import mondrian.olap.Role.HierarchyAccess;
 import mondrian.olap.Schema;
 import mondrian.rolap.RestrictedMemberReader.MultiCardinalityDefaultMember;
+import mondrian.rolap.sql.MemberChildrenConstraint;
 import mondrian.test.FoodMartTestCase;
 
 import junit.framework.Assert;
 
 import org.mockito.Mockito;
 
+import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 public class RestrictedMemberReaderTest extends FoodMartTestCase {
 
@@ -295,6 +297,37 @@ public class RestrictedMemberReaderTest extends FoodMartTestCase {
       }
     }
     return null;
+  }
+
+  public void testProcessMemberChildren() {
+
+      MemberReader delegateMemberReader = Mockito.mock(MemberReader.class);
+      MemberChildrenConstraint constraint = Mockito.mock(MemberChildrenConstraint.class);
+      Role role = Mockito.mock(Role.class);
+      Schema schema = Mockito.mock(Schema.class);
+      Dimension dimension = Mockito.mock(Dimension.class);
+      RolapHierarchy hierarchy = Mockito.mock(RolapHierarchy.class);
+
+      Level[] hierarchyAccessLevels = new Level[] { null };
+
+      Mockito.doReturn(schema).when(dimension).getSchema();
+      Mockito.doReturn(dimension).when(hierarchy).getDimension();
+      Mockito.doReturn(hierarchyAccessLevels).when(hierarchy).getLevels();
+      Mockito.doReturn(true).when(hierarchy).isRagged();
+      Mockito.doReturn(hierarchy).when(delegateMemberReader).getHierarchy();
+
+      List<RolapMember> children = new ArrayList<>();
+      children.add(mockMember());
+
+      List<RolapMember> fullChildren = new ArrayList<>();
+      fullChildren.add(mockMember());
+      fullChildren.add(mockMember());
+
+      rmr = new RestrictedMemberReader(delegateMemberReader, role);
+      final Map<RolapMember, Access> testResult = rmr.processMemberChildren(fullChildren, children, constraint);
+
+      Assert.assertEquals(2, testResult.size());
+      Assert.assertTrue(testResult.containsValue(Access.ALL));
   }
 }
 // End RestrictedMemberReaderTest.java

--- a/mondrian/src/main/java/mondrian/rolap/RestrictedMemberReader.java
+++ b/mondrian/src/main/java/mondrian/rolap/RestrictedMemberReader.java
@@ -5,7 +5,7 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2003-2005 Julian Hyde
-// Copyright (C) 2005-2017 Hitachi Vantara
+// Copyright (C) 2005-2018 Hitachi Vantara
 // All Rights Reserved.
 */
 package mondrian.rolap;
@@ -121,7 +121,7 @@ class RestrictedMemberReader extends DelegatingMemberReader {
         return processMemberChildren(fullChildren, children, constraint);
     }
 
-    private Map<RolapMember, Access> processMemberChildren(
+    Map<RolapMember, Access> processMemberChildren(
         List<RolapMember> fullChildren,
         List<RolapMember> children,
         MemberChildrenConstraint constraint)
@@ -134,15 +134,8 @@ class RestrictedMemberReader extends DelegatingMemberReader {
             RolapMember member = fullChildren.get(i);
 
             // If a child is hidden (due to raggedness)
-            // or doesn't have access include its children.
             // This must be done before applying access-control.
-            final Access access;
-            if (hierarchyAccess != null) {
-                access = hierarchyAccess.getAccess(member);
-            } else {
-                access = Access.ALL;
-            }
-            if ((ragged && member.isHidden()) || access.equals(Access.NONE)) {
+            if ((ragged && member.isHidden())) {
                 // Replace this member with all of its children.
                 // They might be hidden too, but we'll get to them in due
                 // course. They also might be access-controlled; that's why
@@ -164,6 +157,12 @@ class RestrictedMemberReader extends DelegatingMemberReader {
 
             // Filter out children which are invisible because of
             // access-control.
+            final Access access;
+            if (hierarchyAccess != null) {
+                access = hierarchyAccess.getAccess(member);
+            } else {
+                access = Access.ALL;
+            }
             switch (access) {
             case NONE:
                 break;


### PR DESCRIPTION
…n to the lowest level when using role with topLevel thus causing performance issues

* Adjusted implementation of MONDRIAN-2440 in order to avoid a side effect.