### PR TITLE
[PPP-4784] Vulnerable Component: groovy

### DIFF
--- a/assemblies/psw-ce/pom.xml
+++ b/assemblies/psw-ce/pom.xml
@@ -16,7 +16,7 @@
   <properties>
     <jlfgr.version>1.0</jlfgr.version>
     <pentaho-launcher.version>10.3.0.0-SNAPSHOT</pentaho-launcher.version>
-    <dependency.groovy-all.revision>2.4.8</dependency.groovy-all.revision>
+    <dependency.groovy-all.revision>2.4.21</dependency.groovy-all.revision>
     <pdi-dataservice-client-plugin.version>10.3.0.0-SNAPSHOT</pdi-dataservice-client-plugin.version>
     <oss-licenses.version>10.3.0.0-SNAPSHOT</oss-licenses.version>
     <dependency.jersey.revision>1.19.1</dependency.jersey.revision>

--- a/assemblies/psw-ce/pom.xml
+++ b/assemblies/psw-ce/pom.xml
@@ -184,6 +184,12 @@
       <groupId>org.codehaus.groovy</groupId>
       <artifactId>groovy-all</artifactId>
       <version>${dependency.groovy-all.revision}</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>*</artifactId>
+          <groupId>*</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.sun.jersey</groupId>


### PR DESCRIPTION
- Update groovy minor version to 2.4.21 to address CVE-2020-17521
- exclude transitive dependencies and their vulnerabilities

JIRA: https://hv-eng.atlassian.net/browse/PPP-4784

PR Set:
- https://github.com/pentaho/pentaho-platform/pull/5680
- https://github.com/pentaho/pentaho-reporting/pull/1676
- https://github.com/pentaho/big-data-plugin/pull/2584
- https://github.com/pentaho/pentaho-big-data-ee/pull/612
- https://github.com/pentaho/mondrian/pull/1386