### PR TITLE
Don't do an IN clause on the fact table for degenerate dimensions

### DIFF
--- a/mondrian/src/main/java/mondrian/rolap/agg/Aggregation.java
+++ b/mondrian/src/main/java/mondrian/rolap/agg/Aggregation.java
@@ -229,7 +229,12 @@ public class Aggregation {
                 continue;
             }
 
-            if (valueCount > maxConstraints) {
+            if (valueCount > maxConstraints || columns[i].getTable().getTableName().equalsIgnoreCase(columns[i].getStar().getFactTable().getTableName())) {
+                
+                // if we have a degenerate dimension
+                // we don't want to do an IN clause on lots of columns on the fact table
+                // especially if these aren't indexed
+                
                 // Some databases can handle only a limited number of elements
                 // in 'WHERE IN (...)'. This set is greater than this database
                 // can handle, so we drop this constraint. Hopefully there are


### PR DESCRIPTION
This change prevents large IN clauses on the fact table, when you have degenerate dimensions.  

The following query would have an IN clause containing hundreds of customer's last names.

with
set [slimline] as Order({[Products].[Slimline Curve Electric Radiator],[Products].[Slimline Digital Electric Radiator]},[Products].currentmember.level.Ordinal)
set [ProductsNS] as {[slimline]}
member [Products].[Filter] as Aggregate([ProductsNS])
set [Grouping] as TopCount(Filter({[Customers].[Name].members},not isempty([Measures].[Unit Sales])),5,([Measures].[Unit Sales]))
select
{[Measures].[Unit Sales]}  on axis(0)
,{[Grouping]}  on axis(1)
from [Sales]
where ([Products].[Filter],[Time].[2019].[Q4].[October])

When using mondrian against mongodb it is efficient to have degenerate dimensions.  This is because mongodb performs poorly with Lookups (and it shouldn't be used as am RDBMS).