### PR TITLE
fix[mondrian]: restore Docker-backed integration tests BACKLOG-50612

### DIFF
--- a/mondrian/README.md
+++ b/mondrian/README.md
@@ -13,22 +13,17 @@ mvn -DrunITs -P embedded-mysql,load-foodmart install
 ```
 Skip the integration tests by omitting `-DrunITs -P embedded-mysql,load-foodmart`
 
-#### Run Isolate Integration Test
-To run the tests locally, the following property must be set
-```
-<pentaho.docker.pull.host>repo.orl.eng.hitachivantara.com/pnt-docker</pentaho.docker.pull.host>
-```
-It must not have the "/" at the end, because in wingman this variable is being overridden, and it does not have the "/" at the end https://github.com/pentaho/jenkins-pipelines/blob/master/resources/config/maven/wingman-settings.xml#L91.
-
-Also, the `mysql.url.base` property must be changed to
-```
-<mysql.url.base>jdbc:mysql://127.0.0.1:3306</mysql.url.base>
-```
-
-Then, run the command bellow:
+#### Run Local Docker Integration Test
+Wingman runs Maven in a container and connects to MySQL through Fabric8's container bridge IP. Docker Desktop does not expose that bridge IP to the host. Activate `local-docker` to connect through the mapped localhost port instead:
 
 ```
-mvn verify -DrunITs -Dit.test=NonEmptyTest.java -DfailIfNoTests=false
+mvn verify -DrunITs -Plocal-docker -Dit.test=NonEmptyTest.java -DfailIfNoTests=false
+```
+
+Use the same `-Plocal-docker` profile with the full integration test suite:
+
+```
+mvn -DrunITs -Plocal-docker,load-foodmart install
 ```
 
 #### Alternate Foodmart

--- a/mondrian/pom.xml
+++ b/mondrian/pom.xml
@@ -368,7 +368,7 @@
           <plugin>
             <groupId>io.fabric8</groupId>
             <artifactId>docker-maven-plugin</artifactId>
-            <version>0.48.1</version>
+            <version>0.49.0</version>
             <executions>
               <execution>
                 <id>start</id>
@@ -502,6 +502,14 @@
         <mysql.driver>com.mysql.cj.jdbc.Driver</mysql.driver>
         <dependency.sql-maven-plugin.version>1.5</dependency.sql-maven-plugin.version>
         <mysql.url.base>jdbc:mysql://${docker.container.mondrian-mysql8027-db.ip}:3306</mysql.url.base>
+        <mysql.url.default>${mysql.url.base}/mysql</mysql.url.default>
+        <mondrian.foodmart.jdbcURL>${mysql.url.base}/foodmart</mondrian.foodmart.jdbcURL>
+      </properties>
+    </profile>
+    <profile>
+      <id>local-docker</id>
+      <properties>
+        <mysql.url.base>jdbc:mysql://localhost:3306</mysql.url.base>
         <mysql.url.default>${mysql.url.base}/mysql</mysql.url.default>
         <mondrian.foodmart.jdbcURL>${mysql.url.base}/foodmart</mondrian.foodmart.jdbcURL>
       </properties>

--- a/mondrian/src/it/java/mondrian/olap/fun/FunctionTest.java
+++ b/mondrian/src/it/java/mondrian/olap/fun/FunctionTest.java
@@ -11660,7 +11660,7 @@ Intel platforms):
         + "on 0 from sales",
       Util.IBM_JVM
         ? "StringIndexOutOfBoundsException: null"
-        : "java.lang.StringIndexOutOfBoundsException: Range [0, -20) out of bounds for length 10" );
+        : "java.lang.StringIndexOutOfBoundsException:" );
   }
 
   public void testMidFunctionWithValidArguments() {
@@ -12018,7 +12018,7 @@ Intel platforms):
       "right(\"abc\", -4)",
       Util.IBM_JVM
         ? "StringIndexOutOfBoundsException: null"
-        : "java.lang.StringIndexOutOfBoundsException: Range [7, 3) out of bounds for length 3" );
+        : "java.lang.StringIndexOutOfBoundsException:" );
   }
 
   public void testVbaDateTime() {


### PR DESCRIPTION
## Summary

Backports the Mondrian Docker-backed integration-test repair to 11.0.

- Updates Fabric8 Docker Maven Plugin to `0.49.0`.
- Adds `local-docker` JDBC configuration for Docker Desktop networking.
- Makes two `FunctionTest` exception assertions independent of JDK-specific message text.

Requires the companion parent-POM registry backport: https://github.com/pentaho/maven-parent-poms/pull/968

## Original Pull Request

https://github.com/pentaho/mondrian/pull/1484

## Validation

`mvn --batch-mode clean install -DrunITs -Plocal-docker,load-foodmart`

Failsafe report (`mondrian.test.Main`): 3,310 tests, 0 failures, 0 errors, 0 skipped. Build completed successfully in 8m31s.

## Ticket

BACKLOG-50612