### PR TITLE
[MONDRIAN-2630] Mondrian: filter a set of members including null, plu…

### DIFF
--- a/mondrian/src/main/java/mondrian/rolap/SqlConstraintUtils.java
+++ b/mondrian/src/main/java/mondrian/rolap/SqlConstraintUtils.java
@@ -565,10 +565,21 @@ public class SqlConstraintUtils {
         String expr,
         final String value)
     {
-        // No extra slicers.... just use the = method
-        final StringBuilder buf = new StringBuilder();
-        sqlQuery.getDialect().quote(buf, value, column.getDatatype());
-        sqlQuery.addWhere(expr, " = ", buf.toString());
+        if ((RolapUtil.mdxNullLiteral().equalsIgnoreCase(value))
+                || (value.equalsIgnoreCase(RolapUtil.sqlNullValue.toString())))
+        {
+            sqlQuery.addWhere(expr, " is ", RolapUtil.sqlNullLiteral);
+        } else {
+            if ( column.getDatatype().isNumeric() ) {
+                // make sure it can be parsed
+                Double.valueOf( value );
+            }
+
+            // No extra slicers.... just use the = method
+            final StringBuilder buf = new StringBuilder();
+            sqlQuery.getDialect().quote(buf, value, column.getDatatype());
+            sqlQuery.addWhere(expr, " = ", buf.toString());
+        }
     }
 
     public static Map<Level, List<RolapMember>> getRoleConstraintMembers(


### PR DESCRIPTION
…s a numeric filter, results in incorrect data

Hey @mkambol, when a column wasn't constrained by a slicer, we weren't building the "IS NULL" expression, that's the reason why testNativeWithOverriddenNullMemberRepAndNullConstraint was failing.