### PR TITLE
[BACKLOG-30300]  PSW/Mondrian Error on debug log file w/ some db types

### DIFF
--- a/mondrian/src/main/java/mondrian/spi/impl/JdbcDialectImpl.java
+++ b/mondrian/src/main/java/mondrian/spi/impl/JdbcDialectImpl.java
@@ -4,7 +4,7 @@
 // http://www.eclipse.org/legal/epl-v10.html.
 // You must accept the terms of that agreement to use this software.
 //
-// Copyright (c) 2002-2018 Hitachi Vantara.  All rights reserved.
+// Copyright (c) 2002-2019 Hitachi Vantara.  All rights reserved.
 */
 package mondrian.spi.impl;
 
@@ -1169,8 +1169,11 @@ public class JdbcDialectImpl implements Dialect {
             LOGGER.debug("NOT Using " + databaseProduct.name() + " dialect");
             return false;
         } catch (SQLException e) {
-            LOGGER.debug(
-                "NOT Using " + databaseProduct.name() + " dialect.", e);
+            // this exception can be hit by any db types that don't support
+            // 'select version()'
+            // no need to log exception, this is an "expected" error as we
+            // loop through all dialects looking for one that matches.
+            LOGGER.debug("NOT Using " + databaseProduct.name() + " dialect.");
             return false;
         } finally {
             Util.close(resultSet, statement, null);


### PR DESCRIPTION
Mondrian iterates through each supported dialect when looking for
a dialect appropriate for the current connection.  For some dbtypes
(redshift, impala, hive, etc.) we fall back to attempting to get
the type via "select version()".  For any db that doesn't support
version(), we would log the stacktrace.

Removing the stacktrace from debug logging, since it's misleading.
The error is expected and allowable in such cases, and just means
that the dialect is not correct for the given connection.

https://jira.pentaho.com/browse/BACKLOG-30300