### PR TITLE
[BACKLOG-40978] 10.2: Default driver class used is org.gjt.mm.mysql.driver instead of recommended com.mysql.jdbc.Driver

### DIFF
--- a/workbench/src/main/java/mondrian/gui/PreferencesDialog.java
+++ b/workbench/src/main/java/mondrian/gui/PreferencesDialog.java
@@ -280,7 +280,7 @@ public class PreferencesDialog extends javax.swing.JDialog {
         gridBagConstraints.insets = new java.awt.Insets(4, 4, 4, 4);
         jPanel1.add(requireSchemaButton, gridBagConstraints);
 
-        driverClassTextField.setText("org.gjt.mm.mysql.Driver");
+        driverClassTextField.setText("com.mysql.jdbc.Driver");
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 1;
         gridBagConstraints.gridy = 0;


### PR DESCRIPTION
[BACKLOG-40978] 10.2: Default driver class used is org.gjt.mm.mysql.driver instead of recommended com.mysql.jdbc.Driver

[BACKLOG-40978]: https://hv-eng.atlassian.net/browse/BACKLOG-40978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ