### PR TITLE
Adjustment to default value for attribute type in SharedDimension/PrivateDimension, attribute collapsed added to AggLevel 

### DIFF
--- a/mondrian/src/main/resources/mondrian.xsd
+++ b/mondrian/src/main/resources/mondrian.xsd
@@ -716,7 +716,7 @@
                 </xsd:documentation>
             </xsd:annotation>
         </xsd:attribute>
-        <xsd:attribute name="type" use="optional" default="Standard">
+        <xsd:attribute name="type" use="optional" default="StandardDimension">
             <xsd:annotation>
                 <xsd:documentation>
                     The dimension's type may be one of "Standard" or "Time".
@@ -727,7 +727,7 @@
             </xsd:annotation>
             <xsd:simpleType>
                 <xsd:restriction base="xsd:string">
-                    <xsd:enumeration value="Standard"/>
+                    <xsd:enumeration value="StandardDimension"/>
                     <xsd:enumeration value="TimeDimension"/>
                 </xsd:restriction>
             </xsd:simpleType>
@@ -769,7 +769,7 @@
                 </xsd:documentation>
             </xsd:annotation>
         </xsd:attribute>
-        <xsd:attribute name="type" use="optional" default="Standard">
+        <xsd:attribute name="type" use="optional" default="StandardDimension">
             <xsd:annotation>
                 <xsd:documentation>
                     The dimension's type may be one of "Standard" or "Time".
@@ -780,7 +780,7 @@
             </xsd:annotation>
             <xsd:simpleType>
                 <xsd:restriction base="xsd:string">
-                    <xsd:enumeration value="Standard"/>
+                    <xsd:enumeration value="StandardDimension"/>
                     <xsd:enumeration value="TimeDimension"/>
                 </xsd:restriction>
             </xsd:simpleType>
@@ -1466,6 +1466,13 @@
                                     <xsd:annotation>
                                         <xsd:documentation>
                                             The name of the Cube measure.
+                                        </xsd:documentation>
+                                    </xsd:annotation>
+                                </xsd:attribute>
+                                <xsd:attribute name="collapsed" type="xsd:string">
+                                    <xsd:annotation>
+                                        <xsd:documentation>
+                                            Indicator whether the hierarchy is collapsed or not in the agg table.
                                         </xsd:documentation>
                                     </xsd:annotation>
                                 </xsd:attribute>


### PR DESCRIPTION
- adjusted default value for attribute type in SharedDimension and PrivateDimension from "Standard" to "StandardDimension"

- added attribute collapsed to type AggLevel