### PR TITLE
Security Fix: Potential XXE Vulnerability in parse function

### DIFF
--- a/mondrian/src/main/java/mondrian/tui/XmlUtil.java
+++ b/mondrian/src/main/java/mondrian/tui/XmlUtil.java
@@ -520,12 +520,15 @@ public class XmlUtil {
      * Parse a stream into a Document (no validation).
      *
      */
-    public static Document parse(InputStream in)
-        throws SAXException, IOException
-    {
+    public static Document parse(InputStream in) throws SAXException, IOException {
         InputSource source = new InputSource(in);
 
+        // Securely configure the DOMParser
         DOMParser parser = XmlUtil.getParser(null, null, false);
+        parser.setFeature("http://xml.org/sax/features/external-general-entities", false);
+        parser.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+        parser.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+
         try {
             parser.parse(source);
             checkForParseError(parser);


### PR DESCRIPTION
This PR addresses a potential vulnerability in the parse() function in XmlUtil.java that could lead to XML External Entity (XXE) attacks because it does not explicitly disables features that allow external entities and Document Type Definitions (DTDs) which are the primary vectors for XXE attacks. This issue was originally reported and resolved in the repository via this commit https://github.com/codelibs/fess/commit/4e0d9f5faaf4ec75dbe89f5ff97ece0f03b097a8.

**Fix**
- **Disabling External General Entities, External Parameter Entities, Loading of External DTDs**
    - Ensures that the DOMParser processes only the XML content provided in the input stream without resolving or loading any external resources

**References**
CWE-611: Improper Restriction of XML External Entity Reference
https://nvd.nist.gov/vuln/detail/cve-2018-1000632
https://github.com/codelibs/fess/commit/4e0d9f5faaf4ec75dbe89f5ff97ece0f03b097a8