### PR TITLE
[MONDRIAN-2662] making the resultlimit value stored in ArrayTupleList…

### DIFF
--- a/mondrian/src/main/java/mondrian/calc/impl/ArrayTupleList.java
+++ b/mondrian/src/main/java/mondrian/calc/impl/ArrayTupleList.java
@@ -32,7 +32,7 @@ import java.util.Objects;
 public class ArrayTupleList extends AbstractEndToEndTupleList {
   private transient Member[] objectData;
   private int size;
-  private static final int CJ_MAX_SIZE = MondrianProperties.instance().ResultLimit.get();
+  private final int cjMaxSize = MondrianProperties.instance().ResultLimit.get();
 
   /**
    * Creates an empty ArrayTupleList with an initial capacity of 10 tuples.
@@ -257,9 +257,9 @@ public class ArrayTupleList extends AbstractEndToEndTupleList {
       // Up to next multiple of arity.
       final int rem = newCapacity % arity;
       newCapacity += ( arity - rem );
-      if ( CJ_MAX_SIZE > 0 && newCapacity > CJ_MAX_SIZE ) {
+      if ( cjMaxSize > 0 && newCapacity > cjMaxSize ) {
         throw MondrianResource.instance().TotalMembersLimitExceeded.ex(
-          newCapacity, CJ_MAX_SIZE );
+          newCapacity, cjMaxSize );
       }
       Util.checkCJResultLimit( newCapacity );
       objectData = Util.copyOf( objectData, newCapacity );


### PR DESCRIPTION
… non static

Accidentally set it to static with previous commit, which would prevent the property
from being updated at runtime and used for new tuple lists.