### PR TITLE
[BACKLOG-43190] License fails to load when opening PSW from outside i…

### DIFF
--- a/assemblies/psw-ce/src/main/resources-filtered/workbench.bat
+++ b/assemblies/psw-ce/src/main/resources-filtered/workbench.bat
@@ -16,7 +16,7 @@ rem Schema Workbench launch script
 
 rem base Mondrian JARs need to be included
 
-set CP=lib/*;plugins/*;drivers/*;lib/
+set CP=%~dp0;lib/*;plugins/*;drivers/*;lib/
 
 rem Have a .schemaWorkbench directory for local 
 

--- a/assemblies/psw-ce/src/main/resources-filtered/workbench.sh
+++ b/assemblies/psw-ce/src/main/resources-filtered/workbench.sh
@@ -30,7 +30,8 @@ Windows_NT|CYGWIN*)
     ;;
 esac
 
-CP="${MONDRIAN_HOME}/lib/*"
+CP="${MONDRIAN_HOME}/"
+CP="${CP}${PS}${MONDRIAN_HOME}/lib/*"
 CP="${CP}${PS}${MONDRIAN_HOME}/plugins/*"
 CP="${CP}${PS}${MONDRIAN_HOME}/drivers/*"
 CP="${CP}${PS}${MONDRIAN_HOME}/lib/"

--- a/workbench/src/main/java/mondrian/gui/Workbench.java
+++ b/workbench/src/main/java/mondrian/gui/Workbench.java
@@ -84,7 +84,7 @@ public class Workbench extends javax.swing.JFrame {
 
     private static final Logger LOGGER = LogManager.getLogger(Workbench.class);
 
-    private static final String LICENSE_FILE_PATH = "./LICENSE.TXT";
+    private static final String LICENSE_FILE = "LICENSE.TXT";
 
     private String jdbcDriverClassName;
     private String jdbcConnectionUrl;
@@ -1140,12 +1140,14 @@ public class Workbench extends javax.swing.JFrame {
           String line;
             try {
                 BufferedReader reader =
-                  new BufferedReader( new FileReader( LICENSE_FILE_PATH ) );
+                  new BufferedReader(
+                    new InputStreamReader( this.getClass().getClassLoader().getResourceAsStream( LICENSE_FILE ) ) );
+
                 while ( ( line = reader.readLine() ) != null ) {
                     sb.append( line + System.getProperty( "line.separator" ) );
                 }
             } catch ( Exception ex ) {
-                sb.append( String.format( "Error reading license file from product directory: \"%s\"", LICENSE_FILE_PATH ) );
+                sb.append( String.format( "Error reading license file from product directory: \"%s\"", LICENSE_FILE ) );
                 LOGGER.error( getResourceConverter().getString( "schemaExplorer.about.licenseTextNotFound",
                   "Failed to load the license text" ), ex );
             }


### PR DESCRIPTION
…ts root directory

- Add LICENSE.TXT to classpath so it can be found on any OS regardless of where the program is started from