### PR TITLE
[BACKLOG-41287]-Upgrading Mondrian from Java EE to  Jakarta EE to be compatiable with Tomcat-10.X

### DIFF
--- a/mondrian/src/main/java/mondrian/tui/MockHttpServletRequest.java
+++ b/mondrian/src/main/java/mondrian/tui/MockHttpServletRequest.java
@@ -14,6 +14,7 @@ import java.security.Principal;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.*;
+import jakarta.servlet.ServletConnection;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpSession;
 import jakarta.servlet.http.HttpServletRequest;
@@ -473,6 +474,20 @@ public class MockHttpServletRequest implements HttpServletRequest {
 
     @Override
     public AsyncContext startAsync() throws IllegalStateException {
+        return null;
+    }
+    @Override
+    public ServletConnection getServletConnection() {
+        return null;
+    }
+
+    @Override
+    public String getProtocolRequestId() {
+        return null;
+    }
+
+    @Override
+    public String getRequestId() {
         return null;
     }
 


### PR DESCRIPTION
[BACKLOG-41287]-Upgrading Mondrian from Java EE to  Jakarta EE to be compatiable with Tomcat-10.X

[BACKLOG-41287]: https://hv-eng.atlassian.net/browse/BACKLOG-41287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ