### PR TITLE
[MONDRIAN-990] fix: ensure unicode strings are processed correctly

### DIFF
--- a/mondrian/src/it/java/mondrian/rolap/SqlConstraintUtilsTest.java
+++ b/mondrian/src/it/java/mondrian/rolap/SqlConstraintUtilsTest.java
@@ -847,7 +847,13 @@ public class SqlConstraintUtilsTest extends FoodMartTestCase {
         columnValue[0] = "dummyValue";
 
         String levelStr = SqlConstraintUtils.constrainLevel(level, query, baseCube, aggStar, columnValue, false);
-        assertEquals("dummyName = 'dummyValue'",  levelStr);
+
+        // Handle Unicode characters possibility (MONDRIAN-990)
+        if (dialect.getDatabaseProduct() == Dialect.DatabaseProduct.MSSQL || dialect.getDatabaseProduct() == Dialect.DatabaseProduct.ORACLE) {
+            assertEquals("dummyName = N'dummyValue'",  levelStr);
+        } else {
+            assertEquals("dummyName = 'dummyValue'",  levelStr);
+        }
     }
     
     private void setSlicerContext(RolapEvaluator e, Member m) {

--- a/mondrian/src/it/java/mondrian/spi/impl/MicrosoftSqlServerDialectTest.java
+++ b/mondrian/src/it/java/mondrian/spi/impl/MicrosoftSqlServerDialectTest.java
@@ -90,5 +90,11 @@ public class MicrosoftSqlServerDialectTest extends TestCase {
     }
   }
 
+  public void testQuoteStringLiteral() throws Exception {
+    StringBuilder buf = new StringBuilder();
+    String stringToQuote = "test";
+    dialect.quoteStringLiteral(buf, stringToQuote);
+    assertEquals("N'test'", buf.toString());
+  }
 }
 // End MicrosoftSqlServerDialectTest.java

--- a/mondrian/src/it/java/mondrian/spi/impl/OracleDialectTest.java
+++ b/mondrian/src/it/java/mondrian/spi/impl/OracleDialectTest.java
@@ -46,12 +46,19 @@ public class OracleDialectTest extends TestCase {
 
   public void testGenerateRegularExpression_CaseInsensitive() throws Exception {
     String sql = dialect.generateRegularExpression( "table.column", "(?i)|(?u).*a.*" );
-    assertEquals( "table.column IS NOT NULL AND REGEXP_LIKE(table.column, '.*a.*', 'i')", sql );
+    assertEquals( "table.column IS NOT NULL AND REGEXP_LIKE(table.column, N'.*a.*', N'i')", sql );
   }
 
   public void testGenerateRegularExpression_CaseSensitive() throws Exception {
     String sql = dialect.generateRegularExpression( "table.column", ".*a.*" );
-    assertEquals( "table.column IS NOT NULL AND REGEXP_LIKE(table.column, '.*a.*', '')", sql );
+    assertEquals( "table.column IS NOT NULL AND REGEXP_LIKE(table.column, N'.*a.*', N'')", sql );
+  }
+
+  public void testQuoteStringLiteral() throws Exception {
+    StringBuilder buf = new StringBuilder();
+    String stringToQuote = "test";
+    dialect.quoteStringLiteral(buf, stringToQuote);
+    assertEquals("N'test'", buf.toString());
   }
 }
 //End OracleDialectTest.java

--- a/mondrian/src/it/java/mondrian/test/DrillThroughTest.java
+++ b/mondrian/src/it/java/mondrian/test/DrillThroughTest.java
@@ -147,6 +147,12 @@ public class DrillThroughTest extends FoodMartTestCase {
                 }).getDrillThroughSQL(false));
 
         String sql = cell.getDrillThroughSQL(false);
+        // Handle Unicode characters possibility (MONDRIAN-990)
+        Dialect dialect = getTestContext().getDialect();
+        String unicodePrefix = "";
+        if (dialect.getDatabaseProduct() == Dialect.DatabaseProduct.MSSQL || dialect.getDatabaseProduct() == Dialect.DatabaseProduct.ORACLE) {
+            unicodePrefix = "N";
+        }
         String expectedSql =
             "select `time_by_day`.`the_year` as `Year`,"
             + " `product_class`.`product_family` as `Product Family`,"
@@ -159,7 +165,7 @@ public class DrillThroughTest extends FoodMartTestCase {
             + " and `time_by_day`.`the_year` = 1997"
             + " and `sales_fact_1997`.`product_id` = `product`.`product_id`"
             + " and `product`.`product_class_id` = `product_class`.`product_class_id`"
-            + " and `product_class`.`product_family` = 'Drink' "
+            + " and `product_class`.`product_family` = " + unicodePrefix + "'Drink' "
             + "order by "
             + (TestContext.instance().getDialect().requiresOrderByAlias()
                 ? "`Year` ASC,"
@@ -186,7 +192,7 @@ public class DrillThroughTest extends FoodMartTestCase {
             + " and `time_by_day`.`the_year` = 1997"
             + " and `sales_fact_1997`.`product_id` = `product`.`product_id`"
             + " and `product`.`product_class_id` = `product_class`.`product_class_id`"
-            + " and `product_class`.`product_family` = 'Drink' "
+            + " and `product_class`.`product_family` = " + unicodePrefix + "'Drink' "
             + "order by "
             + (TestContext.instance().getDialect().requiresOrderByAlias()
                 ? "`Year` ASC,"
@@ -275,8 +281,15 @@ public class DrillThroughTest extends FoodMartTestCase {
         final Cell cell = result.getCell(new int[]{});
         assertTrue(cell.canDrillThrough());
         assertEquals(3584, cell.getDrillThroughCount());
-        getTestContext().assertSqlEquals(
-            "select\n"
+
+        // Handle Unicode characters possibility (MONDRIAN-990)
+        Dialect dialect = getTestContext().getDialect();
+        String unicodePrefix = "";
+        if (dialect.getDatabaseProduct() == Dialect.DatabaseProduct.MSSQL || dialect.getDatabaseProduct() == Dialect.DatabaseProduct.ORACLE) {
+            unicodePrefix = "N";
+        }
+        String expectedSql =
+          "select\n"
             + "    time_by_day.the_year as Year,\n"
             + "    promotion.media_type as Media Type,\n"
             + "    sales_fact_1997.unit_sales as Unit Sales\n"
@@ -292,11 +305,13 @@ public class DrillThroughTest extends FoodMartTestCase {
             + "    sales_fact_1997.promotion_id = promotion.promotion_id\n"
             + "and\n"
             + "    ((promotion.media_type in "
-            + "('Bulk Mail', 'Cash Register Handout')))\n"
+            + "(" + unicodePrefix + "'Bulk Mail', " + unicodePrefix + "'Cash Register Handout')))\n"
             + "order by\n"
             + (TestContext.instance().getDialect().requiresOrderByAlias()
-                ? "    Year ASC"
-                : "    time_by_day.the_year ASC"),
+            ? "    Year ASC"
+            : "    time_by_day.the_year ASC");
+        getTestContext().assertSqlEquals(
+            expectedSql,
             cell.getDrillThroughSQL(false), 3584);
     }
 
@@ -310,6 +325,12 @@ public class DrillThroughTest extends FoodMartTestCase {
         assertTrue(cell.canDrillThrough());
         String sql = cell.getDrillThroughSQL(false);
 
+        // Handle Unicode characters possibility (MONDRIAN-990)
+        Dialect dialect = getTestContext().getDialect();
+        String unicodePrefix = "";
+        if (dialect.getDatabaseProduct() == Dialect.DatabaseProduct.MSSQL || dialect.getDatabaseProduct() == Dialect.DatabaseProduct.ORACLE) {
+            unicodePrefix = "N";
+        }
         String expectedSql =
             "select `time_by_day`.`the_year` as `Year`,"
             + " `product_class`.`product_family` as `Product Family`,"
@@ -322,7 +343,7 @@ public class DrillThroughTest extends FoodMartTestCase {
             + " and `time_by_day`.`the_year` = 1997"
             + " and `sales_fact_1997`.`product_id` = `product`.`product_id`"
             + " and `product`.`product_class_id` = `product_class`.`product_class_id`"
-            + " and `product_class`.`product_family` = 'Drink' "
+            + " and `product_class`.`product_family` = " + unicodePrefix + "'Drink' "
             + (TestContext.instance().getDialect().requiresOrderByAlias()
                 ? "order by `Year` ASC,"
                 + " `Product Family` ASC"
@@ -373,6 +394,12 @@ public class DrillThroughTest extends FoodMartTestCase {
 
         String nameExpStr = getNameExp(result, "Customers", "Name");
 
+        // Handle Unicode characters possibility (MONDRIAN-990)
+        Dialect dialect = getTestContext().getDialect();
+        String unicodePrefix = "";
+        if (dialect.getDatabaseProduct() == Dialect.DatabaseProduct.MSSQL || dialect.getDatabaseProduct() == Dialect.DatabaseProduct.ORACLE) {
+            unicodePrefix = "N";
+        }
         String expectedSql =
             "select `store`.`store_country` as `Store Country`,"
             + " `store`.`store_state` as `Store State`,"
@@ -416,7 +443,7 @@ public class DrillThroughTest extends FoodMartTestCase {
             + " and `time_by_day`.`the_year` = 1997"
             + " and `sales_fact_1997`.`product_id` = `product`.`product_id`"
             + " and `product`.`product_class_id` = `product_class`.`product_class_id`"
-            + " and `product_class`.`product_family` = 'Drink'"
+            + " and `product_class`.`product_family` = " + unicodePrefix + "'Drink'"
             + " and `sales_fact_1997`.`promotion_id` = `promotion`.`promotion_id`"
             + " and `sales_fact_1997`.`customer_id` = `customer`.`customer_id` "
             + "order by"
@@ -501,6 +528,12 @@ public class DrillThroughTest extends FoodMartTestCase {
 
         String nameExpStr = getNameExp(result, "Customers", "Name");
 
+        // Handle Unicode characters possibility (MONDRIAN-990)
+        Dialect dialect = getTestContext().getDialect();
+        String unicodePrefix = "";
+        if (dialect.getDatabaseProduct() == Dialect.DatabaseProduct.MSSQL || dialect.getDatabaseProduct() == Dialect.DatabaseProduct.ORACLE) {
+            unicodePrefix = "N";
+        }
         String expectedSql =
             "select"
             + " `store`.`store_country` as `Store Country`,"
@@ -542,12 +575,12 @@ public class DrillThroughTest extends FoodMartTestCase {
             + "where `sales_fact_1997`.`store_id` = `store`.`store_id` and "
             + "`sales_fact_1997`.`time_id` = `time_by_day`.`time_id` and "
             + "`time_by_day`.`the_year` = 1997 and "
-            + "`time_by_day`.`quarter` = 'Q4' and "
+            + "`time_by_day`.`quarter` = " + unicodePrefix + "'Q4' and "
             + "`time_by_day`.`month_of_year` = 12 and "
             + "`sales_fact_1997`.`product_id` = `product`.`product_id` and "
             + "`product`.`product_class_id` = `product_class`.`product_class_id` and "
-            + "`product_class`.`product_family` = 'Drink' and "
-            + "`product_class`.`product_department` = 'Dairy' and "
+            + "`product_class`.`product_family` = " + unicodePrefix + "'Drink' and "
+            + "`product_class`.`product_department` = " + unicodePrefix + "'Dairy' and "
             + "`sales_fact_1997`.`promotion_id` = `promotion`.`promotion_id` and "
             + "`sales_fact_1997`.`customer_id` = `customer`.`customer_id` "
             + "order by"
@@ -641,6 +674,12 @@ public class DrillThroughTest extends FoodMartTestCase {
 
         String nameExpStr = getNameExp(result, "Customers", "Name");
 
+        // Handle Unicode characters possibility (MONDRIAN-990)
+        Dialect dialect = getTestContext().getDialect();
+        String unicodePrefix = "";
+        if (dialect.getDatabaseProduct() == Dialect.DatabaseProduct.MSSQL || dialect.getDatabaseProduct() == Dialect.DatabaseProduct.ORACLE) {
+            unicodePrefix = "N";
+        }
         final String expectedSql =
             "select"
             + " `store`.`store_state` as `Store State`,"
@@ -680,8 +719,8 @@ public class DrillThroughTest extends FoodMartTestCase {
             + " `promotion` =as= `promotion`,"
             + " `customer` =as= `customer` "
             + "where `sales_fact_1997`.`store_id` = `store`.`store_id` and"
-            + " `store`.`store_state` = 'CA' and"
-            + " `store`.`store_city` = 'Beverly Hills' and"
+            + " `store`.`store_state` = " + unicodePrefix + "'CA' and"
+            + " `store`.`store_city` = " + unicodePrefix + "'Beverly Hills' and"
             + " `sales_fact_1997`.time_id` = `time_by_day`.`time_id` and"
             + " `sales_fact_1997`.`product_id` = `product`.`product_id` and"
             + " `product`.`product_class_id` = `product_class`.`product_class_id` and"
@@ -759,6 +798,14 @@ public class DrillThroughTest extends FoodMartTestCase {
             + "from Sales");
         String sql = result.getCell(new int[] {0, 0}).getDrillThroughSQL(false);
 
+        // Handle Unicode characters possibility (MONDRIAN-990)
+        final Cube cube = result.getQuery().getCube();
+        RolapStar star = ((RolapCube) cube).getStar();
+        Dialect dialect = star.getSqlQueryDialect();
+        String unicodePrefix = "";
+        if (dialect.getDatabaseProduct() == Dialect.DatabaseProduct.MSSQL || dialect.getDatabaseProduct() == Dialect.DatabaseProduct.ORACLE) {
+            unicodePrefix = "N";
+        }
         String expectedSql =
             "select"
             + " `time_by_day`.`the_year` as `Year`,"
@@ -774,16 +821,12 @@ public class DrillThroughTest extends FoodMartTestCase {
             + " and `time_by_day`.`the_year` = 1997"
             + " and `sales_fact_1997`.`product_id` = `product`.`product_id`"
             + " and `product`.`product_class_id` = `product_class`.`product_class_id`"
-            + " and `product_class`.`product_family` = 'Drink' "
+            + " and `product_class`.`product_family` = "+ unicodePrefix + "'Drink' "
             + (TestContext.instance().getDialect().requiresOrderByAlias()
                 ? "order by `Year` ASC, `Product Family` ASC"
                 : "order by `time_by_day`.`the_year` ASC, `product_class`.`product_family` ASC");
 
-        final Cube cube = result.getQuery().getCube();
-        RolapStar star = ((RolapCube) cube).getStar();
-
         // Adjust expected SQL for dialect differences in FoodMart.xml.
-        Dialect dialect = star.getSqlQueryDialect();
         final String caseStmt =
             " \\(case when `sales_fact_1997`.`promotion_id` = 0 then 0"
             + " else `sales_fact_1997`.`store_sales` end\\)";
@@ -1019,6 +1062,12 @@ public class DrillThroughTest extends FoodMartTestCase {
 
         String sql = result.getCell(new int[]{0, 0}).getDrillThroughSQL(false);
 
+        // Handle Unicode characters possibility (MONDRIAN-990)
+        Dialect dialect = getTestContext().getDialect();
+        String unicodePrefix = "";
+        if (dialect.getDatabaseProduct() == Dialect.DatabaseProduct.MSSQL || dialect.getDatabaseProduct() == Dialect.DatabaseProduct.ORACLE) {
+            unicodePrefix = "N";
+        }
         String expectedSql =
             "select `time_by_day`.`the_year` as `Year`,"
             + " `time_by_day`.`quarter` as `Quarter`,"
@@ -1032,12 +1081,12 @@ public class DrillThroughTest extends FoodMartTestCase {
             + " `customer` =as= `customer`"
             + " where `sales_fact_1997`.`time_id` = `time_by_day`.`time_id` and"
             + " `time_by_day`.`the_year` = 1997 and"
-            + " `time_by_day`.`quarter` = 'Q4' and"
+            + " `time_by_day`.`quarter` = " + unicodePrefix + "'Q4' and"
             + " `time_by_day`.`month_of_year` = 12 and"
             + " `sales_fact_1997`.`customer_id` = `customer`.customer_id` and"
-            + " `customer`.`state_province` = 'OR' and"
-            + " `customer`.`city` = 'Albany' and"
-            + " `customer`.`gender` = 'F'"
+            + " `customer`.`state_province` = " + unicodePrefix + "'OR' and"
+            + " `customer`.`city` = " + unicodePrefix + "'Albany' and"
+            + " `customer`.`gender` = " + unicodePrefix + "'F'"
             + " order by "
             + (TestContext.instance().getDialect().requiresOrderByAlias()
                 ? "`Year` ASC,"

--- a/mondrian/src/it/java/mondrian/test/Main.java
+++ b/mondrian/src/it/java/mondrian/test/Main.java
@@ -371,6 +371,7 @@ public class Main extends TestSuite {
       addTest( suite, CompatibilityTest.class );
       addTest( suite, CaptionTest.class );
       addTest( suite, UdfTest.class );
+      addTest( suite, UnicodeSpecialCharactersTest.class);
       addTest( suite, NullValueTest.class );
       addTest( suite, NamedSetTest.class );
       addTest( suite, NativeSetEvaluationTest.class );

--- a/mondrian/src/it/java/mondrian/test/UnicodeSpecialCharactersTest.java
+++ b/mondrian/src/it/java/mondrian/test/UnicodeSpecialCharactersTest.java
@@ -1,0 +1,72 @@
+package mondrian.test;
+
+import junit.framework.TestCase;
+import mondrian.olap.Connection;
+import mondrian.spi.Dialect;
+
+import javax.sql.DataSource;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+public class UnicodeSpecialCharactersTest extends TestCase {
+
+  // Test to check fix for MONDRIAN-990
+  public void test_specialCharacters() throws SQLException {
+    TestContext context = TestContext.instance().withSchema(
+      "<?xml version=\"1.0\"?>\n"
+        + "<Schema name=\"FoodMart\">\n"
+        + "  <Cube name=\"Cube1\">"
+        + "    <Table name=\"unicode_test\" schema=\"dbo\"/>"
+        + "    <Dimension highCardinality=\"false\" name=\"Dimension1\" type=\"StandardDimension\" visible=\"true\">"
+        + "      <Hierarchy hasAll=\"true\" name=\"Hierarchy1\" visible=\"true\">"
+        + "        <Level column=\"name\" hideMemberIf=\"Never\" levelType=\"Regular\" name=\"Level1\"/>"
+        + "      </Hierarchy>"
+        + "    </Dimension>"
+        + "    <Measure aggregator=\"sum\" column=\"value\" name=\"sum\" visible=\"true\"/>"
+        + "  </Cube>"
+        + "</Schema>\n" );
+
+    Dialect dialect = context.getDialect();
+    // We only want to test the Unicode characters processing in SQL Server and Oracle
+    if ( dialect.getDatabaseProduct() != Dialect.DatabaseProduct.MSSQL
+      && dialect.getDatabaseProduct() != Dialect.DatabaseProduct.ORACLE ) {
+      return;
+    }
+
+    Connection olapConnection = context.getConnection();
+    DataSource ds = olapConnection.getDataSource();
+    java.sql.Connection connection = ds.getConnection();
+    Statement createStatement = connection.createStatement();
+    createStatement.execute( "CREATE TABLE foodmart.dbo.unicode_test\n"
+      + "(\n"
+      + "    name  varchar(100) COLLATE Korean_Wansung_CI_AS,\n"
+      + "    value int,\n"
+      + ");\n" );
+    createStatement.close();
+
+    Statement insertStatement = connection.createStatement();
+    insertStatement.execute( "INSERT INTO foodmart.dbo.unicode_test\n"
+      + "VALUES ( N'박', 1),\n"
+      + "       ( N'유', 2),\n"
+      + "       (N'김', 3);" );
+    insertStatement.close();
+
+    String queryFromAnalyzer = ""
+      + "select "
+      + "  [Measures].[sum] on columns "
+      + "from Cube1 "
+      + "where ([Dimension1.Hierarchy1].[Level1].[김])";
+
+    String expectedResult = "Axis #0:\n"
+      + "{[Dimension1.Hierarchy1].[김]}\n"
+      + "Axis #1:\n"
+      + "{[Measures].[sum]}\n"
+      + "Row #0: 3\n";
+
+    context.assertQueryReturns( queryFromAnalyzer, expectedResult );
+
+    Statement deleteStatement = connection.createStatement();
+    deleteStatement.execute( "DROP TABLE foodmart.dbo.unicode_test" );
+    deleteStatement.close();
+  }
+}

--- a/mondrian/src/it/java/mondrian/test/UnicodeSpecialCharactersTest.java
+++ b/mondrian/src/it/java/mondrian/test/UnicodeSpecialCharactersTest.java
@@ -10,7 +10,9 @@ import java.sql.Statement;
 
 public class UnicodeSpecialCharactersTest extends TestCase {
 
-  // Test to check fix for MONDRIAN-990
+  // Test to check fix for MONDRIAN-990, ensuring that when Unicode characters
+  // (tested with characters that don't belong to the QL_Latin1_General_CP1_CI_AS collation) are used in identifiers of
+  // a MDX query, then Mondrian is able to process the query and return a result with the characters present
   public void test_specialCharacters() throws SQLException {
     TestContext context = TestContext.instance().withSchema(
       "<?xml version=\"1.0\"?>\n"

--- a/mondrian/src/main/java/mondrian/spi/impl/MicrosoftSqlServerDialect.java
+++ b/mondrian/src/main/java/mondrian/spi/impl/MicrosoftSqlServerDialect.java
@@ -82,6 +82,13 @@ public class MicrosoftSqlServerDialect extends JdbcDialectImpl {
       buf.append(Util.singleQuoteString(value));
     }
 
+    @Override
+    public void quoteStringLiteral(StringBuilder buf, String s) {
+        // Ensure Unicode characters are handled correctly
+        buf.append('N');
+        Util.singleQuoteString(s, buf);
+    }
+
     protected void quoteDateLiteral(StringBuilder buf, String value, Date date)
     {
         buf.append("CONVERT(DATE, '");

--- a/mondrian/src/main/java/mondrian/spi/impl/OracleDialect.java
+++ b/mondrian/src/main/java/mondrian/spi/impl/OracleDialect.java
@@ -12,6 +12,7 @@
 
 package mondrian.spi.impl;
 
+import mondrian.olap.Util;
 import mondrian.rolap.SqlStatement;
 import mondrian.spi.DialectUtil;
 
@@ -99,7 +100,7 @@ public class OracleDialect extends JdbcDialectImpl {
         StringBuilder mappedFlags = new StringBuilder();
         String[][] mapping = new String[][]{{"c","c"},{"i","i"},{"m","m"}};
         javaRegex = extractEmbeddedFlags( javaRegex, mapping, mappedFlags );
-        
+
         final Matcher escapeMatcher = escapePattern.matcher(javaRegex);
         while (escapeMatcher.find()) {
             javaRegex =
@@ -182,6 +183,13 @@ public class OracleDialect extends JdbcDialectImpl {
         }
         logTypeInfo(metaData, columnIndex, type);
         return type;
+    }
+
+    @Override
+    public void quoteStringLiteral(StringBuilder buf, String s) {
+        // Ensure Unicode characters are handled correctly
+        buf.append('N');
+        Util.singleQuoteString(s, buf);
     }
 }
 


### PR DESCRIPTION
Ensure that unicode strings are processed correctly for SQL Server and Oracle.
When used in conditions, the SQL queries were not yielding the expected results.
See https://hv-eng.atlassian.net/browse/MONDRIAN-990 and https://hv-eng.atlassian.net/browse/MONDRIAN-990?focusedCommentId=1650724 for more details (the proposed solution is similar to the one implement in eazyBI)

Demo video with sql server connection before changes:
https://github.com/user-attachments/assets/fe5c86f0-7857-42bf-944c-9fb7f7b91478

Demo video with sql server connection after changes:
https://github.com/user-attachments/assets/5cf67026-5ff7-4597-a0fe-ea10bb4c8706




