### PR TITLE
build[SP-7224]: Bump version of validation-api dependency to 1.1.0.Final

### DIFF
--- a/mondrian/pom.xml
+++ b/mondrian/pom.xml
@@ -90,7 +90,6 @@
     <dependency>
       <groupId>javax.validation</groupId>
       <artifactId>validation-api</artifactId>
-      <version>${validation-api.version}</version>
     </dependency>
     <dependency>
       <groupId>eigenbase</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,6 @@
     <eigenbase-resgen.version>1.3.1</eigenbase-resgen.version>
     <junit.version>3.8.1</junit.version>
     <commons-pool2.version>2.11.1</commons-pool2.version>
-    <validation-api.version>1.0.0.GA</validation-api.version>
     <commons-collections.version>3.2.2</commons-collections.version>
     <commons-math.version>1.1</commons-math.version>
     <olap4j-xmla.version>1.2.0</olap4j-xmla.version>


### PR DESCRIPTION
## Summary
- remove repo-local javax.validation:validation-api version ownership
- inherit javax.validation:validation-api 1.1.0.Final from pentaho-parent-pom on 10.2