### PR TITLE
[SME-542] chore: mark highCardinality attribute as deprecated in XSD

### DIFF
--- a/mondrian/src/main/resources/mondrian.xsd
+++ b/mondrian/src/main/resources/mondrian.xsd
@@ -245,6 +245,7 @@
     <xs:attribute name="highCardinality" type="xs:boolean" default="false">
       <xs:annotation>
         <xs:documentation>
+          This attribute is deprecated.
           Flag to mark this dimension as a high cardinality one
           and avoid caching.
         </xs:documentation>


### PR DESCRIPTION
Relates to SME-542 and SME-981.

Add comment to mark `highCardinality` attribute as deprecated