### PR TITLE
[BACKLOG-43902]-Java 21 : compatibility check for Pentaho and fix Build and Run time issues while building / testing

### DIFF
--- a/mondrian/build.xml
+++ b/mondrian/build.xml
@@ -69,7 +69,7 @@
 
     <java classpath="${classpath}"
         classname="mondrian.util.PropertyUtil"
-        fork="no">
+        fork="true">
         <arg value="${java.dir}/mondrian/olap"/>
         <arg value="${generated.java.dir}/mondrian/olap"/>
       </java>


### PR DESCRIPTION
This pull request makes a minor change to the build process by updating the `mondrian/build.xml` file. The main change is switching the `fork` attribute from "no" to "true" for a Java execution task, which will cause the Java process to run in a separate JVM.
Forking starts the Java process separately, allowing better compatibility with newer JVM options
