### PR TITLE
fix: replace string simple type usages with a complex type [SME-313]

### DIFF
--- a/mondrian/src/main/resources/mondrian.xsd
+++ b/mondrian/src/main/resources/mondrian.xsd
@@ -1216,7 +1216,7 @@
   <xs:complexType name="CalculatedMemberType">
     <xs:sequence>
       <xs:element name="Annotations" type="AnnotationsType" minOccurs="0"/>
-      <xs:element name="Formula" type="xs:string" minOccurs="0">
+      <xs:element name="Formula" type="FormulaType" minOccurs="0">
         <xs:annotation>
           <xs:documentation>
             MDX expression which gives the value of this member.
@@ -1256,7 +1256,7 @@
         </xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="formula" type="xs:string">
+    <xs:attribute name="formula" type="FormulaType">
       <xs:annotation>
         <xs:documentation>
           MDX expression which gives the value of this member. Equivalent to the Formula sub-element.
@@ -1361,7 +1361,7 @@
 
     <xs:sequence>
       <xs:element name="Annotations" type="AnnotationsType" minOccurs="0"/>
-      <xs:element name="Formula" type="xs:string" minOccurs="0">
+      <xs:element name="Formula" type="FormulaType" minOccurs="0">
         <xs:annotation>
           <xs:documentation>
             MDX expression which gives the value of this set.
@@ -1391,7 +1391,7 @@
         </xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="formula" type="xs:string">
+    <xs:attribute name="formula" type="FormulaType">
       <xs:annotation>
         <xs:documentation>
           MDX expression which gives the value of this set. Equivalent to the Formula sub-element.
@@ -2323,6 +2323,13 @@
           </xs:attribute>
         </xs:extension>
       </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="FormulaType">
+    <xs:complexContent>
+      <xs:extension base="xs:string">
+      </xs:extension>
+    </xs:complexContent>
   </xs:complexType>
 
   <xs:complexType name="ExpressionViewType">

--- a/mondrian/src/main/resources/mondrian.xsd
+++ b/mondrian/src/main/resources/mondrian.xsd
@@ -2325,6 +2325,8 @@
       </xs:complexContent>
   </xs:complexType>
 
+  <!-- Having simple types referenced at elements, introduces issues at jaxb generated code at Semantic Model Editor (SME) project.
+      SME requires the injection of a new smeID attribute at the generated types, that is not possible with the primitive String type. -->
   <xs:complexType name="FormulaType">
     <xs:complexContent>
       <xs:extension base="xs:string">


### PR DESCRIPTION
## Addressed Issue(s)
https://hv-eng.atlassian.net/browse/SME-313

## Description
Having simple types referenced at elements, introduces issues at jaxb generated code at Semantic Model Editor project.
SME requires the injection of a new smeID atribute at the generated types, that is not possible with the primitive String type.

## Checklist
- [ ] Relevant tests have been added
- [ ] This PR should not be squashed
