### PR TITLE
fix: fix FormulaType definition [SME-313]

### DIFF
--- a/mondrian/src/main/resources/mondrian.xsd
+++ b/mondrian/src/main/resources/mondrian.xsd
@@ -2328,10 +2328,10 @@
   <!-- Having simple types referenced at elements, introduces issues at jaxb generated code at Semantic Model Editor (SME) project.
       SME requires the injection of a new smeID attribute at the generated types, that is not possible with the primitive String type. -->
   <xs:complexType name="FormulaType">
-    <xs:complexContent>
+    <xs:simpleContent>
       <xs:extension base="xs:string">
       </xs:extension>
-    </xs:complexContent>
+    </xs:simpleContent>
   </xs:complexType>
 
   <xs:complexType name="ExpressionViewType">


### PR DESCRIPTION
## Addressed Issue(s)
https://hv-eng.atlassian.net/browse/SME-313

## Description
Fix FormulaType definition: simple types as base must be used inside <xs:simpleContent>.
When <complexContent> is used, the base type must be a complexType.

## Checklist
- [ ] Relevant tests have been added
- [ ] This PR should not be squashed