### PR TITLE
[TESTS] Fix integration testing on Windows.

### DIFF
--- a/mondrian/README.md
+++ b/mondrian/README.md
@@ -12,8 +12,6 @@ mvn -DrunITs install
 ```
 Skip the integration tests by omitting `-DrunITs`
 
-The embedded mysql server does not work on Windows.  If you are running on Windows you will need to configure foodmart as explained in the next section.
-
 #### Run Isolate Integration Test
 ```
 mvn verify -DrunITs -Dit.test=NonEmptyTest.java -DfailIfNoTests=false

--- a/mondrian/pom.xml
+++ b/mondrian/pom.xml
@@ -404,6 +404,24 @@
             </executions>
           </plugin>
           <plugin>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <version>1.7</version>
+            <executions>
+              <execution>
+                <id>copy-mysql-cnf</id>
+                <phase>pre-integration-test</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <tasks>
+                    <copy file="${project.build.directory}/mysql-dist/my-default.ini" tofile="${project.build.directory}/mysql-dist/support-files/my-default.cnf" failonerror="false" />
+                  </tasks>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>          
+          <plugin>
             <groupId>com.jcabi</groupId>
             <artifactId>jcabi-mysql-maven-plugin</artifactId>
             <version>${jcabi-mysql-maven-plugin.version}</version>

--- a/mondrian/src/it/java/mondrian/rolap/aggmatcher/SpeciesNonCollapsedAggTest.java
+++ b/mondrian/src/it/java/mondrian/rolap/aggmatcher/SpeciesNonCollapsedAggTest.java
@@ -4,7 +4,7 @@
 * http://www.eclipse.org/legal/epl-v10.html.
 * You must accept the terms of that agreement to use this software.
 *
-* Copyright (c) 2002-2017 Hitachi Vantara..  All rights reserved.
+* Copyright (c) 2002-2020 Hitachi Vantara..  All rights reserved.
 */
 
 package mondrian.rolap.aggmatcher;
@@ -36,7 +36,7 @@ public class SpeciesNonCollapsedAggTest extends AggTableTestCase {
         + "    </Hierarchy>\n"
         + "  </Dimension>\n"
         + "  <Cube name='Test' defaultMeasure='Population'>\n"
-        + "    <Table name='SPECIES_MART'>\n"
+        + "    <Table name='species_mart'>\n" // See MONDRIAN-2237 - Table name needs to be lower case for embedded Windows MySQL integration testing
         + "      <AggName name='AGG_SPECIES_MART'>\n"
         + "        <AggFactCount column='FACT_COUNT' />\n"
         + "        <AggMeasure name='Measures.[Population]' column='POPULATION' />\n"


### PR DESCRIPTION
1)  For embedded MySQL, need to provide default cnf file.  (Same fix applied to Pentaho Analyzer).
2)  Fix integration test failure caused by table name casing difference in Mondrian schema and what actually gets created in Windows MySQL (default lower_case_table_names=1)