### PR TITLE
Improve Handling of Non-Existent Members in MDX Range Queries

### DIFF
--- a/mondrian/src/it/java/mondrian/olap/fun/FunctionTest.java
+++ b/mondrian/src/it/java/mondrian/olap/fun/FunctionTest.java
@@ -5230,13 +5230,51 @@ public class FunctionTest extends FoodMartTestCase {
   public void testRangeBoundedByNull() {
     assertAxisReturns(
       "[Gender].[F] : [Gender].[M].NextMember",
-      "" );
+            "[Gender].[F]\n"
+                    + "[Gender].[M]" );
   }
 
   public void testRangeBoundedByNullLarge() {
     assertAxisReturns(
       "[Customers].PrevMember : [Customers].[USA].[OR]",
-      "" );
+            "[Customers].[Canada].[BC]\n"
+                    + "[Customers].[Mexico].[DF]\n"
+                    + "[Customers].[Mexico].[Guerrero]\n"
+                    + "[Customers].[Mexico].[Jalisco]\n"
+                    + "[Customers].[Mexico].[Mexico]\n"
+                    + "[Customers].[Mexico].[Oaxaca]\n"
+                    + "[Customers].[Mexico].[Sinaloa]\n"
+                    + "[Customers].[Mexico].[Veracruz]\n"
+                    + "[Customers].[Mexico].[Yucatan]\n"
+                    + "[Customers].[Mexico].[Zacatecas]\n"
+                    + "[Customers].[USA].[CA]\n"
+                    + "[Customers].[USA].[OR]" );
+  }
+
+  public void testRangeBoundedByStartMemberOfNull() {
+    assertAxisReturns(
+            "[Time.Weekly].[Year].[#null] : [Time.Weekly].[Year].[1997]",
+            "[Time].[Weekly].[1997]");
+  }
+
+  public void testRangeBoundedByEndMemberOfNull() {
+    assertAxisReturns(
+            "[Time.Weekly].[Year].[1997] : [Time.Weekly].[Year].[#null]",
+            "[Time].[Weekly].[1997]\n"
+                    + "[Time].[Weekly].[1998]");
+  }
+
+  public void testRangeBoundedByEndMemberOfNotExist() {
+    assertAxisReturns(
+            "[Time.Weekly].[Year].[1997] : [Time.Weekly].[Year].[1999]",
+            "[Time].[Weekly].[1997]\n"
+                    + "[Time].[Weekly].[1998]");
+  }
+
+  public void testRangeBoundedByAllOfNull() {
+    assertAxisReturns(
+            "[Time.Weekly].[Year].[#null] : [Time.Weekly].[Year].[#null]",
+            "");
   }
 
   public void testSetContainingLevelFails() {

--- a/mondrian/src/it/java/mondrian/olap/fun/FunctionTest.java
+++ b/mondrian/src/it/java/mondrian/olap/fun/FunctionTest.java
@@ -5138,7 +5138,29 @@ public class FunctionTest extends FoodMartTestCase {
   public void testNullRange() {
     assertAxisReturns(
       "[Time].[1997].[Q1].[2] : NULL", //[Time].[1997].[Q2].[5]
-      "" ); // Empty Set
+            "[Time].[1997].[Q1].[2]\n"
+                    + "[Time].[1997].[Q1].[3]\n"
+                    + "[Time].[1997].[Q2].[4]\n"
+                    + "[Time].[1997].[Q2].[5]\n"
+                    + "[Time].[1997].[Q2].[6]\n"
+                    + "[Time].[1997].[Q3].[7]\n"
+                    + "[Time].[1997].[Q3].[8]\n"
+                    + "[Time].[1997].[Q3].[9]\n"
+                    + "[Time].[1997].[Q4].[10]\n"
+                    + "[Time].[1997].[Q4].[11]\n"
+                    + "[Time].[1997].[Q4].[12]\n"
+                    + "[Time].[1998].[Q1].[1]\n"
+                    + "[Time].[1998].[Q1].[2]\n"
+                    + "[Time].[1998].[Q1].[3]\n"
+                    + "[Time].[1998].[Q2].[4]\n"
+                    + "[Time].[1998].[Q2].[5]\n"
+                    + "[Time].[1998].[Q2].[6]\n"
+                    + "[Time].[1998].[Q3].[7]\n"
+                    + "[Time].[1998].[Q3].[8]\n"
+                    + "[Time].[1998].[Q3].[9]\n"
+                    + "[Time].[1998].[Q4].[10]\n"
+                    + "[Time].[1998].[Q4].[11]\n"
+                    + "[Time].[1998].[Q4].[12]" );
   }
 
   /**
@@ -5252,12 +5274,24 @@ public class FunctionTest extends FoodMartTestCase {
   }
 
   public void testRangeBoundedByStartMemberOfNull() {
+    propSaver.set(
+            MondrianProperties.instance().IgnoreInvalidMembers,
+            true );
+    propSaver.set(
+            MondrianProperties.instance().IgnoreInvalidMembersDuringQuery,
+            true );
     assertAxisReturns(
             "[Time.Weekly].[Year].[#null] : [Time.Weekly].[Year].[1997]",
             "[Time].[Weekly].[1997]");
   }
 
   public void testRangeBoundedByEndMemberOfNull() {
+    propSaver.set(
+            MondrianProperties.instance().IgnoreInvalidMembers,
+            true );
+    propSaver.set(
+            MondrianProperties.instance().IgnoreInvalidMembersDuringQuery,
+            true );
     assertAxisReturns(
             "[Time.Weekly].[Year].[1997] : [Time.Weekly].[Year].[#null]",
             "[Time].[Weekly].[1997]\n"
@@ -5265,6 +5299,12 @@ public class FunctionTest extends FoodMartTestCase {
   }
 
   public void testRangeBoundedByEndMemberOfNotExist() {
+    propSaver.set(
+            MondrianProperties.instance().IgnoreInvalidMembers,
+            true );
+    propSaver.set(
+            MondrianProperties.instance().IgnoreInvalidMembersDuringQuery,
+            true );
     assertAxisReturns(
             "[Time.Weekly].[Year].[1997] : [Time.Weekly].[Year].[1999]",
             "[Time].[Weekly].[1997]\n"
@@ -5272,6 +5312,12 @@ public class FunctionTest extends FoodMartTestCase {
   }
 
   public void testRangeBoundedByAllOfNull() {
+    propSaver.set(
+            MondrianProperties.instance().IgnoreInvalidMembers,
+            true );
+    propSaver.set(
+            MondrianProperties.instance().IgnoreInvalidMembersDuringQuery,
+            true );
     assertAxisReturns(
             "[Time.Weekly].[Year].[#null] : [Time.Weekly].[Year].[#null]",
             "");

--- a/mondrian/src/main/java/mondrian/olap/fun/FunUtil.java
+++ b/mondrian/src/main/java/mondrian/olap/fun/FunUtil.java
@@ -1167,8 +1167,8 @@ public class FunUtil extends Util {
     Evaluator evaluator,
     Member startMember,
     Member endMember ) {
-    final Level level = startMember.getLevel();
-    assertTrue( level == endMember.getLevel() );
+    final Level level = startMember.isNull() ? endMember.getLevel() : startMember.getLevel();
+    assertTrue(startMember.isNull() || endMember.isNull() || level == endMember.getLevel() );
     List<Member> members = new ArrayList<Member>();
     evaluator.getSchemaReader().getMemberRange(
       level, startMember, endMember, members );

--- a/mondrian/src/main/java/mondrian/olap/fun/RangeFunDef.java
+++ b/mondrian/src/main/java/mondrian/olap/fun/RangeFunDef.java
@@ -95,10 +95,10 @@ class RangeFunDef extends FunDefBase {
             public TupleList evaluateList(Evaluator evaluator) {
                 final Member member0 = memberCalcs[0].evaluateMember(evaluator);
                 final Member member1 = memberCalcs[1].evaluateMember(evaluator);
-                if (member0.isNull() || member1.isNull()) {
+                if (member0.isNull() && member1.isNull()) {
                     return TupleCollections.emptyList(1);
                 }
-                if (member0.getLevel() != member1.getLevel()) {
+                if (!member0.isNull() && !member1.isNull() && member0.getLevel() != member1.getLevel()) {
                     throw evaluator.newEvalException(
                         call.getFunDef(),
                         "Members must belong to the same level");

--- a/mondrian/src/main/java/mondrian/rolap/CacheMemberReader.java
+++ b/mondrian/src/main/java/mondrian/rolap/CacheMemberReader.java
@@ -278,9 +278,10 @@ class CacheMemberReader implements MemberReader, MemberCache {
     {
         assert startMember != null;
         assert endMember != null;
-        assert startMember.getLevel() == endMember.getLevel();
-        final int endOrdinal = endMember.getOrdinal();
-        for (int i = startMember.getOrdinal(); i <= endOrdinal; i++) {
+        assert startMember.isNull() || endMember.isNull() || startMember.getLevel() == endMember.getLevel();
+        final int startOrdinal = startMember.isNull() ? 0 : startMember.getOrdinal();
+        final int endOrdinal = endMember.isNull() ? startOrdinal : endMember.getOrdinal();
+        for (int i = startOrdinal; i <= endOrdinal; i++) {
             if (members.get(i).getLevel() == endMember.getLevel()) {
                 list.add(members.get(i));
             }

--- a/mondrian/src/main/java/mondrian/rolap/NoCacheMemberReader.java
+++ b/mondrian/src/main/java/mondrian/rolap/NoCacheMemberReader.java
@@ -260,11 +260,7 @@ public class NoCacheMemberReader implements MemberReader, MemberCache {
         assert endMember != null : "pre";
         assert startMember.isNull() || endMember.isNull() || startMember.getLevel() == endMember.getLevel()
             : "pre: startMember.getLevel() == endMember.getLevel()";
-
-        if (compare(startMember, endMember, false) > 0) {
-            return;
-        }
-        if (startMember.isNull() && endMember.isNull()) {
+        if (compare(startMember, endMember, false) > 0 || (startMember.isNull() && endMember.isNull())) {
             return;
         }
         if (!startMember.isNull()) {
@@ -273,31 +269,29 @@ public class NoCacheMemberReader implements MemberReader, MemberCache {
         if (startMember.equals(endMember)) {
             return;
         }
+
         if (startMember.isNull()) {
             SiblingIterator siblings = new SiblingIterator(this, endMember);
             while (siblings.hasPrevious()) {
-                final RolapMember member = siblings.previousMember();
-                list.add(member);
+                list.add(siblings.previousMember());
             }
             Collections.reverse(list);
             list.add(endMember);
             return;
-        }else {
-            SiblingIterator siblings = new SiblingIterator(this, startMember);
-            while (siblings.hasNext()) {
-                final RolapMember member = siblings.nextMember();
-                list.add(member);
-                if (member.equals(endMember)) {
-                    return;
-                }
-            }
-            if (endMember.isNull()) {
+        }
+        SiblingIterator siblings = new SiblingIterator(this, startMember);
+        while (siblings.hasNext()) {
+            final RolapMember member = siblings.nextMember();
+            list.add(member);
+            if (member.equals(endMember)) {
                 return;
             }
         }
-        throw Util.newInternal(
-                "sibling iterator did not hit end point, start="
-                        + startMember + ", end=" + endMember);
+        if (!endMember.isNull()) {
+            throw Util.newInternal(
+                    "sibling iterator did not hit end point, start="
+                            + startMember + ", end=" + endMember);
+        }
     }
 
     public int getMemberCount() {
@@ -305,9 +299,9 @@ public class NoCacheMemberReader implements MemberReader, MemberCache {
     }
 
     public int compare(
-        final RolapMember m1,
-        final RolapMember m2,
-        final boolean siblingsAreEqual)
+            final RolapMember m1,
+            final RolapMember m2,
+            final boolean siblingsAreEqual)
     {
         if (Util.equals(m1, m2)) {
             return 0;
@@ -315,67 +309,62 @@ public class NoCacheMemberReader implements MemberReader, MemberCache {
         if (m1.isNull() || m2.isNull()) {
             return -1;
         }
+
         if (Util.equals(m1.getParentMember(), m2.getParentMember())) {
-            // including case where both parents are null
-            if (siblingsAreEqual) {
-                return 0;
-            } else if (m1.getParentMember() == null) {
-                // at this point we know that both parent members are null.
-                int pos1 = -1, pos2 = -1;
-                List<RolapMember> siblingList = getRootMembers();
-                for (int i = 0, n = siblingList.size(); i < n; i++) {
-                    RolapMember child = siblingList.get(i);
-                    if (child.equals(m1)) {
-                        pos1 = i;
-                    }
-                    if (child.equals(m2)) {
-                        pos2 = i;
-                    }
-                }
-                if (pos1 == -1) {
-                    throw Util.newInternal(m1 + " not found among siblings");
-                }
-                if (pos2 == -1) {
-                    throw Util.newInternal(m2 + " not found among siblings");
-                }
-                Util.assertTrue(pos1 != pos2);
-                return pos1 < pos2 ? -1 : 1;
-            } else {
-                List<RolapMember> children = new ArrayList<RolapMember>();
-                getMemberChildren(m1.getParentMember(), children);
-                int pos1 = -1, pos2 = -1;
-                for (int i = 0, n = children.size(); i < n; i++) {
-                    RolapMember child = children.get(i);
-                    if (child.equals(m1)) {
-                        pos1 = i;
-                    }
-                    if (child.equals(m2)) {
-                        pos2 = i;
-                    }
-                }
-                if (pos1 == -1) {
-                    throw Util.newInternal(m1 + " not found among siblings");
-                }
-                if (pos2 == -1) {
-                    throw Util.newInternal(m2 + " not found among siblings");
-                }
-                assert pos1 != pos2;
-                return pos1 < pos2 ? -1 : 1;
+            return compareSameParent(m1, m2, siblingsAreEqual);
+        }
+
+        return compareDifferentLevels(m1, m2);
+    }
+
+    private int compareSameParent(RolapMember m1, RolapMember m2, boolean siblingsAreEqual) {
+        if (siblingsAreEqual) {
+            return 0;
+        }
+
+        List<RolapMember> peerMembers;
+        if (m1.getParentMember() == null) {
+            peerMembers = getRootMembers();
+        } else {
+            peerMembers = new ArrayList<>();
+            getMemberChildren(m1.getParentMember(), peerMembers);
+        }
+
+        int pos1 = -1, pos2 = -1;
+        for (int i = 0; i < peerMembers.size(); i++) {
+            RolapMember child = peerMembers.get(i);
+            if (child.equals(m1)) {
+                pos1 = i;
+            }
+            if (child.equals(m2)) {
+                pos2 = i;
             }
         }
-        int levelDepth1 = m1.getLevel().getDepth();
-        int levelDepth2 = m2.getLevel().getDepth();
-        if (levelDepth1 < levelDepth2) {
-            final int c = compare(m1, m2.getParentMember(), false);
-            return (c == 0) ? -1 : c;
 
-        } else if (levelDepth1 > levelDepth2) {
-            final int c = compare(m1.getParentMember(), m2, false);
-            return (c == 0) ? 1 : c;
-
-        } else {
-            return compare(m1.getParentMember(), m2.getParentMember(), false);
+        if (pos1 == -1) {
+            throw Util.newInternal(m1 + " not found among siblings");
         }
+        if (pos2 == -1) {
+            throw Util.newInternal(m2 + " not found among siblings");
+        }
+        Util.assertTrue(pos1 != pos2);
+        return Integer.compare(pos1, pos2);
+    }
+
+
+    private int compareDifferentLevels(RolapMember m1, RolapMember m2) {
+        int depth1 = m1.getLevel().getDepth();
+        int depth2 = m2.getLevel().getDepth();
+
+        if (depth1 < depth2) {
+            int c = compare(m1, m2.getParentMember(), false);
+            return (c == 0) ? -1 : c;
+        }
+        if (depth1 > depth2) {
+            int c = compare(m1.getParentMember(), m2, false);
+            return (c == 0) ? 1 : c;
+        }
+        return compare(m1.getParentMember(), m2.getParentMember(), false);
     }
 
     /**

--- a/mondrian/src/main/java/mondrian/rolap/SmartMemberReader.java
+++ b/mondrian/src/main/java/mondrian/rolap/SmartMemberReader.java
@@ -365,10 +365,7 @@ public class SmartMemberReader implements MemberReader {
         assert endMember != null;
         assert startMember.isNull() || endMember.isNull() || startMember.getLevel() == endMember.getLevel();
 
-        if (compare(startMember, endMember, false) > 0) {
-            return;
-        }
-        if (startMember.isNull() && endMember.isNull()) {
+        if (compare(startMember, endMember, false) > 0 || (startMember.isNull() && endMember.isNull())) {
             return;
         }
         if (!startMember.isNull()) {
@@ -381,29 +378,25 @@ public class SmartMemberReader implements MemberReader {
         if (startMember.isNull()) {
             SiblingIterator siblings = new SiblingIterator(this, endMember);
             while (siblings.hasPrevious()) {
-                final RolapMember member = siblings.previousMember();
-                list.add(member);
+                list.add(siblings.previousMember());
             }
             Collections.reverse(list);
             list.add(endMember);
             return;
-        }else {
-            SiblingIterator siblings = new SiblingIterator(this, startMember);
-            while (siblings.hasNext()) {
-                final RolapMember member = siblings.nextMember();
-                list.add(member);
-                if (member.equals(endMember)) {
-                    return;
-                }
-            }
-            if (endMember.isNull()) {
+        }
+        SiblingIterator siblings = new SiblingIterator(this, startMember);
+        while (siblings.hasNext()) {
+            final RolapMember member = siblings.nextMember();
+            list.add(member);
+            if (member.equals(endMember)) {
                 return;
             }
         }
-        throw Util.newInternal(
-                "sibling iterator did not hit end point, start="
-                        + startMember + ", end=" + endMember);
-
+        if (!endMember.isNull()) {
+            throw Util.newInternal(
+                    "sibling iterator did not hit end point, start="
+                            + startMember + ", end=" + endMember);
+        }
     }
 
     public int getMemberCount() {
@@ -411,77 +404,72 @@ public class SmartMemberReader implements MemberReader {
     }
 
     public int compare(
-        RolapMember m1,
-        RolapMember m2,
-        boolean siblingsAreEqual)
+            final RolapMember m1,
+            final RolapMember m2,
+            final boolean siblingsAreEqual)
     {
-        if (m1.equals(m2)) {
+        if (Util.equals(m1, m2)) {
             return 0;
         }
         if (m1.isNull() || m2.isNull()) {
             return -1;
         }
+
         if (Util.equals(m1.getParentMember(), m2.getParentMember())) {
-            // including case where both parents are null
-            if (siblingsAreEqual) {
-                return 0;
-            } else if (m1.getParentMember() == null) {
-                // at this point we know that both parent members are null.
-                int pos1 = -1, pos2 = -1;
-                List<RolapMember> siblingList = getRootMembers();
-                for (int i = 0, n = siblingList.size(); i < n; i++) {
-                    RolapMember child = siblingList.get(i);
-                    if (child.equals(m1)) {
-                        pos1 = i;
-                    }
-                    if (child.equals(m2)) {
-                        pos2 = i;
-                    }
-                }
-                if (pos1 == -1) {
-                    throw Util.newInternal(m1 + " not found among siblings");
-                }
-                if (pos2 == -1) {
-                    throw Util.newInternal(m2 + " not found among siblings");
-                }
-                Util.assertTrue(pos1 != pos2);
-                return pos1 < pos2 ? -1 : 1;
-            } else {
-                List<RolapMember> children = new ArrayList<RolapMember>();
-                getMemberChildren(m1.getParentMember(), children);
-                int pos1 = -1, pos2 = -1;
-                for (int i = 0, n = children.size(); i < n; i++) {
-                    RolapMember child = children.get(i);
-                    if (child.equals(m1)) {
-                        pos1 = i;
-                    }
-                    if (child.equals(m2)) {
-                        pos2 = i;
-                    }
-                }
-                if (pos1 == -1) {
-                    throw Util.newInternal(m1 + " not found among siblings");
-                }
-                if (pos2 == -1) {
-                    throw Util.newInternal(m2 + " not found among siblings");
-                }
-                Util.assertTrue(pos1 != pos2);
-                return pos1 < pos2 ? -1 : 1;
+            return compareSameParent(m1, m2, siblingsAreEqual);
+        }
+
+        return compareDifferentLevels(m1, m2);
+    }
+
+    private int compareSameParent(RolapMember m1, RolapMember m2, boolean siblingsAreEqual) {
+        if (siblingsAreEqual) {
+            return 0;
+        }
+
+        List<RolapMember> peerMembers;
+        if (m1.getParentMember() == null) {
+            peerMembers = getRootMembers();
+        } else {
+            peerMembers = new ArrayList<>();
+            getMemberChildren(m1.getParentMember(), peerMembers);
+        }
+
+        int pos1 = -1, pos2 = -1;
+        for (int i = 0; i < peerMembers.size(); i++) {
+            RolapMember child = peerMembers.get(i);
+            if (child.equals(m1)) {
+                pos1 = i;
+            }
+            if (child.equals(m2)) {
+                pos2 = i;
             }
         }
-        int levelDepth1 = m1.getLevel().getDepth();
-        int levelDepth2 = m2.getLevel().getDepth();
-        if (levelDepth1 < levelDepth2) {
-            final int c = compare(m1, m2.getParentMember(), false);
-            return (c == 0) ? -1 : c;
 
-        } else if (levelDepth1 > levelDepth2) {
-            final int c = compare(m1.getParentMember(), m2, false);
-            return (c == 0) ? 1 : c;
-
-        } else {
-            return compare(m1.getParentMember(), m2.getParentMember(), false);
+        if (pos1 == -1) {
+            throw Util.newInternal(m1 + " not found among siblings");
         }
+        if (pos2 == -1) {
+            throw Util.newInternal(m2 + " not found among siblings");
+        }
+        Util.assertTrue(pos1 != pos2);
+        return Integer.compare(pos1, pos2);
+    }
+
+
+    private int compareDifferentLevels(RolapMember m1, RolapMember m2) {
+        int depth1 = m1.getLevel().getDepth();
+        int depth2 = m2.getLevel().getDepth();
+
+        if (depth1 < depth2) {
+            int c = compare(m1, m2.getParentMember(), false);
+            return (c == 0) ? -1 : c;
+        }
+        if (depth1 > depth2) {
+            int c = compare(m1.getParentMember(), m2, false);
+            return (c == 0) ? 1 : c;
+        }
+        return compare(m1.getParentMember(), m2.getParentMember(), false);
     }
 
     /**

--- a/mondrian/src/main/java/mondrian/rolap/SmartMemberReader.java
+++ b/mondrian/src/main/java/mondrian/rolap/SmartMemberReader.java
@@ -363,26 +363,47 @@ public class SmartMemberReader implements MemberReader {
     {
         assert startMember != null;
         assert endMember != null;
-        assert startMember.getLevel() == endMember.getLevel();
+        assert startMember.isNull() || endMember.isNull() || startMember.getLevel() == endMember.getLevel();
 
         if (compare(startMember, endMember, false) > 0) {
             return;
         }
-        list.add(startMember);
+        if (startMember.isNull() && endMember.isNull()) {
+            return;
+        }
+        if (!startMember.isNull()) {
+            list.add(startMember);
+        }
         if (startMember.equals(endMember)) {
             return;
         }
-        SiblingIterator siblings = new SiblingIterator(this, startMember);
-        while (siblings.hasNext()) {
-            final RolapMember member = siblings.nextMember();
-            list.add(member);
-            if (member.equals(endMember)) {
+
+        if (startMember.isNull()) {
+            SiblingIterator siblings = new SiblingIterator(this, endMember);
+            while (siblings.hasPrevious()) {
+                final RolapMember member = siblings.previousMember();
+                list.add(member);
+            }
+            Collections.reverse(list);
+            list.add(endMember);
+            return;
+        }else {
+            SiblingIterator siblings = new SiblingIterator(this, startMember);
+            while (siblings.hasNext()) {
+                final RolapMember member = siblings.nextMember();
+                list.add(member);
+                if (member.equals(endMember)) {
+                    return;
+                }
+            }
+            if (endMember.isNull()) {
                 return;
             }
         }
         throw Util.newInternal(
-            "sibling iterator did not hit end point, start="
-            + startMember + ", end=" + endMember);
+                "sibling iterator did not hit end point, start="
+                        + startMember + ", end=" + endMember);
+
     }
 
     public int getMemberCount() {
@@ -396,6 +417,9 @@ public class SmartMemberReader implements MemberReader {
     {
         if (m1.equals(m2)) {
             return 0;
+        }
+        if (m1.isNull() || m2.isNull()) {
+            return -1;
         }
         if (Util.equals(m1.getParentMember(), m2.getParentMember())) {
             // including case where both parents are null
@@ -500,8 +524,8 @@ public class SmartMemberReader implements MemberReader {
 
         boolean hasNext() {
             return (this.position < this.siblings.size() - 1)
-                || (parentIterator != null)
-                && parentIterator.hasNext();
+                    || (parentIterator != null)
+                    && parentIterator.hasNext();
         }
 
         Object next() {


### PR DESCRIPTION
**Description**
When querying a range of members in MDX, if some members do not exist, Mondrian currently returns an empty result when ignoreInvalidMembers settings are enabled.
This behavior is inconsistent with platforms like SSAS (SQL Server Analysis Services), which return results for valid members while ignoring non-existent ones.

This PR improves Mondrian's query engine to correctly skip invalid members and return results for existing members within the specified range.

**Problem**
Users are often unaware of whether specific members exist when writing MDX queries.
For example, a user may query sales from 1997 to 1999 using the following MDX:
`SELECT
    [Measures].[Store Sales] ON 0,
    [Time.Weekly].[Year].[1997]:[Time.Weekly].[Year].[1999] ON 1
FROM [Sales]
`
However, when the following properties are enabled in Mondrian.properties:
`mondrian.rolap.ignoreInvalidMembers=true
mondrian.rolap.ignoreInvalidMembersDuringQuery=true
`
the query returns an empty result if one of the specified members (e.g., 1999) does not exist in the cube.

**Expected Behavior**
In systems like SSAS, even if a member such as 1999 does not exist, the query would still return results for the existing members (e.g., sales for 1997 and 1998), simply ignoring the missing member.
This pull request aligns Mondrian's behavior with that expectation — ensuring that invalid or missing members are skipped during query evaluation.

**Screenshots**
Before the fix:
![b9d3ee41b34c7ad8d4ca54e965bf840](https://github.com/user-attachments/assets/0ae03a6a-81c2-4e89-86f4-6f3d04becb67)

After the fix:
![cc7b1652f72aec9e5853ccbb6b3684e](https://github.com/user-attachments/assets/6e4bb967-49c8-4ad4-9acc-a08bfd766322)


**Summary**
This change improves query robustness when ignoreInvalidMembers is enabled, providing a better experience for users querying ranges of members, even when some members are missing.

