### PR TITLE
fix(XSD): Prevent `PrivateDimensionType` to be used as dimensions of a Schema. [SME-365]

### DIFF
--- a/mondrian/src/main/resources/mondrian.xsd
+++ b/mondrian/src/main/resources/mondrian.xsd
@@ -23,7 +23,7 @@
     <xs:sequence>
       <xs:element name="Annotations" type="AnnotationsType" minOccurs="0"/>
       <xs:element name="Parameter" type="ParameterType" minOccurs="0" maxOccurs="unbounded"/>
-      <xs:element name="Dimension" type="DimensionType" minOccurs="0" maxOccurs="unbounded">
+      <xs:element name="Dimension" type="SharedDimensionType" minOccurs="0" maxOccurs="unbounded">
         <xs:annotation>
           <xs:documentation>
             Dimension available to be used by any cube of this schema.
@@ -229,6 +229,12 @@
       </xs:annotation>
     </xs:attribute>
 
+  </xs:complexType>
+  
+  <xs:complexType name="SharedDimensionType">
+    <xs:complexContent>
+      <xs:extension base="DimensionType"/>
+    </xs:complexContent>
   </xs:complexType>
 
   <xs:complexType name="PrivateDimensionType">


### PR DESCRIPTION
Merge only after [CubeDimensionType json deserialization ](https://github.com/pentaho/semantic-model-editor/blob/53e84f0799c88d8a8db7d753634446667853f2c6/backend/src/main/java/com/pentaho/plugin/semantic_model_editor/mapper/model/CubeDimensionTypeDeserializer.java#L19-L25)has been fixed.