### PR TITLE
[BACKLOG-33104] - Copyright needs to be updated to 2020 on 'Info.plis…

### DIFF
--- a/assemblies/psw-ce/src/main/resources/Schema_Workbench.app/Contents/Info.plist
+++ b/assemblies/psw-ce/src/main/resources/Schema_Workbench.app/Contents/Info.plist
@@ -22,5 +22,7 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>1.6</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright (c) 2020 Hitachi Vantara. All rights reserved</string>
 </dict>
 </plist>


### PR DESCRIPTION
…t' for each client tool

@pentaho/millenniumfalcon 