### PR TITLE
[PPP-4271] - Fixed Use of Vulnerable Component: xercesImpl-2.11.0 and…

### DIFF
--- a/assemblies/psw-ce/pom.xml
+++ b/assemblies/psw-ce/pom.xml
@@ -209,7 +209,6 @@
     <dependency>
       <groupId>xerces</groupId>
       <artifactId>xercesImpl</artifactId>
-      <version>${xercesImpl.version}</version>
     </dependency>
     <dependency>
       <groupId>pentaho</groupId>

--- a/mondrian/pom.xml
+++ b/mondrian/pom.xml
@@ -14,7 +14,6 @@
   <url>http://mondrian.pentaho.com</url>
   <properties>
     <project.version.minor>000</project.version.minor>
-    <xml-apis.version>2.0.2</xml-apis.version>
     <driver.version>${project.version}</driver.version>
     <project.version.major>8</project.version.major>
     <schema.version>3</schema.version>
@@ -27,7 +26,6 @@
     <dependency>
       <groupId>xml-apis</groupId>
       <artifactId>xml-apis</artifactId>
-      <version>${xml-apis.version}</version>
     </dependency>
     <dependency>
       <groupId>commons-collections</groupId>
@@ -118,7 +116,6 @@
     <dependency>
       <groupId>xerces</groupId>
       <artifactId>xercesImpl</artifactId>
-      <version>${xercesImpl.version}</version>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,6 @@
     <maven-bundle-plugin.version>2.3.7</maven-bundle-plugin.version>
     <commons-pool.version>1.2</commons-pool.version>
     <validation-api.version>1.0.0.GA</validation-api.version>
-    <xercesImpl.version>2.9.1</xercesImpl.version>
     <commons-collections.version>3.2.2</commons-collections.version>
     <commons-math.version>1.1</commons-math.version>
     <olap4j-xmla.version>1.2.0</olap4j-xmla.version>


### PR DESCRIPTION
… xercesImpl-2.9.1 (CVE-2013-4002 | CVE-2012-0881 | CVE-2009-2625 | sonatype-2017-0348)

Do not merge before https://github.com/pentaho/maven-parent-poms/pull/120.
This is a series of PRs to update Apache Xerces to version 2.12.0.

@pentaho-lmartins 