### PR TITLE
[SP-5310] Backport of MONDRIAN-2674 - NullPointerException on Mondrian.rolap.cache.SegmentCacheIndexImpl (8.3 Suite)

### DIFF
--- a/mondrian/src/it/java/mondrian/rolap/cache/SegmentCacheIndexImplTest.java
+++ b/mondrian/src/it/java/mondrian/rolap/cache/SegmentCacheIndexImplTest.java
@@ -1,0 +1,31 @@
+/*
+// This software is subject to the terms of the Eclipse Public License v1.0
+// Agreement, available at the following URL:
+// http://www.eclipse.org/legal/epl-v10.html.
+// You must accept the terms of that agreement to use this software.
+//
+// Copyright (c) 2019-2019 Hitachi Vantara.
+// All Rights Reserved.
+*/
+package mondrian.rolap.cache;
+
+import static org.mockito.Mockito.mock;
+
+import mondrian.spi.SegmentBody;
+import mondrian.spi.SegmentHeader;
+import mondrian.test.FoodMartTestCase;
+
+public class SegmentCacheIndexImplTest extends FoodMartTestCase {
+    public void testNoHeaderOnLoad() {
+        final SegmentCacheIndexImpl index =
+            new SegmentCacheIndexImpl(Thread.currentThread());
+
+        final SegmentHeader header = mock(SegmentHeader.class);
+        final SegmentBody body = mock(SegmentBody.class);
+
+        // This should not fail.
+        index.loadSucceeded(header, body);
+    }
+}
+
+//End SegmentCacheIndexImplTest.java

--- a/mondrian/src/it/java/mondrian/test/Main.java
+++ b/mondrian/src/it/java/mondrian/test/Main.java
@@ -22,6 +22,7 @@ import mondrian.olap4j.XmlaExtraTest;
 import mondrian.rolap.*;
 import mondrian.rolap.agg.*;
 import mondrian.rolap.aggmatcher.*;
+import mondrian.rolap.cache.SegmentCacheIndexImplTest;
 import mondrian.rolap.format.DefaultFormatterTest;
 import mondrian.rolap.format.FormatterCreateContextTest;
 import mondrian.rolap.format.FormatterFactoryTest;
@@ -178,6 +179,7 @@ public class Main extends TestSuite {
             addTest(suite, ScenarioTest.class);
             addTest(suite, BasicQueryTest.class);
             addTest(suite, SegmentCacheTest.class);
+            addTest(suite, SegmentCacheIndexImplTest.class);
             addTest(suite, CVBasicTest.class, "suite");
             addTest(suite, GrandTotalTest.class, "suite");
             addTest(suite, HangerDimensionTest.class, "suite");

--- a/mondrian/src/main/java/mondrian/rolap/cache/SegmentCacheIndexImpl.java
+++ b/mondrian/src/main/java/mondrian/rolap/cache/SegmentCacheIndexImpl.java
@@ -4,7 +4,7 @@
 // http://www.eclipse.org/legal/epl-v10.html.
 // You must accept the terms of that agreement to use this software.
 //
-// Copyright (c) 2002-2017 Hitachi Vantara.
+// Copyright (c) 2002-2019 Hitachi Vantara.
 // All Rights Reserved.
 */
 package mondrian.rolap.cache;
@@ -267,8 +267,15 @@ public class SegmentCacheIndexImpl implements SegmentCacheIndex {
         checkThread();
 
         final HeaderInfo headerInfo = headerMap.get(header);
-        assert headerInfo != null
-            : "segment header " + header.getUniqueID() + " is missing";
+
+        if (headerInfo == null) {
+            LOGGER.trace(
+                "loadSucceeded: Discarding data for header "
+                + header.getUniqueID()
+                + ". Data arrived late.");
+            return;
+        }
+
         if (!headerInfo.slot.isDone()) {
             headerInfo.slot.put(body);
         }


### PR DESCRIPTION
Merge Masters: @pentaho-lmartins  and @smmribeiro
Cherry-picks:
* https://github.com/Pentaho/mondrian/commit/e967bf0ed1f43e11d4d6bcf1d89600a8ae53cf9b
