### PR TITLE
[SP-6319] - Backport of PPP-3713 - Beanshell version we're using is vulnerable to serialization exploit - CVE-2016-2510 (9.3 Suite)

### DIFF
--- a/assemblies/psw-ce/pom.xml
+++ b/assemblies/psw-ce/pom.xml
@@ -110,10 +110,6 @@
           <groupId>org.owasp.antisamy</groupId>
         </exclusion>
         <exclusion>
-          <artifactId>bsh-core</artifactId>
-          <groupId>org.beanshell</groupId>
-        </exclusion>
-        <exclusion>
           <artifactId>commons-digester</artifactId>
           <groupId>commons-digester</groupId>
         </exclusion>


### PR DESCRIPTION
@andreramos89 
@bcostahitachivantara 
@smmribeiro 

Original PR: https://github.com/pentaho/mondrian/pull/1335