### PR TITLE
[SP-5641] Snowflake does not require a column to appear in the

### DIFF
--- a/mondrian/src/main/java/mondrian/spi/impl/SnowflakeDialect.java
+++ b/mondrian/src/main/java/mondrian/spi/impl/SnowflakeDialect.java
@@ -51,25 +51,6 @@ public class SnowflakeDialect extends JdbcDialectImpl {
     return false;
   }
 
-  /**
-   * Requires order by alias, in some cases:
-   *
-   * For example: a select query that lists all the columns used in the ORDER_BY expression will succeed
-   *
-   * <code>SELECT "store_id", "unit_sales" FROM "sales_fact_1997" ORDER BY "store_id" + "unit_sales";</code>
-   *
-   * while a query that only has some of the columns used in the ORDER_BY expression will not:
-   *
-   * <code>SELECT "unit_sales" FROM "sales_fact_1997" ORDER BY "store_id" + "unit_sales";</code>
-   *
-   * @return true,
-   *  in some cases snowflake requires expressions in the ORDER_BY clause to be in aliased in the SELECT clause
-   */
-  @Override
-  public boolean requiresOrderByAlias() {
-    return true;
-  }
-
   @Override
   public boolean allowsRegularExpressionInWhereClause() {
     return true;


### PR DESCRIPTION
SELECT clause with an alias in order to use it in an ORDER BY clause.

This commit is a cherry-pick from master bc5947d77