### PR TITLE
[SP-6337] - Backport of MONDRIAN-2733 - Performance issues when Mondrian is dealing with large GetMemberChildren queue (9.3 Suite)

### DIFF
--- a/mondrian/src/main/java/mondrian/rolap/MemberCacheHelper.java
+++ b/mondrian/src/main/java/mondrian/rolap/MemberCacheHelper.java
@@ -23,6 +23,7 @@ import org.apache.commons.collections.Predicate;
 
 import java.util.*;
 import java.util.Map.Entry;
+import java.util.stream.Collectors;
 
 import static org.apache.commons.collections.CollectionUtils.filter;
 
@@ -165,8 +166,10 @@ public class MemberCacheHelper implements MemberCache {
             return null;
         }
 
-        boolean foundAll = children.parallelStream().allMatch( member -> childNames.contains( member.getName() ));
-        return foundAll ? children : null;
+        List<RolapMember> foundElements =
+          children.parallelStream().filter( member -> childNames.contains( ( (RolapMember) member ).getName() ) )
+            .collect( Collectors.toList() );
+        return childNames.size() == foundElements.size() ? foundElements : null;
     }
 
     private List<RolapMember> checkDefaultAndNamedChildrenCache(

--- a/mondrian/src/main/java/mondrian/rolap/RolapMember.java
+++ b/mondrian/src/main/java/mondrian/rolap/RolapMember.java
@@ -26,8 +26,6 @@ public interface RolapMember extends Member, RolapCalculation {
     RolapHierarchy getHierarchy();
     RolapLevel getLevel();
 
-    String getName();
-
     /** @deprecated will be removed in mondrian-4.0 */
     boolean isAllMember();
 }


### PR DESCRIPTION
@smmribeiro 
@renato-s 
@bcostahitachivantara 

Fixing problem found in integration tests when checking cache elements are present.