### PR TITLE
[MONDRIAN-2720] - GetMemberChildren should not return actual members for distinct count optimization

### DIFF
--- a/mondrian/src/main/java/mondrian/olap/IdBatchResolver.java
+++ b/mondrian/src/main/java/mondrian/olap/IdBatchResolver.java
@@ -17,6 +17,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static org.apache.commons.collections.CollectionUtils.filter;
 
@@ -257,16 +258,13 @@ public final class IdBatchResolver {
     private List<Id.NameSegment> collectChildrenNameSegments(
         final Member parentMember, List<Id> children)
     {
-        filter(
-            children, new Predicate() {
-            // remove children we can't support
-                public boolean evaluate(Object theId)
-                {
-                    Id id = (Id)theId;
-                    return !Util.matches(parentMember, id.getSegments())
-                        && supportedIdentifier(id);
-                }
-            });
+        children.parallelStream()
+          .filter(theId -> {
+              Id id = (Id) theId;
+              return !Util.matches(parentMember, id.getSegments()) && supportedIdentifier(id);
+          })
+          .collect( Collectors.toList());
+
         return new ArrayList(
             CollectionUtils.collect(
                 children, new Transformer()

--- a/mondrian/src/main/java/mondrian/olap/fun/AggregateFunDef.java
+++ b/mondrian/src/main/java/mondrian/olap/fun/AggregateFunDef.java
@@ -569,7 +569,7 @@ public class AggregateFunDef extends AbstractAggregateFunDef {
             if (childrenCountFromCache != -1) {
                 return childrenCountFromCache;
             }
-            return reader.getMemberChildren(parentMember).size();
+            return reader.getLevelCardinality(parentMember.getLevel(), false, true);
         }
     }
 }


### PR DESCRIPTION
@smmribeiro 
@renato-s 
@bcostahitachivantara 

We used SchemaReader.getLevelCardinality (gets the size of the elements loaded to cache for that level) instead of getting all elements and counting them.