### PR TITLE
[PPP-4936] - Vulnerable component upgrade guava version to guava-32.1…

### DIFF
--- a/assemblies/psw-ce/pom.xml
+++ b/assemblies/psw-ce/pom.xml
@@ -16,7 +16,6 @@
   <properties>
     <jlfgr.version>1.0</jlfgr.version>
     <pentaho-launcher.version>10.1.0.0-SNAPSHOT</pentaho-launcher.version>
-    <guava.version>17.0</guava.version>
     <dependency.groovy-all.revision>2.4.8</dependency.groovy-all.revision>
     <pdi-dataservice-client-plugin.version>10.1.0.0-SNAPSHOT</pdi-dataservice-client-plugin.version>
     <oss-licenses.version>10.1.0.0-SNAPSHOT</oss-licenses.version>


### PR DESCRIPTION
[PPP-4936] - Vulnerable component upgrade guava version to guava-32.1.2-jre

[PPP-4936]: https://hv-eng.atlassian.net/browse/PPP-4936?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ