### PR TITLE
fix: allow empty string in element name type [SME-529]

### DIFF
--- a/mondrian/src/main/resources/mondrian.xsd
+++ b/mondrian/src/main/resources/mondrian.xsd
@@ -989,6 +989,7 @@
   <xs:simpleType name="ElementNameType">
     <xs:restriction base="xs:string">
       <xs:pattern value="[^ ].*"/>
+      <xs:pattern value=""/>
     </xs:restriction>
   </xs:simpleType>
 


### PR DESCRIPTION
Allow for empty strings in `ElementNameType`. Now only strings with only white spaces will be considered invalid (see https://github.com/pentaho/mondrian/pull/1437)